### PR TITLE
Add NoBools linter as an opt-in check to prevent usage of boolean types

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ lintersConfig:
     jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # Provide a custom regex, which the json tag must match.
 ```
 
+## NoBools
+
+The `nobools` linter checks that fields in the API types do not contain a `bool` type.
+
+Booleans are limited and do not evolve well over time.
+It is recommended instead to create a string alias with meaningful values, as an enum.
+
 ## Nophase
 
 The `nophase` linter checks that the fields in the API types don't contain a 'Phase', or any field which contains 'Phase' as a substring, e.g MachinePhase.

--- a/pkg/analysis/integers/analyzer.go
+++ b/pkg/analysis/integers/analyzer.go
@@ -2,10 +2,9 @@ package integers
 
 import (
 	"errors"
-	"fmt"
 	"go/ast"
 
-	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/utils"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -23,7 +22,7 @@ var Analyzer = &analysis.Analyzer{
 	Name:     name,
 	Doc:      "All integers should be explicit about their size, int32 and int64 should be used over plain int. Unsigned ints are not allowed.",
 	Run:      run,
-	Requires: []*analysis.Analyzer{inspect.Analyzer, extractjsontags.Analyzer},
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -39,65 +38,21 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		(*ast.TypeSpec)(nil),
 	}
 
+	typeChecker := utils.NewTypeChecker(checkIntegers)
+
 	// Preorder visits all the nodes of the AST in depth-first order. It calls
 	// f(n) for each node n before it visits n's children.
 	//
 	// We use the filter defined above, ensuring we only look at struct fields and type declarations.
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		switch typ := n.(type) {
-		case *ast.StructType:
-			if typ.Fields == nil {
-				return
-			}
-
-			for _, field := range typ.Fields.List {
-				checkField(pass, field)
-			}
-		case *ast.TypeSpec:
-			checkTypeSpec(pass, typ, typ, "type")
-		}
+		typeChecker.CheckNode(pass, n)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field) {
-	if field == nil || len(field.Names) == 0 || field.Names[0] == nil {
-		return
-	}
-
-	fieldName := field.Names[0].Name
-	prefix := fmt.Sprintf("field %s", fieldName)
-
-	checkTypeExpr(pass, field.Type, field, prefix)
-}
-
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, prefix string) {
-	if tSpec.Name == nil {
-		return
-	}
-
-	typeName := tSpec.Name.Name
-	prefix = fmt.Sprintf("%s %s", prefix, typeName)
-
-	checkTypeExpr(pass, tSpec.Type, node, prefix)
-}
-
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, prefix string) {
-	switch typ := typeExpr.(type) {
-	case *ast.Ident:
-		checkIdent(pass, typ, node, prefix)
-	case *ast.StarExpr:
-		checkTypeExpr(pass, typ.X, node, fmt.Sprintf("%s pointer", prefix))
-	case *ast.ArrayType:
-		checkTypeExpr(pass, typ.Elt, node, fmt.Sprintf("%s array element", prefix))
-	}
-}
-
-// checkIdent looks for known type of integers that do not match the allowed `int32` or `int64` requirements.
-// It will also identify fields that are using type aliases and determine if these type aliases use invalid
-// types of integers, and highlight this.
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
+// checkIntegers looks for known type of integers that do not match the allowed `int32` or `int64` requirements.
+func checkIntegers(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
 	switch ident.Name {
 	case "int32", "int64":
 		// Valid cases
@@ -106,16 +61,4 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix str
 	case "uint", "uint8", "uint16", "uint32", "uint64":
 		pass.Reportf(node.Pos(), "%s should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive", prefix)
 	}
-
-	if ident.Obj == nil || ident.Obj.Decl == nil {
-		return
-	}
-
-	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
-	if !ok {
-		return
-	}
-
-	// The field is using a type alias, check if the alias is an int.
-	checkTypeSpec(pass, tSpec, node, fmt.Sprintf("%s type", prefix))
 }

--- a/pkg/analysis/nobools/analyzer.go
+++ b/pkg/analysis/nobools/analyzer.go
@@ -1,0 +1,58 @@
+package nobools
+
+import (
+	"errors"
+	"go/ast"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/utils"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const name = "nobools"
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+)
+
+// Analyzer is the analyzer for the nobools package.
+// It checks that no struct fields are `bool`.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "Boolean values cannot evolve over time, use an enum with meaningful values instead",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter typespecs so that we can look at type aliases.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+		(*ast.TypeSpec)(nil),
+	}
+
+	typeChecker := utils.NewTypeChecker(checkBool)
+
+	// Preorder visits all the nodes of the AST in depth-first order. It calls
+	// f(n) for each node n before it visits n's children.
+	//
+	// We use the filter defined above, ensuring we only look at struct fields and type declarations.
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		typeChecker.CheckNode(pass, n)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkBool(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
+	if ident.Name == "bool" {
+		pass.Reportf(node.Pos(), "%s should not use a bool. Use a string type with meaningful constant values as an enum.", prefix)
+	}
+}

--- a/pkg/analysis/nobools/analyzer_test.go
+++ b/pkg/analysis/nobools/analyzer_test.go
@@ -1,0 +1,13 @@
+package nobools_test
+
+import (
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/nobools"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, nobools.Analyzer, "a")
+}

--- a/pkg/analysis/nobools/doc.go
+++ b/pkg/analysis/nobools/doc.go
@@ -1,0 +1,15 @@
+/*
+nobools is an analyzer that checks for usage of bool types.
+
+Boolean values can only ever have 2 states, true or false.
+Over time, needs may change, and with a bool type, there is no way to add additional states.
+This problem then leads to pairs of bools, where values of one are only valid given the value of another.
+This is confusing and error-prone.
+
+It is recommended instead to use a string type with a set of constants to represent the different states,
+creating an enum.
+
+By using an enum, not only can you provide meaningul names for the various states of the API,
+but you can also add additional states in the future without breaking the API.
+*/
+package nobools

--- a/pkg/analysis/nobools/initializer.go
+++ b/pkg/analysis/nobools/initializer.go
@@ -1,0 +1,32 @@
+package nobools
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return Analyzer, nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	// Bools avoidance in the Kube conventions is not a must.
+	// Make this opt in depending on the projects own preference.
+	return false
+}

--- a/pkg/analysis/nobools/testdata/src/a/a.go
+++ b/pkg/analysis/nobools/testdata/src/a/a.go
@@ -1,0 +1,35 @@
+package a
+
+type Integers struct {
+	ValidString string
+
+	ValidMap map[string]string
+
+	ValidInt32 int32
+
+	ValidInt64 int64
+
+	InvalidBool bool // want "field InvalidBool should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolPtr *bool // want "field InvalidBoolPtr pointer should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolSlice []bool // want "field InvalidBoolSlice array element should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolPtrSlice []*bool // want "field InvalidBoolPtrSlice array element pointer should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolAlias BoolAlias // want "field InvalidBoolAlias type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolPtrAlias *BoolAlias // want "field InvalidBoolPtrAlias pointer type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolSliceAlias []BoolAlias // want "field InvalidBoolSliceAlias array element type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidBoolPtrSliceAlias []*BoolAlias // want "field InvalidBoolPtrSliceAlias array element pointer type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+}
+
+type BoolAlias bool // want "type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+
+type BoolAliasPtr *bool // want "type BoolAliasPtr pointer should not use a bool. Use a string type with meaningful constant values as an enum."
+
+type BoolAliasSlice []bool // want "type BoolAliasSlice array element should not use a bool. Use a string type with meaningful constant values as an enum."
+
+type BoolAliasPtrSlice []*bool // want "type BoolAliasPtrSlice array element pointer should not use a bool. Use a string type with meaningful constant values as an enum."

--- a/pkg/analysis/registry.go
+++ b/pkg/analysis/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
 	"github.com/JoelSpeed/kal/pkg/analysis/integers"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/nobools"
 	"github.com/JoelSpeed/kal/pkg/analysis/nophase"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
 	"github.com/JoelSpeed/kal/pkg/analysis/requiredfields"
@@ -56,6 +57,7 @@ func NewRegistry() Registry {
 			commentstart.Initializer(),
 			integers.Initializer(),
 			jsontags.Initializer(),
+			nobools.Initializer(),
 			nophase.Initializer(),
 			optionalorrequired.Initializer(),
 			requiredfields.Initializer(),

--- a/pkg/analysis/registry_test.go
+++ b/pkg/analysis/registry_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Registry", func() {
 				"commentstart",
 				"integers",
 				"jsontags",
+				"nobools",
 				"nophase",
 				"optionalorrequired",
 				"requiredfields",

--- a/pkg/analysis/utils/testdata/src/a/a.go
+++ b/pkg/analysis/utils/testdata/src/a/a.go
@@ -1,0 +1,35 @@
+package a
+
+type Integers struct {
+	String string // want "field String is a string"
+
+	Map map[string]string
+
+	Int32 int32
+
+	Int64 int64
+
+	Bool bool
+
+	StringPtr *string // want "field StringPtr pointer is a string"
+
+	StringSlice []string // want "field StringSlice array element is a string"
+
+	StringPtrSlice []*string // want "field StringPtrSlice array element pointer is a string"
+
+	StringAlias StringAlias // want "field StringAlias type StringAlias is a string"
+
+	StringAliasPtr *StringAlias // want "field StringAliasPtr pointer type StringAlias is a string"
+
+	StringAliasSlice []StringAlias // want "field StringAliasSlice array element type StringAlias is a string"
+
+	StringAliasPtrSlice []*StringAlias // want "field StringAliasPtrSlice array element pointer type StringAlias is a string"
+}
+
+type StringAlias string // want "type StringAlias is a string"
+
+type StringAliasPtr *string // want "type StringAliasPtr pointer is a string"
+
+type StringAliasSlice []string // want "type StringAliasSlice array element is a string"
+
+type StringAliasPtrSlice []*string // want "type StringAliasPtrSlice array element pointer is a string"

--- a/pkg/analysis/utils/type_check.go
+++ b/pkg/analysis/utils/type_check.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"fmt"
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// TypeChecker is an interface for checking types in an AST.
+// It is used to check the underlying, built-in types of fields within structs, and raw type declarations.
+// It is up to the implementer to provide a function that will be called when a built-in type is found,
+// and to provide the logic for providing analysis about this type.
+type TypeChecker interface {
+	CheckNode(pass *analysis.Pass, node ast.Node)
+}
+
+// NewTypeChecker returns a new TypeChecker with the provided checkFunc.
+func NewTypeChecker(checkFunc func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string)) TypeChecker {
+	return &typeChecker{
+		checkFunc: checkFunc,
+	}
+}
+
+type typeChecker struct {
+	checkFunc func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string)
+}
+
+// CheckNode checks the provided node for built-in types.
+// It will iterate through fields within structs, and raw type declarations.
+// Calling the checkFunc when a built-in type is found.
+func (t *typeChecker) CheckNode(pass *analysis.Pass, node ast.Node) {
+	switch n := node.(type) {
+	case *ast.StructType:
+		if n.Fields == nil {
+			return
+		}
+
+		for _, field := range n.Fields.List {
+			t.checkField(pass, field)
+		}
+	case *ast.TypeSpec:
+		t.checkTypeSpec(pass, n, node, "type")
+	}
+}
+
+func (t *typeChecker) checkField(pass *analysis.Pass, field *ast.Field) {
+	if field == nil || len(field.Names) == 0 || field.Names[0] == nil {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+	prefix := fmt.Sprintf("field %s", fieldName)
+
+	t.checkTypeExpr(pass, field.Type, field, prefix)
+}
+
+func (t *typeChecker) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, prefix string) {
+	if tSpec.Name == nil {
+		return
+	}
+
+	typeName := tSpec.Name.Name
+	prefix = fmt.Sprintf("%s %s", prefix, typeName)
+
+	t.checkTypeExpr(pass, tSpec.Type, node, prefix)
+}
+
+func (t *typeChecker) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, prefix string) {
+	switch typ := typeExpr.(type) {
+	case *ast.Ident:
+		t.checkIdent(pass, typ, node, prefix)
+	case *ast.StarExpr:
+		t.checkTypeExpr(pass, typ.X, node, fmt.Sprintf("%s pointer", prefix))
+	case *ast.ArrayType:
+		t.checkTypeExpr(pass, typ.Elt, node, fmt.Sprintf("%s array element", prefix))
+	}
+}
+
+// checkIdent calls the checkFunc with the ident, when we have hit a built-in type.
+// If the ident is not a built in, we look at the underlying type until we hit a built-in type.
+func (t *typeChecker) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
+	if ident.Obj == nil || ident.Obj.Decl == nil {
+		// We've hit a built-in type, no need to check further.
+		t.checkFunc(pass, ident, node, prefix)
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	// The field is using a type alias, check if the alias is an int.
+	t.checkTypeSpec(pass, tSpec, node, fmt.Sprintf("%s type", prefix))
+}

--- a/pkg/analysis/utils/type_check_test.go
+++ b/pkg/analysis/utils/type_check_test.go
@@ -1,0 +1,54 @@
+package utils_test
+
+import (
+	"errors"
+	"go/ast"
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/utils"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, testAnalyzer(), "a")
+}
+
+func testAnalyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     "test",
+		Doc:      "test",
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+			if !ok {
+				return nil, errCouldNotGetInspector
+			}
+
+			// Filter to structs so that we can iterate over fields in a struct.
+			nodeFilter := []ast.Node{
+				(*ast.StructType)(nil),
+				(*ast.TypeSpec)(nil),
+			}
+
+			typeChecker := utils.NewTypeChecker(func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
+				if ident.Name == "string" {
+					pass.Reportf(node.Pos(), "%s is a string", prefix)
+				}
+			})
+
+			inspect.Preorder(nodeFilter, func(n ast.Node) {
+				typeChecker.CheckNode(pass, n)
+			})
+
+			return nil, nil
+		},
+	}
+}


### PR DESCRIPTION
Based on the `integers` linter pattern, this adds an opt-in linter (since different communities vary in how strict they are in enforcing this rule) that prevents the usage of new boolean based fields.