### PR TITLE
Prevent integer and bool misuse in maps

### DIFF
--- a/pkg/analysis/integers/testdata/src/a/a.go
+++ b/pkg/analysis/integers/testdata/src/a/a.go
@@ -70,6 +70,22 @@ type Integers struct {
 	InvalidSliceUIntAlias []InvalidUIntAlias // want "field InvalidSliceUIntAlias array element type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
 
 	InvalidSliceUIntAliasPtr []*InvalidUIntAlias // want "field InvalidSliceUIntAliasPtr array element pointer type InvalidUIntAlias should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	ValidMapStringToInt32 map[string]int32
+
+	ValidMapStringToInt64 map[string]int64
+
+	InvalidMapStringToInt map[string]int // want "field InvalidMapStringToInt map value should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidMapStringToUInt map[string]uint // want "field InvalidMapStringToUInt map value should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
+
+	ValidMapInt32ToString map[int32]string
+
+	ValidMapInt64ToString map[int64]string
+
+	InvalidMapIntToString map[int]string // want "field InvalidMapIntToString map key should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
+
+	InvalidMapUIntToString map[uint]string // want "field InvalidMapUIntToString map key should not use unsigned integers, use only int32 or int64 and apply validation to ensure the value is positive"
 }
 
 type ValidInt32Alias int32

--- a/pkg/analysis/nobools/testdata/src/a/a.go
+++ b/pkg/analysis/nobools/testdata/src/a/a.go
@@ -24,6 +24,14 @@ type Integers struct {
 	InvalidBoolSliceAlias []BoolAlias // want "field InvalidBoolSliceAlias array element type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
 
 	InvalidBoolPtrSliceAlias []*BoolAlias // want "field InvalidBoolPtrSliceAlias array element pointer type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidMapStringToBool map[string]bool // want "field InvalidMapStringToBool map value should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidMapStringToBoolPtr map[string]*bool // want "field InvalidMapStringToBoolPtr map value pointer should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidMapBoolToString map[bool]string // want "field InvalidMapBoolToString map key should not use a bool. Use a string type with meaningful constant values as an enum."
+
+	InvalidMapBoolPtrToString map[*bool]string // want "field InvalidMapBoolPtrToString map key pointer should not use a bool. Use a string type with meaningful constant values as an enum."
 }
 
 type BoolAlias bool // want "type BoolAlias should not use a bool. Use a string type with meaningful constant values as an enum."
@@ -33,3 +41,7 @@ type BoolAliasPtr *bool // want "type BoolAliasPtr pointer should not use a bool
 type BoolAliasSlice []bool // want "type BoolAliasSlice array element should not use a bool. Use a string type with meaningful constant values as an enum."
 
 type BoolAliasPtrSlice []*bool // want "type BoolAliasPtrSlice array element pointer should not use a bool. Use a string type with meaningful constant values as an enum."
+
+type MapStringToBoolAlias map[string]bool // want "type MapStringToBoolAlias map value should not use a bool. Use a string type with meaningful constant values as an enum"
+
+type MapStringToBoolPtrAlias map[string]*bool //want "type MapStringToBoolPtrAlias map value pointer should not use a bool. Use a string type with meaningful constant values as an enum"

--- a/pkg/analysis/utils/testdata/src/a/a.go
+++ b/pkg/analysis/utils/testdata/src/a/a.go
@@ -3,7 +3,9 @@ package a
 type Integers struct {
 	String string // want "field String is a string"
 
-	Map map[string]string
+	Map map[string]string // want "field Map map key is a string" "field Map map value is a string"
+
+	MapStringToStringAlias map[string]StringAlias // want "field MapStringToStringAlias map key is a string" "field MapStringToStringAlias map value type StringAlias is a string"
 
 	Int32 int32
 

--- a/pkg/analysis/utils/type_check.go
+++ b/pkg/analysis/utils/type_check.go
@@ -74,6 +74,9 @@ func (t *typeChecker) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node
 		t.checkTypeExpr(pass, typ.X, node, fmt.Sprintf("%s pointer", prefix))
 	case *ast.ArrayType:
 		t.checkTypeExpr(pass, typ.Elt, node, fmt.Sprintf("%s array element", prefix))
+	case *ast.MapType:
+		t.checkTypeExpr(pass, typ.Key, node, fmt.Sprintf("%s map key", prefix))
+		t.checkTypeExpr(pass, typ.Value, node, fmt.Sprintf("%s map value", prefix))
 	}
 }
 


### PR DESCRIPTION
This PR updates the typechecker implementation to also prevent usage of forbidden integer or boolean types as keys/values in maps