### PR TITLE
Add integers linter to enforce int32/int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ The `commentstart` linter can automatically fix comments that do not start with 
 
 When the `json` tag is present, and matches the first word of the field comment in all but casing, the linter will suggest that the comment be updated to match the `json` tag.
 
+## Integers
+
+The `integers` linter checks for usage of unsupported integer types.
+Only `int32` and `int64` types should be used in APIs, and other integer types, including unsigned integers are forbidden.
+
 ## JSONTags
 
 The `jsontags` linter checks that all fields in the API types have a `json` tag, and that those tags are correctly formatted.

--- a/pkg/analysis/integers/analyzer.go
+++ b/pkg/analysis/integers/analyzer.go
@@ -1,0 +1,121 @@
+package integers
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const name = "integers"
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+)
+
+// Analyzer is the analyzer for the integers package.
+// It checks that no struct fields or type aliases are `int`, or unsigned integers.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "All integers should be explicit about their size, int32 and int64 should be used over plain int. Unsigned ints are not allowed.",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer, extractjsontags.Analyzer},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter typespecs so that we can look at type aliases.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+		(*ast.TypeSpec)(nil),
+	}
+
+	// Preorder visits all the nodes of the AST in depth-first order. It calls
+	// f(n) for each node n before it visits n's children.
+	//
+	// We use the filter defined above, ensuring we only look at struct fields and type declarations.
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		switch typ := n.(type) {
+		case *ast.StructType:
+			if typ.Fields == nil {
+				return
+			}
+
+			for _, field := range typ.Fields.List {
+				checkField(pass, field)
+			}
+		case *ast.TypeSpec:
+			checkTypeSpec(pass, typ, typ, "type")
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field) {
+	if field == nil || len(field.Names) == 0 || field.Names[0] == nil {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+	prefix := fmt.Sprintf("field %s", fieldName)
+
+	checkTypeExpr(pass, field.Type, field, prefix)
+}
+
+func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, prefix string) {
+	if tSpec.Name == nil {
+		return
+	}
+
+	typeName := tSpec.Name.Name
+	prefix = fmt.Sprintf("%s %s", prefix, typeName)
+
+	checkTypeExpr(pass, tSpec.Type, node, prefix)
+}
+
+func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, prefix string) {
+	switch typ := typeExpr.(type) {
+	case *ast.Ident:
+		checkIdent(pass, typ, node, prefix)
+	case *ast.StarExpr:
+		checkTypeExpr(pass, typ.X, node, fmt.Sprintf("%s pointer", prefix))
+	case *ast.ArrayType:
+		checkTypeExpr(pass, typ.Elt, node, fmt.Sprintf("%s array element", prefix))
+	}
+}
+
+// checkIdent looks for known type of integers that do not match the allowed `int32` or `int64` requirements.
+// It will also identify fields that are using type aliases and determine if these type aliases use invalid
+// types of integers, and highlight this.
+func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
+	switch ident.Name {
+	case "int32", "int64":
+		// Valid cases
+	case "int", "int8", "int16":
+		pass.Reportf(node.Pos(), "%s should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements", prefix)
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		pass.Reportf(node.Pos(), "%s should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive", prefix)
+	}
+
+	if ident.Obj == nil || ident.Obj.Decl == nil {
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	// The field is using a type alias, check if the alias is an int.
+	checkTypeSpec(pass, tSpec, node, fmt.Sprintf("%s type", prefix))
+}

--- a/pkg/analysis/integers/analyzer_test.go
+++ b/pkg/analysis/integers/analyzer_test.go
@@ -1,0 +1,13 @@
+package integers_test
+
+import (
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/integers"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, integers.Analyzer, "a")
+}

--- a/pkg/analysis/integers/doc.go
+++ b/pkg/analysis/integers/doc.go
@@ -1,0 +1,15 @@
+/*
+integers is an analyzer that checks for usage of unsupported integer types.
+
+According to the API conventions, only int32 and int64 types should be used in Kubernetes APIs.
+
+int32 is preferred and should be used in most cases, unless the use case requireds representing
+values larger than int32.
+
+It also states that unsigned integers should be replaced with signed integers, and then numeric
+lower bounds added to prevent negative integers.
+
+Succinctly this anaylzer checks for int, int8, int16, uint, uint8, uint16, uint32 and uint64 types
+and highlights that they should not be used.
+*/
+package integers

--- a/pkg/analysis/integers/initializer.go
+++ b/pkg/analysis/integers/initializer.go
@@ -1,0 +1,30 @@
+package integers
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return Analyzer, nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return true
+}

--- a/pkg/analysis/integers/testdata/src/a/a.go
+++ b/pkg/analysis/integers/testdata/src/a/a.go
@@ -1,0 +1,111 @@
+package a
+
+type Integers struct {
+	ValidString string
+
+	ValidMap map[string]string
+
+	ValidInt32 int32
+
+	ValidInt32Ptr *int32
+
+	ValidInt64 int64
+
+	ValidInt64Ptr *int64
+
+	InvalidInt int // want "field InvalidInt should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidIntPtr *int // want "field InvalidIntPtr pointer should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidInt8 int8 // want "field InvalidInt8 should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidInt16 int16 // want "field InvalidInt16 should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidUInt uint // want "field InvalidUInt should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUIntPtr uint // want "field InvalidUIntPtr should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUInt8 uint8 // want "field InvalidUInt8 should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUInt16 uint16 // want "field InvalidUInt16 should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUInt32 uint32 // want "field InvalidUInt32 should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUInt64 uint64 // want "field InvalidUInt64 should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	ValidInt32Alias ValidInt32Alias
+
+	ValidInt32AliasPtr *ValidInt32Alias
+
+	InvalidIntAlias InvalidIntAlias // want "field InvalidIntAlias type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidIntAliasPtr *InvalidIntAlias // want "field InvalidIntAliasPtr pointer type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidUIntAlias InvalidUIntAlias // want "field InvalidUIntAlias type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidUIntAliasPtr *InvalidUIntAlias // want "field InvalidUIntAliasPtr pointer type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidIntAliasAlias InvalidIntAliasAlias // want "field InvalidIntAliasAlias type InvalidIntAliasAlias type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	ValidSliceInt32 []int32
+
+	ValidSliceInt32Ptr []*int32
+
+	ValidSliceInt64 []int64
+
+	ValidSliceInt64Ptr []*int64
+
+	InvalidSliceInt []int // want "field InvalidSliceInt array element should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidSliceIntPtr []*int // want "field InvalidSliceIntPtr array element pointer should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidSliceUInt []uint // want "field InvalidSliceUInt array element should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidSliceUIntPtr []*uint // want "field InvalidSliceUIntPtr array element pointer should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidSliceIntAlias []InvalidIntAlias // want "field InvalidSliceIntAlias array element type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidSliceIntAliasPtr []*InvalidIntAlias // want "field InvalidSliceIntAliasPtr array element pointer type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidSliceUIntAlias []InvalidUIntAlias // want "field InvalidSliceUIntAlias array element type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	InvalidSliceUIntAliasPtr []*InvalidUIntAlias // want "field InvalidSliceUIntAliasPtr array element pointer type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+}
+
+type ValidInt32Alias int32
+
+type ValidInt32PtrAlias *int32
+
+type ValidInt64Alias int64
+
+type ValidInt64PtrAlias *int64
+
+type InvalidIntAlias int // want "type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidIntPtrAlias *int // want "type InvalidIntPtrAlias pointer should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidInt8Alias int8 // want "type InvalidInt8Alias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidInt16Alias int16 // want "type InvalidInt16Alias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidUIntAlias uint // want "type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidUIntPtrAlias *uint // want "type InvalidUIntPtrAlias pointer should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidUInt8Alias uint8 // want "type InvalidUInt8Alias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidUInt16Alias uint16 // want "type InvalidUInt16Alias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidUInt32Alias uint32 // want "type InvalidUInt32Alias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidUInt64Alias uint64 // want "type InvalidUInt64Alias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+type InvalidIntAliasAlias InvalidIntAlias // want "type InvalidIntAliasAlias type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidSliceIntAlias []int // want "type InvalidSliceIntAlias array element should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidSliceIntPtrAlias []*int // want "type InvalidSliceIntPtrAlias array element pointer should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidSliceIntAliasAlias []InvalidIntAlias // want "type InvalidSliceIntAliasAlias array element type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+type InvalidSliceIntAliasPtrAlias []*InvalidIntAlias // want "type InvalidSliceIntAliasPtrAlias array element pointer type InvalidIntAlias should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"

--- a/pkg/analysis/registry.go
+++ b/pkg/analysis/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JoelSpeed/kal/pkg/analysis/commentstart"
 	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
+	"github.com/JoelSpeed/kal/pkg/analysis/integers"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
 	"github.com/JoelSpeed/kal/pkg/analysis/nophase"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
@@ -53,6 +54,7 @@ func NewRegistry() Registry {
 		initializers: []AnalyzerInitializer{
 			conditions.Initializer(),
 			commentstart.Initializer(),
+			integers.Initializer(),
 			jsontags.Initializer(),
 			nophase.Initializer(),
 			optionalorrequired.Initializer(),

--- a/pkg/analysis/registry_test.go
+++ b/pkg/analysis/registry_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Registry", func() {
 			Expect(r.DefaultLinters().UnsortedList()).To(ConsistOf(
 				"conditions",
 				"commentstart",
+				"integers",
 				"jsontags",
 				"nophase",
 				"optionalorrequired",
@@ -32,6 +33,7 @@ var _ = Describe("Registry", func() {
 			Expect(r.AllLinters().UnsortedList()).To(ConsistOf(
 				"conditions",
 				"commentstart",
+				"integers",
 				"jsontags",
 				"nophase",
 				"optionalorrequired",


### PR DESCRIPTION
API conventions state that `int` and `uint` types should not be used, and that the only numeric types supported in Kube APIs are `int32` and `int64`.

This adds an analyzer that checks for all kinds of ints, that aren't `int32` or `int64`, including type aliases, and recommends that they are not used.