### PR TITLE
Add Conditions linter to verify conditions type, tags and markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,41 @@ allowing for customisation or automatic copmilation of the project should it not
 
 # Linters
 
+## Conditions
+
+The `conditions` linter checks that `Conditions` fields in the API types are correctly formatted.
+The `Conditions` field should be a slice of `metav1.Condition` with the following tags and markers:
+
+```go
+// +listType=map
+// +listMapKey=type
+// +patchStrategy=merge
+// +patchMergeKey=type
+// +optional
+Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,opt,name=conditions"`
+```
+
+Conditions are idiomatically the first field within the status struct, and the linter will highlight when the Conditions are not the first field.
+
+### Configuration
+
+```yaml
+lintersConfig:
+  conditions:
+    isFirstField: Warn | Ignore # The policy for the Conditions field being the first field. Defaults to `Warn`.
+    useProtobuf: SuggestFix | Warn | Ignore # The policy for the protobuf tag on the Conditions field. Defaults to `SuggestFix`.
+```
+
+### Fixes (via standalone binary only)
+
+The `conditions` linter can automatically fix the tags on the `Conditions` field.
+When they do not match the expected format, the linter will suggest to update the tags to match the expected format.
+
+For CRDs, protobuf tags are not expected. By setting the `useProtobuf` configuration to `Ignore`, the linter will not suggest to add the protobuf tag to the `Conditions` field tags.
+
+The linter will also suggest to add missing markers.
+If any of the 5 markers in the example above are missing, the linter will suggest to add them directly above the field.
+
 ## CommentStart
 
 The `commentstart` linter checks that all comments in the API types start with the serialized form of the type they are commenting on.

--- a/pkg/analysis/conditions/analyzer.go
+++ b/pkg/analysis/conditions/analyzer.go
@@ -1,0 +1,301 @@
+package conditions
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/markers"
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	name = "conditions"
+
+	listTypeMap       = "listType=map"
+	listMapKeyType    = "listMapKey=type"
+	patchStrategy     = "patchStrategy=merge"
+	patchMergeKeyType = "patchMergeKey=type"
+	optional          = "optional"
+
+	expectedTagWithProtobufFmt = "`json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,%d,rep,name=conditions\"`"
+	expectedTagWithoutProtobuf = "`json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+	errCouldNotGetMarkers   = errors.New("could not get markers")
+)
+
+type analyzer struct {
+	isFirstField config.ConditionsFirstField
+	useProtobuf  config.ConditionsUseProtobuf
+}
+
+// newAnalyzer creates a new analyzer.
+func newAnalyzer(cfg config.ConditionsConfig) *analysis.Analyzer {
+	defaultConfig(&cfg)
+
+	a := &analyzer{
+		isFirstField: cfg.IsFirstField,
+		useProtobuf:  cfg.UseProtobuf,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      `Checks that all conditions type fields conform to the required conventions.`,
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer, extractjsontags.Analyzer},
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	if !ok {
+		return nil, errCouldNotGetMarkers
+	}
+
+	// Filter to structs so that we can iterate over fields in a struct.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		sTyp, ok := n.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		if sTyp.Fields == nil {
+			return
+		}
+
+		for i, field := range sTyp.Fields.List {
+			if field == nil || len(field.Names) == 0 {
+				continue
+			}
+
+			fieldName := field.Names[0].Name
+			fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
+
+			a.checkField(pass, i, field, fieldMarkers)
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func (a *analyzer) checkField(pass *analysis.Pass, index int, field *ast.Field, fieldMarkers markers.MarkerSet) {
+	if !fieldIsCalledConditions(field) {
+		return
+	}
+
+	if !isSliceMetaV1Condition(field) {
+		pass.Reportf(field.Pos(), "Conditions field must be a slice of metav1.Condition")
+		return
+	}
+
+	checkFieldMarkers(pass, field, fieldMarkers)
+	a.checkFieldTags(pass, index, field)
+
+	if a.isFirstField == config.ConditionsFirstFieldWarn && index != 0 {
+		pass.Reportf(field.Pos(), "Conditions field must be the first field in the struct")
+	}
+}
+
+func checkFieldMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet) {
+	missingMarkers := []string{}
+
+	if !fieldMarkers.Has(listTypeMap) {
+		missingMarkers = append(missingMarkers, listTypeMap)
+	}
+
+	if !fieldMarkers.Has(listMapKeyType) {
+		missingMarkers = append(missingMarkers, listMapKeyType)
+	}
+
+	if !fieldMarkers.Has(patchStrategy) {
+		missingMarkers = append(missingMarkers, patchStrategy)
+	}
+
+	if !fieldMarkers.Has(patchMergeKeyType) {
+		missingMarkers = append(missingMarkers, patchMergeKeyType)
+	}
+
+	if !fieldMarkers.Has(optional) {
+		missingMarkers = append(missingMarkers, optional)
+	}
+
+	if len(missingMarkers) != 0 {
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			End:     field.End(),
+			Message: "Conditions field is missing the following markers: " + strings.Join(missingMarkers, ", "),
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: "Add missing markers",
+					TextEdits: []analysis.TextEdit{
+						{
+							Pos:     field.Pos(),
+							End:     token.NoPos,
+							NewText: getNewMarkers(missingMarkers),
+						},
+					},
+				},
+			},
+		})
+	}
+}
+
+func getNewMarkers(missingMarkers []string) []byte {
+	var out string
+
+	for _, marker := range missingMarkers {
+		out += "// +" + marker + "\n"
+	}
+
+	return []byte(out)
+}
+
+func (a *analyzer) checkFieldTags(pass *analysis.Pass, index int, field *ast.Field) {
+	if field.Tag == nil {
+		expectedTag := getExpectedTag(a.useProtobuf, a.isFirstField, index)
+
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			End:     field.End(),
+			Message: "Conditions field is missing tags, should be: " + expectedTag,
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: "Add missing tags",
+					TextEdits: []analysis.TextEdit{
+						{
+							Pos:     field.End(),
+							End:     token.NoPos,
+							NewText: []byte(expectedTag),
+						},
+					},
+				},
+			},
+		})
+
+		return
+	}
+
+	asExpected, shouldFix := tagIsAsExpected(field.Tag.Value, a.useProtobuf, a.isFirstField, index)
+	if !asExpected {
+		expectedTag := getExpectedTag(a.useProtobuf, a.isFirstField, index)
+
+		if !shouldFix {
+			pass.Reportf(field.Tag.ValuePos, "Conditions field has incorrect tags, should be: %s", expectedTag)
+		} else {
+			pass.Report(analysis.Diagnostic{
+				Pos:     field.Tag.ValuePos,
+				End:     field.Tag.End(),
+				Message: "Conditions field has incorrect tags, should be: " + expectedTag,
+				SuggestedFixes: []analysis.SuggestedFix{
+					{
+						Message: "Update tags",
+						TextEdits: []analysis.TextEdit{
+							{
+								Pos:     field.Tag.ValuePos,
+								End:     field.Tag.End(),
+								NewText: []byte(expectedTag),
+							},
+						},
+					},
+				},
+			})
+		}
+	}
+}
+
+func getExpectedTag(useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) string {
+	if useProtobuf == config.ConditionsUseProtobufSuggestFix || useProtobuf == config.ConditionsUseProtobufWarn {
+		i := 1
+		if isFirstField == config.ConditionsFirstFieldIgnore {
+			i = index + 1
+		}
+
+		return fmt.Sprintf(expectedTagWithProtobufFmt, i)
+	}
+
+	return expectedTagWithoutProtobuf
+}
+
+func tagIsAsExpected(tag string, useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) (bool, bool) {
+	switch useProtobuf {
+	case config.ConditionsUseProtobufSuggestFix:
+		return tag == getExpectedTag(config.ConditionsUseProtobufSuggestFix, isFirstField, index), true
+	case config.ConditionsUseProtobufWarn:
+		return tag == getExpectedTag(config.ConditionsUseProtobufWarn, isFirstField, index), false
+	case config.ConditionsUseProtobufIgnore:
+		return tag == getExpectedTag(config.ConditionsUseProtobufIgnore, isFirstField, index) || tag == getExpectedTag(config.ConditionsUseProtobufSuggestFix, isFirstField, index), true
+	default:
+		panic("unexpected useProtobuf value")
+	}
+}
+
+func fieldIsCalledConditions(field *ast.Field) bool {
+	if field == nil {
+		return false
+	}
+
+	return len(field.Names) != 0 && field.Names[0] != nil && field.Names[0].Name == "Conditions"
+}
+
+func isSliceMetaV1Condition(field *ast.Field) bool {
+	if field == nil {
+		return false
+	}
+
+	// Field is not an array type.
+	arr, ok := field.Type.(*ast.ArrayType)
+	if !ok {
+		return false
+	}
+
+	// Array element is not imported.
+	selector, ok := arr.Elt.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	// Array element is not imported from metav1.
+	if selector.X == nil || pkg.Name != "metav1" {
+		return false
+	}
+
+	// Array element is not a metav1.Condition.
+	if selector.Sel == nil || selector.Sel.Name != "Condition" {
+		return false
+	}
+
+	return true
+}
+
+func defaultConfig(cfg *config.ConditionsConfig) {
+	if cfg.IsFirstField == "" {
+		cfg.IsFirstField = config.ConditionsFirstFieldWarn
+	}
+
+	if cfg.UseProtobuf == "" {
+		cfg.UseProtobuf = config.ConditionsUseProtobufSuggestFix
+	}
+}

--- a/pkg/analysis/conditions/analyzer_test.go
+++ b/pkg/analysis/conditions/analyzer_test.go
@@ -1,0 +1,50 @@
+package conditions_test
+
+import (
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestDefaultConfiguration(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "a")
+}
+
+func TestNotFieldFirst(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{
+		Conditions: config.ConditionsConfig{
+			IsFirstField: config.ConditionsFirstFieldIgnore,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "b")
+}
+
+func TestIgnoreProtobuf(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{
+		Conditions: config.ConditionsConfig{
+			UseProtobuf: config.ConditionsUseProtobufIgnore,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "c")
+}

--- a/pkg/analysis/conditions/doc.go
+++ b/pkg/analysis/conditions/doc.go
@@ -1,0 +1,25 @@
+/*
+conditions is a linter that verifies that the conditions field within the struct is correctly defined.
+
+conditions fields in Kuberenetes API types are expected to be a slice of metav1.Condition.
+This linter verifies that the field is a slice of metav1.Condition and that it is correctly annotated with the required markers,
+and tags.
+
+The expected condition field should look like this:
+
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+Where the tags and markers are incorrect, the linter will suggest fixes to improve the field definition.
+
+Conditions are also idiomatically the first item in the struct, the linter will highlight when the conditions field is not the first field in the struct.
+If this is not a desired behaviour, set the linter config option `isFirstField` to `Ignore`.
+
+Protobuf tags are required for in-tree API types, but not for CRDs.
+When linting CRD based types, set the `useProtobuf` config option to `Ignore`.
+*/
+package conditions

--- a/pkg/analysis/conditions/initializer.go
+++ b/pkg/analysis/conditions/initializer.go
@@ -1,0 +1,30 @@
+package conditions
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg.Conditions), nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return true
+}

--- a/pkg/analysis/conditions/testdata/src/a/a.go
+++ b/pkg/analysis/conditions/testdata/src/a/a.go
@@ -1,0 +1,103 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/a/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/a/a.go.golden
@@ -1,0 +1,113 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/b/a.go
+++ b/pkg/analysis/conditions/testdata/src/b/a.go
@@ -1,0 +1,119 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
+}
+
+type ConditionsThird struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// another field
+	AnotherField string `json:"anotherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/b/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/b/a.go.golden
@@ -1,0 +1,129 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
+}
+
+type ConditionsThird struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// another field
+	AnotherField string `json:"anotherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/c/a.go
+++ b/pkg/analysis/conditions/testdata/src/c/a.go
@@ -1,0 +1,73 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ValidConditionsMissingProtobuf struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/c/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/c/a.go.golden
@@ -1,0 +1,73 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ValidConditionsMissingProtobuf struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/pkg/analysis/conditions/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1,0 +1,92 @@
+/*
+This is a copy of the minimum amount of the original file to be able to test the conditions linter.
+*/
+package v1
+
+import "time"
+
+// Time is a wrapper around time.Time which supports correct
+// marshaling to YAML and JSON.  Wrappers are provided for many
+// of the factory methods that the time package offers.
+//
+// +protobuf.options.marshal=false
+// +protobuf.as=Timestamp
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+type Time struct {
+	time.Time `protobuf:"-"`
+}
+
+type ConditionStatus string
+
+// These are valid condition statuses. "ConditionTrue" means a resource is in the condition.
+// "ConditionFalse" means a resource is not in the condition. "ConditionUnknown" means kubernetes
+// can't decide if a resource is in the condition or not. In the future, we could add other
+// intermediate conditions, e.g. ConditionDegraded.
+const (
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
+)
+
+// Condition contains details for one aspect of the current state of this API Resource.
+// ---
+// This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+//
+//	type FooStatus struct{
+//	    // Represents the observations of a foo's current state.
+//	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+//	    // +patchMergeKey=type
+//	    // +patchStrategy=merge
+//	    // +listType=map
+//	    // +listMapKey=type
+//	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+//
+//	    // other fields
+//	}
+type Condition struct {
+	// type of condition in CamelCase or in foo.example.com/CamelCase.
+	// ---
+	// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+	// useful (see .node.status.conditions), the ability to deconflict is important.
+	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+	// +kubebuilder:validation:MaxLength=316
+	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
+	// status of the condition, one of True, False, Unknown.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status"`
+	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the instance.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
+	// lastTransitionTime is the last time the condition transitioned from one status to another.
+	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"`
+	// reason contains a programmatic identifier indicating the reason for the condition's last transition.
+	// Producers of specific condition types may define expected values and meanings for this field,
+	// and whether the values are considered a guaranteed API.
+	// The value should be a CamelCase string.
+	// This field may not be empty.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
+	// message is a human readable message indicating details about the transition.
+	// This may be an empty string.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=32768
+	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
+}

--- a/pkg/analysis/registry.go
+++ b/pkg/analysis/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/JoelSpeed/kal/pkg/analysis/commentstart"
+	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
 	"github.com/JoelSpeed/kal/pkg/analysis/requiredfields"
@@ -49,6 +50,7 @@ type registry struct {
 func NewRegistry() Registry {
 	return &registry{
 		initializers: []AnalyzerInitializer{
+			conditions.Initializer(),
 			commentstart.Initializer(),
 			jsontags.Initializer(),
 			optionalorrequired.Initializer(),

--- a/pkg/analysis/registry_test.go
+++ b/pkg/analysis/registry_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Registry", func() {
 		It("should return the default linters", func() {
 			r := analysis.NewRegistry()
 			Expect(r.DefaultLinters().UnsortedList()).To(ConsistOf(
+				"conditions",
 				"commentstart",
 				"jsontags",
 				"optionalorrequired",
@@ -28,6 +29,7 @@ var _ = Describe("Registry", func() {
 		It("should return the all known linters", func() {
 			r := analysis.NewRegistry()
 			Expect(r.AllLinters().UnsortedList()).To(ConsistOf(
+				"conditions",
 				"commentstart",
 				"jsontags",
 				"optionalorrequired",

--- a/pkg/config/linters_config.go
+++ b/pkg/config/linters_config.go
@@ -2,6 +2,9 @@ package config
 
 // LintersConfig contains configuration for individual linters.
 type LintersConfig struct {
+	// conditions contains configuration for the conditions linter.
+	Conditions ConditionsConfig `json:"conditions"`
+
 	// jsonTags contains configuration for the jsontags linter.
 	JSONTags JSONTagsConfig `json:"jsonTags"`
 
@@ -10,6 +13,49 @@ type LintersConfig struct {
 
 	// requiredFields contains configuration for the requiredfields linter.
 	RequiredFields RequiredFieldsConfig `json:"requiredFields"`
+}
+
+// ConditionsFirstField is the policy for the conditions linter.
+type ConditionsFirstField string
+
+const (
+	// ConditionsFirstFieldWarn indicates that the conditions should be the first field in the struct.
+	ConditionsFirstFieldWarn ConditionsFirstField = "Warn"
+
+	// ConditionsFirstFieldIgnore indicates that the conditions do not need to be the first field in the struct.
+	ConditionsFirstFieldIgnore ConditionsFirstField = "Ignore"
+)
+
+// ConditionsUseProtobuf is the policy for the conditions linter.
+type ConditionsUseProtobuf string
+
+const (
+	// ConditionsUseProtobufSuggestFix indicates that the linter will emit a warning if the conditions are not using protobuf tags and suggest a fix.
+	ConditionsUseProtobufSuggestFix ConditionsUseProtobuf = "SuggestFix"
+
+	// ConditionsUseProtobufWarn indicates that the linter will emit a warning if the conditions are not using protobuf tags.
+	ConditionsUseProtobufWarn ConditionsUseProtobuf = "Warn"
+
+	// ConditionsUseProtobufIgnore indicates that the linter will not emit a warning if the conditions are not using protobuf tags.
+	ConditionsUseProtobufIgnore ConditionsUseProtobuf = "Ignore"
+)
+
+// ConditionsConfig contains configuration for the conditions linter.
+type ConditionsConfig struct {
+	// isFirstField indicates whether the conditions should be the first field in the struct.
+	// Valid values are Warn and Ignore.
+	// When set to Warn, the linter will emit a warning if the conditions are not the first field in the struct.
+	// When set to Ignore, the linter will not emit a warning if the conditions are not the first field in the struct.
+	// When otherwise not specified, the default value is Warn.
+	IsFirstField ConditionsFirstField `json:"isFirstField"`
+
+	// useProtobuf indicates whether the linter should use protobuf tags.
+	// Valid values are SuggestFix, Warn and Ignore.
+	// When set to SuggestFix, the linter will emit a warning if the conditions are not using protobuf tags and suggest a fix.
+	// When set to Warn, the linter will emit a warning if the conditions are not using protobuf tags.
+	// When set to Ignore, the linter will not emit a warning if the conditions are not using protobuf tags.
+	// When otherwise not specified, the default value is SuggestFix.
+	UseProtobuf ConditionsUseProtobuf `json:"useProtobuf"`
 }
 
 // JSONTagsConfig contains configuration for the jsontags linter.

--- a/pkg/validation/linters_config.go
+++ b/pkg/validation/linters_config.go
@@ -14,9 +14,29 @@ import (
 func ValidateLintersConfig(lc config.LintersConfig, fldPath *field.Path) field.ErrorList {
 	fieldErrors := field.ErrorList{}
 
+	fieldErrors = append(fieldErrors, validateConditionsConfig(lc.Conditions, fldPath.Child("conditions"))...)
 	fieldErrors = append(fieldErrors, validateJSONTagsConfig(lc.JSONTags, fldPath.Child("jsonTags"))...)
 	fieldErrors = append(fieldErrors, validateOptionalOrRequiredConfig(lc.OptionalOrRequired, fldPath.Child("optionalOrRequired"))...)
 	fieldErrors = append(fieldErrors, validateRequiredFieldsConfig(lc.RequiredFields, fldPath.Child("requiredFields"))...)
+
+	return fieldErrors
+}
+
+// validateConditionsConfig is used to validate the configuration in the config.ConditionsConfig struct.
+func validateConditionsConfig(cc config.ConditionsConfig, fldPath *field.Path) field.ErrorList {
+	fieldErrors := field.ErrorList{}
+
+	switch cc.IsFirstField {
+	case "", config.ConditionsFirstFieldWarn, config.ConditionsFirstFieldIgnore:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("isFirstField"), cc.IsFirstField, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", config.ConditionsFirstFieldWarn, config.ConditionsFirstFieldIgnore)))
+	}
+
+	switch cc.UseProtobuf {
+	case "", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("useProtobuf"), cc.UseProtobuf, fmt.Sprintf("invalid value, must be one of %q, %q, %q or omitted", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore)))
+	}
 
 	return fieldErrors
 }

--- a/pkg/validation/linters_config_test.go
+++ b/pkg/validation/linters_config_test.go
@@ -30,6 +30,73 @@ var _ = Describe("LintersConfig", func() {
 			expectedErr: "",
 		}),
 
+		// ConditionsConfig validation
+		Entry("With a valid ConditionsConfig", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					IsFirstField: "",
+					UseProtobuf:  "",
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig IsFirstField: Warn", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					IsFirstField: config.ConditionsFirstFieldWarn,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig IsFirstField: Ignore", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					IsFirstField: config.ConditionsFirstFieldIgnore,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With an invalid ConditionsConfig IsFirstField", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					IsFirstField: "invalid",
+				},
+			},
+			expectedErr: "lintersConfig.conditions.isFirstField: Invalid value: \"invalid\": invalid value, must be one of \"Warn\", \"Ignore\" or omitted",
+		}),
+		Entry("With a valid ConditionsConfig UseProtobuf: SuggestFix", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UseProtobuf: config.ConditionsUseProtobufSuggestFix,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig UseProtobuf: Warn", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UseProtobuf: config.ConditionsUseProtobufWarn,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig UseProtobuf: Ignore", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UseProtobuf: config.ConditionsUseProtobufIgnore,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With an invalid ConditionsConfig UseProtobuf", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UseProtobuf: "invalid",
+				},
+			},
+			expectedErr: "lintersConfig.conditions.useProtobuf: Invalid value: \"invalid\": invalid value, must be one of \"SuggestFix\", \"Warn\", \"Ignore\" or omitted",
+		}),
+
 		// JSONTagsConfig validation
 		Entry("With a valid JSONTagsConfig JSONTagRegex", validateLintersConfigTableInput{
 			config: config.LintersConfig{


### PR DESCRIPTION
This PR adds a new linter, that checks for `Conditions` fields within structs within an API, and makes sure that they match the format expected
```
// +listType=map
// +listMapKey=type
// +patchStrategy=merge
// +patchMergeKey=type
// +optional
Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,opt,name=conditions"`
```

It provides configuration to skip the protobuf tags for APIs that do not need it, as well as suggests that the conditions should always be the first in the list. This is also configurable.