### PR TITLE
Add linter rule to check for required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ The `optionalorrequired` linter can automatically fix fields that are using the 
 
 It will also remove the secondary marker where both the preferred and secondary marker are present on a field.
 
+## RequiredFields
+
+The `requiredfields` linter checks that fields that are marked as required, follow the convention of not being pointers,
+and not having an `omitempty` value in their `json` tag.
+
+### Configuration
+
+```yaml
+lintersConfig:
+  requiredFields:
+    pointerPolicy: Warn | SuggestFix # The policy for pointers in required fields. Defaults to `SuggestFix`.
+```
+
+### Fixes (via standalone binary only)
+
+The `requiredfields` linter can automatically fix fields that are marked as required, but are pointers.
+
+It will suggest to remove the pointer from the field, and update the `json` tag to remove the `omitempty` value.
+
+If you prefer not to suggest fixes for pointers in required fields, you can change the `pointerPolicy` to `Warn`.
+The linter will then only suggest to remove the `omitempty` value from the `json` tag.
+
 # Contributing
 
 New linters can be added by following the [New Linter][new-linter] guide.

--- a/pkg/analysis/registry.go
+++ b/pkg/analysis/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/JoelSpeed/kal/pkg/analysis/commentstart"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
+	"github.com/JoelSpeed/kal/pkg/analysis/requiredfields"
 	"github.com/JoelSpeed/kal/pkg/config"
 	"golang.org/x/tools/go/analysis"
 
@@ -51,6 +52,7 @@ func NewRegistry() Registry {
 			commentstart.Initializer(),
 			jsontags.Initializer(),
 			optionalorrequired.Initializer(),
+			requiredfields.Initializer(),
 		},
 	}
 }

--- a/pkg/analysis/registry_test.go
+++ b/pkg/analysis/registry_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Registry", func() {
 				"commentstart",
 				"jsontags",
 				"optionalorrequired",
+				"requiredfields",
 			))
 		})
 	})
@@ -30,6 +31,7 @@ var _ = Describe("Registry", func() {
 				"commentstart",
 				"jsontags",
 				"optionalorrequired",
+				"requiredfields",
 			))
 		})
 	})

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -1,0 +1,144 @@
+package requiredfields
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/markers"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	name = "requiredfields"
+
+	requiredMarker            = "required"
+	kubebuilderRequiredMarker = "kubebuilder:validation:Required"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+	errCouldNotGetMarkers   = errors.New("could not get markers")
+	errCouldNotGetJSONTags  = errors.New("could not get json tags")
+)
+
+type analyzer struct{}
+
+// newAnalyzer creates a new analyzer.
+func newAnalyzer() *analysis.Analyzer {
+	a := &analyzer{}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that all required fields are not pointers, and do not have the omitempty tag.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer, extractjsontags.Analyzer},
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	if !ok {
+		return nil, errCouldNotGetMarkers
+	}
+
+	jsonTags, ok := pass.ResultOf[extractjsontags.Analyzer].(extractjsontags.StructFieldTags)
+	if !ok {
+		return nil, errCouldNotGetJSONTags
+	}
+
+	// Filter to structs so that we can iterate over fields in a struct.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		sTyp, ok := n.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		if sTyp.Fields == nil {
+			return
+		}
+
+		for _, field := range sTyp.Fields.List {
+			if field == nil || len(field.Names) == 0 {
+				continue
+			}
+
+			fieldName := field.Names[0].Name
+			fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
+			fieldTagInfo := jsonTags.FieldTags(sTyp, fieldName)
+
+			a.checkField(pass, field, fieldMarkers, fieldTagInfo)
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet, fieldTagInfo extractjsontags.FieldTagInfo) {
+	if field == nil || len(field.Names) == 0 {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+
+	if !fieldMarkers.Has(requiredMarker) && !fieldMarkers.Has(kubebuilderRequiredMarker) {
+		// The field is not marked required, so we don't need to check it.
+		return
+	}
+
+	if fieldTagInfo.OmitEmpty {
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			Message: fmt.Sprintf("field %s is marked as required, but has the omitempty tag", fieldName),
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: "should remove the omitempty tag",
+					TextEdits: []analysis.TextEdit{
+						{
+							Pos:     fieldTagInfo.Pos,
+							End:     fieldTagInfo.End,
+							NewText: []byte(strings.Replace(fieldTagInfo.RawValue, ",omitempty", "", 1)),
+						},
+					},
+				},
+			},
+		})
+	}
+
+	if field.Type == nil {
+		// The field has no type? We can't check if it's a pointer.
+		return
+	}
+
+	if starExpr, ok := field.Type.(*ast.StarExpr); ok {
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			Message: fmt.Sprintf("field %s is marked as required, should not be a pointer", fieldName),
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: "should remove the pointer",
+					TextEdits: []analysis.TextEdit{
+						{
+							Pos:     starExpr.Pos(),
+							End:     starExpr.X.Pos(),
+							NewText: nil,
+						},
+					},
+				},
+			},
+		})
+	}
+}

--- a/pkg/analysis/requiredfields/analyzer_test.go
+++ b/pkg/analysis/requiredfields/analyzer_test.go
@@ -1,0 +1,20 @@
+package requiredfields_test
+
+import (
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/requiredfields"
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestDefaultConfiguration(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := requiredfields.Initializer().Init(config.LintersConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "a")
+}

--- a/pkg/analysis/requiredfields/analyzer_test.go
+++ b/pkg/analysis/requiredfields/analyzer_test.go
@@ -18,3 +18,18 @@ func TestDefaultConfiguration(t *testing.T) {
 
 	analysistest.RunWithSuggestedFixes(t, testdata, a, "a")
 }
+
+func TestWithPointerPolicyWarn(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := requiredfields.Initializer().Init(config.LintersConfig{
+		RequiredFields: config.RequiredFieldsConfig{
+			PointerPolicy: config.RequiredFieldPointerWarn,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "b")
+}

--- a/pkg/analysis/requiredfields/doc.go
+++ b/pkg/analysis/requiredfields/doc.go
@@ -1,0 +1,11 @@
+/*
+requiredFields is a linter to check that fields that are marked as required are not pointers, and do not have the omitempty tag.
+The linter will check for fields that are marked as required using the +required marker, or the +kubebuilder:validation:Required marker.
+
+The linter will suggest to remove the omitempty tag from fields that are marked as required, but have the omitempty tag.
+The linter will suggest to remove the pointer type from fields that are marked as required.
+
+If you have a large, existing codebase, you may not want to automatically fix all of the pointer issues.
+In this case, you can configure the linter not to suggest fixing the pointer issues by setting the `pointerPolicy` option to `Warn`.
+*/
+package requiredfields

--- a/pkg/analysis/requiredfields/initializer.go
+++ b/pkg/analysis/requiredfields/initializer.go
@@ -1,0 +1,30 @@
+package requiredfields
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(), nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return true
+}

--- a/pkg/analysis/requiredfields/initializer.go
+++ b/pkg/analysis/requiredfields/initializer.go
@@ -21,7 +21,7 @@ func (initializer) Name() string {
 
 // Init returns the intialized Analyzer.
 func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
-	return newAnalyzer(), nil
+	return newAnalyzer(cfg.RequiredFields), nil
 }
 
 // Default determines whether this Analyzer is on by default, or not.

--- a/pkg/analysis/requiredfields/testdata/src/a/a.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/a.go
@@ -1,0 +1,39 @@
+package a
+
+type A struct {
+	// optional field should not be picked up.
+	// +optional
+	OptionalField *string `json:"optionalField,omitempty"`
+
+	// requiredCorrectField should not be picked up.
+	// +required
+	RequiredCorrectField string `json:"requiredCorrectField"`
+
+	// requiredOmitEmptyField field should be picked up.
+	// +required
+	RequiredOmitEmptyField string `json:"requiredOmitEmptyField,omitempty"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredPointerField should be picked up.
+	// +required
+	RequiredPointerField *string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
+
+	// requiredPointerOmitEmptyField should be picked up.
+	// +required
+	RequiredPointerOmitEmptyField *string `json:"requiredPointerOmitEmptyField,omitempty"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerField should not be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
+
+	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredKubebuilderMarkerPointerField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerField *string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerOmitEmptyField *string `json:"requiredKubebuilderMarkerPointerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+}

--- a/pkg/analysis/requiredfields/testdata/src/a/a.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/a.go.golden
@@ -1,0 +1,39 @@
+package a
+
+type A struct {
+	// optional field should not be picked up.
+	// +optional
+	OptionalField *string `json:"optionalField,omitempty"`
+
+	// requiredCorrectField should not be picked up.
+	// +required
+	RequiredCorrectField string `json:"requiredCorrectField"`
+
+	// requiredOmitEmptyField field should be picked up.
+	// +required
+	RequiredOmitEmptyField string `json:"requiredOmitEmptyField"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredPointerField should be picked up.
+	// +required
+	RequiredPointerField string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
+
+	// requiredPointerOmitEmptyField should be picked up.
+	// +required
+	RequiredPointerOmitEmptyField string `json:"requiredPointerOmitEmptyField"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerField should not be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
+
+	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredKubebuilderMarkerPointerField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerField string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerOmitEmptyField string `json:"requiredKubebuilderMarkerPointerOmitEmptyField"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+}

--- a/pkg/analysis/requiredfields/testdata/src/b/a.go
+++ b/pkg/analysis/requiredfields/testdata/src/b/a.go
@@ -1,0 +1,39 @@
+package a
+
+type A struct {
+	// optional field should not be picked up.
+	// +optional
+	OptionalField *string `json:"optionalField,omitempty"`
+
+	// requiredCorrectField should not be picked up.
+	// +required
+	RequiredCorrectField string `json:"requiredCorrectField"`
+
+	// requiredOmitEmptyField field should be picked up.
+	// +required
+	RequiredOmitEmptyField string `json:"requiredOmitEmptyField,omitempty"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredPointerField should be picked up.
+	// +required
+	RequiredPointerField *string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
+
+	// requiredPointerOmitEmptyField should be picked up.
+	// +required
+	RequiredPointerOmitEmptyField *string `json:"requiredPointerOmitEmptyField,omitempty"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerField should not be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
+
+	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredKubebuilderMarkerPointerField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerField *string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerOmitEmptyField *string `json:"requiredKubebuilderMarkerPointerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+}

--- a/pkg/analysis/requiredfields/testdata/src/b/a.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/b/a.go.golden
@@ -1,0 +1,39 @@
+package a
+
+type A struct {
+	// optional field should not be picked up.
+	// +optional
+	OptionalField *string `json:"optionalField,omitempty"`
+
+	// requiredCorrectField should not be picked up.
+	// +required
+	RequiredCorrectField string `json:"requiredCorrectField"`
+
+	// requiredOmitEmptyField field should be picked up.
+	// +required
+	RequiredOmitEmptyField string `json:"requiredOmitEmptyField"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredPointerField should be picked up.
+	// +required
+	RequiredPointerField *string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
+
+	// requiredPointerOmitEmptyField should be picked up.
+	// +required
+	RequiredPointerOmitEmptyField *string `json:"requiredPointerOmitEmptyField"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerField should not be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
+
+	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
+
+	// requiredKubebuilderMarkerPointerField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerField *string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
+
+	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
+	// +kubebuilder:validation:Required
+	RequiredKubebuilderMarkerPointerOmitEmptyField *string `json:"requiredKubebuilderMarkerPointerOmitEmptyField"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+}

--- a/pkg/config/linters_config.go
+++ b/pkg/config/linters_config.go
@@ -7,6 +7,9 @@ type LintersConfig struct {
 
 	// optionalOrRequired contains configuration for the optionalorrequired linter.
 	OptionalOrRequired OptionalOrRequiredConfig `json:"optionalOrRequired"`
+
+	// requiredFields contains configuration for the requiredfields linter.
+	RequiredFields RequiredFieldsConfig `json:"requiredFields"`
 }
 
 // JSONTagsConfig contains configuration for the jsontags linter.
@@ -28,4 +31,25 @@ type OptionalOrRequiredConfig struct {
 	// If this field is not set, the default value is "required".
 	// Valid values are "required" and "kubebuilder:validation:Required".
 	PreferredRequiredMarker string `json:"preferredRequiredMarker"`
+}
+
+// RequiredFieldPointerPolicy is the policy for pointers in required fields.
+type RequiredFieldPointerPolicy string
+
+const (
+	// RequiredFieldPointerWarn indicates that the linter will emit a warning if a required field is a pointer.
+	RequiredFieldPointerWarn RequiredFieldPointerPolicy = "Warn"
+
+	// RequiredFieldPointerSuggestFix indicates that the linter will emit a warning if a required field is a pointer and suggest a fix.
+	RequiredFieldPointerSuggestFix RequiredFieldPointerPolicy = "SuggestFix"
+)
+
+// RequiredFieldsConfig contains configuration for the requiredfields linter.
+type RequiredFieldsConfig struct {
+	// pointerPolicy is the policy for pointers in required fields.
+	// Valid values are "Warn" and "SuggestFix".
+	// When set to "Warn", the linter will emit a warning if a required field is a pointer.
+	// When set to "SuggestFix", the linter will emit a warning if a required field is a pointer and suggest a fix.
+	// When otherwise not specified, the default value is "SuggestFix".
+	PointerPolicy RequiredFieldPointerPolicy `json:"pointerPolicy"`
 }

--- a/pkg/validation/linters_config.go
+++ b/pkg/validation/linters_config.go
@@ -16,6 +16,7 @@ func ValidateLintersConfig(lc config.LintersConfig, fldPath *field.Path) field.E
 
 	fieldErrors = append(fieldErrors, validateJSONTagsConfig(lc.JSONTags, fldPath.Child("jsonTags"))...)
 	fieldErrors = append(fieldErrors, validateOptionalOrRequiredConfig(lc.OptionalOrRequired, fldPath.Child("optionalOrRequired"))...)
+	fieldErrors = append(fieldErrors, validateRequiredFieldsConfig(lc.RequiredFields, fldPath.Child("requiredFields"))...)
 
 	return fieldErrors
 }
@@ -47,6 +48,19 @@ func validateOptionalOrRequiredConfig(oorc config.OptionalOrRequiredConfig, fldP
 	case "", optionalorrequired.RequiredMarker, optionalorrequired.KubebuilderRequiredMarker:
 	default:
 		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredRequiredMarker"), oorc.PreferredRequiredMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", optionalorrequired.RequiredMarker, optionalorrequired.KubebuilderRequiredMarker)))
+	}
+
+	return fieldErrors
+}
+
+// validateRequiredFieldsConfig is used to validate the configuration in the config.RequiredFieldsConfig struct.
+func validateRequiredFieldsConfig(rfc config.RequiredFieldsConfig, fldPath *field.Path) field.ErrorList {
+	fieldErrors := field.ErrorList{}
+
+	switch rfc.PointerPolicy {
+	case "", config.RequiredFieldPointerWarn, config.RequiredFieldPointerSuggestFix:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("pointerPolicy"), rfc.PointerPolicy, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", config.RequiredFieldPointerWarn, config.RequiredFieldPointerSuggestFix)))
 	}
 
 	return fieldErrors

--- a/pkg/validation/linters_config_test.go
+++ b/pkg/validation/linters_config_test.go
@@ -83,5 +83,39 @@ var _ = Describe("LintersConfig", func() {
 			},
 			expectedErr: "lintersConfig.optionalOrRequired.preferredRequiredMarker: Invalid value: \"invalid\": invalid value, must be one of \"required\", \"kubebuilder:validation:Required\" or omitted",
 		}),
+
+		// RequiredFieldsConfig validation
+		Entry("With a valid RequiredFieldsConfig: omitted", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				RequiredFields: config.RequiredFieldsConfig{
+					PointerPolicy: "",
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid RequiredFieldsConfig: SuggestFix", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				RequiredFields: config.RequiredFieldsConfig{
+					PointerPolicy: config.RequiredFieldPointerSuggestFix,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid RequiredFieldsConfig: Warn", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				RequiredFields: config.RequiredFieldsConfig{
+					PointerPolicy: config.RequiredFieldPointerWarn,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With an invalid RequiredFieldsConfig", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				RequiredFields: config.RequiredFieldsConfig{
+					PointerPolicy: "invalid",
+				},
+			},
+			expectedErr: "lintersConfig.requiredFields.pointerPolicy: Invalid value: \"invalid\": invalid value, must be one of \"Warn\", \"SuggestFix\" or omitted",
+		}),
 	)
 })


### PR DESCRIPTION
This adds a rule that will check that required fields are both not-pointers, but also do not have the `omitempty` json tag.

This linter includes auto-fixing for both of the errors described above.

Since this is core to the API guidelines in Kube, this is enabled by default.