### PR TITLE
Add maxlength linter for strings and arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ lintersConfig:
     jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # Provide a custom regex, which the json tag must match.
 ```
 
+## MaxLength
+
+The `maxlength` linter checks that string and array fields in the API are bounded by a maximum length.
+
+For strings, this means they have a `+kubebuilder:validation:MaxLength` marker.
+
+For arrays, this means they have a `+kubebuilder:validation:MaxItems` marker.
+
+For arrays of strings, the array element should also have a `+kubebuilder:validation:MaxLength` marker if the array element is a type alias,
+or `+kubebuilder:validation:items:MaxLenth` if the array is an element of the built-in string type.
+
+Adding maximum lengths to strings and arrays not only ensures that the API is not abused (used to store overly large data, reduces DDOS etc.),
+but also allows CEL validation cost estimations to be kept within reasonable bounds.
+
 ## NoBools
 
 The `nobools` linter checks that fields in the API types do not contain a `bool` type.

--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -59,34 +59,25 @@ type markers struct {
 // FieldMarkers return the appropriate MarkerSet for the field,
 // or an empty MarkerSet if the appropriate MarkerSet isn't found.
 func (m *markers) FieldMarkers(field *ast.Field) MarkerSet {
-	fMarkers, ok := m.fieldMarkers[field]
-	if !ok {
-		return NewMarkerSet()
-	}
+	fMarkers := m.fieldMarkers[field]
 
-	return fMarkers
+	return NewMarkerSet(fMarkers.UnsortedList()...)
 }
 
 // StructMarkers returns the appropriate MarkerSet if found, else
 // it returns an empty MarkerSet.
 func (m *markers) StructMarkers(sTyp *ast.StructType) MarkerSet {
-	sMarkers, ok := m.structMarkers[sTyp]
-	if !ok {
-		return NewMarkerSet()
-	}
+	sMarkers := m.structMarkers[sTyp]
 
-	return sMarkers
+	return NewMarkerSet(sMarkers.UnsortedList()...)
 }
 
 // TypeMarkers return the appropriate MarkerSet for the type,
 // or an empty MarkerSet if the appropriate MarkerSet isn't found.
 func (m *markers) TypeMarkers(typ *ast.TypeSpec) MarkerSet {
-	tMarkers, ok := m.typeMarkers[typ]
-	if !ok {
-		return NewMarkerSet()
-	}
+	tMarkers := m.typeMarkers[typ]
 
-	return tMarkers
+	return NewMarkerSet(tMarkers.UnsortedList()...)
 }
 
 func (m *markers) insertFieldMarkers(field *ast.Field, ms MarkerSet) {
@@ -376,4 +367,15 @@ func (ms MarkerSet) HasWithExpressions(identifier string, expressions map[string
 	}
 
 	return false
+}
+
+// UnsortedList returns a list of the markers, in no particular order.
+func (ms MarkerSet) UnsortedList() []Marker {
+	markers := []Marker{}
+
+	for _, marker := range ms {
+		markers = append(markers, marker...)
+	}
+
+	return markers
 }

--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -118,7 +118,23 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	nodeFilter := []ast.Node{
-		(*ast.TypeSpec)(nil),
+		// In order to get the godoc comments from a type
+		// definition as such:
+		//
+		// // comment
+		// type Foo struct {...}
+		//
+		// We need to use the ast.GenDecl type instead of the
+		// ast.TypeSpec type. The ast.TypeSpec.Doc field will only
+		// be populated if types are defined as such:
+		//
+		// type(
+		//   // comment
+		//   Foo struct {...}
+		// )
+		//
+		// For more information, see https://github.com/golang/go/issues/27477
+		(*ast.GenDecl)(nil),
 		(*ast.Field)(nil),
 	}
 
@@ -129,8 +145,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
 		switch typ := n.(type) {
-		case *ast.TypeSpec:
-			extractTypeSpecMarkers(typ, results)
+		case *ast.GenDecl:
+			extractGenDeclMarkers(typ, results)
 		case *ast.Field:
 			extractFieldMarkers(typ, results)
 		}
@@ -139,21 +155,30 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return results, nil
 }
 
-func extractTypeSpecMarkers(typ *ast.TypeSpec, results *markers) {
-	typeMarkers := NewMarkerSet()
+func extractGenDeclMarkers(typ *ast.GenDecl, results *markers) {
+	declMarkers := NewMarkerSet()
 
 	if typ.Doc != nil {
 		for _, comment := range typ.Doc.List {
 			if marker := extractMarker(comment); marker.Identifier != "" {
-				typeMarkers.Insert(marker)
+				declMarkers.Insert(marker)
 			}
 		}
 	}
 
-	results.insertTypeMarkers(typ, typeMarkers)
+	if len(typ.Specs) == 0 {
+		return
+	}
 
-	if uTyp, ok := typ.Type.(*ast.StructType); ok {
-		results.insertStructMarkers(uTyp, typeMarkers)
+	tSpec, ok := typ.Specs[0].(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	results.insertTypeMarkers(tSpec, declMarkers)
+
+	if sTyp, ok := tSpec.Type.(*ast.StructType); ok {
+		results.insertStructMarkers(sTyp, declMarkers)
 	}
 }
 

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -1,0 +1,225 @@
+package maxlength
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/markers"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	name = "maxlength"
+
+	kubebuilderMaxLength = "kubebuilder:validation:MaxLength"
+	kubebuilderEnum      = "kubebuilder:validation:Enum"
+	kubebuilderFormat    = "kubebuilder:validation:Format"
+
+	kubebuilderItemsMaxLength = "kubebuilder:validation:items:MaxLength"
+	kubebuilderItemsEnum      = "kubebuilder:validation:items:Enum"
+	kubebuilderItemsFormat    = "kubebuilder:validation:items:Format"
+
+	kubebuilderMaxItems = "kubebuilder:validation:MaxItems"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+	errCouldNotGetMarkers   = errors.New("could not get markers")
+)
+
+// Analyzer is the analyzer for the maxlength package.
+// It checks that strings and arrays have maximum lengths and maximum items respectively.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	if !ok {
+		return nil, errCouldNotGetMarkers
+	}
+
+	// Filter to structs so that we can iterate over the fields in a struct.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		sTyp, ok := n.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		if sTyp.Fields == nil {
+			return
+		}
+
+		for _, field := range sTyp.Fields.List {
+			checkField(pass, field, markersAccess)
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Markers) {
+	if len(field.Names) == 0 || field.Names[0] == nil {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+	prefix := fmt.Sprintf("field %s", fieldName)
+
+	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, kubebuilderMaxLength, needsStringMaxLength)
+}
+
+func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if ident.Obj == nil { // Built-in type
+		if ident.Name == "string" {
+			markers := getCombinedMarkers(markersAccess, node, aliases)
+
+			if needsMaxLength(markers) {
+				pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
+			}
+		}
+
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+}
+
+func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if tSpec.Name == nil {
+		return
+	}
+
+	typeName := tSpec.Name.Name
+	prefix = fmt.Sprintf("%s %s", prefix, typeName)
+
+	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+}
+
+func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	switch typ := typeExpr.(type) {
+	case *ast.Ident:
+		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	case *ast.StarExpr:
+		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	case *ast.ArrayType:
+		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+	}
+}
+
+func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+	if arrayType.Elt != nil {
+		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
+			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+		}
+	}
+
+	markers := getCombinedMarkers(markersAccess, node, aliases)
+
+	if !markers.Has(kubebuilderMaxItems) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, kubebuilderMaxItems)
+	}
+}
+
+func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+	if ident.Obj == nil { // Built-in type
+		if ident.Name == "string" {
+			markers := getCombinedMarkers(markersAccess, node, aliases)
+
+			if needsItemsMaxLength(markers) {
+				pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, kubebuilderItemsMaxLength)
+			}
+		}
+
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	// If the array element wasn't directly a string, allow a string alias to be used
+	// with either the items style markers or the on alias style markers.
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), kubebuilderMaxLength, func(ms markers.MarkerSet) bool {
+		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+	})
+}
+
+func getCombinedMarkers(markersAccess markers.Markers, node ast.Node, aliases []*ast.TypeSpec) markers.MarkerSet {
+	base := markers.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
+
+	for _, a := range aliases {
+		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+	}
+
+	return base
+}
+
+func getMarkers(markersAccess markers.Markers, node ast.Node) markers.MarkerSet {
+	switch t := node.(type) {
+	case *ast.Field:
+		return markersAccess.FieldMarkers(t)
+	case *ast.TypeSpec:
+		return markersAccess.TypeMarkers(t)
+	}
+
+	return nil
+}
+
+// needsMaxLength returns true if the field needs a maximum length.
+// Fields do not need a maximum length if they are already marked with a maximum length,
+// or if they are an enum, or if they are a date, date-time or duration.
+func needsStringMaxLength(markerSet markers.MarkerSet) bool {
+	switch {
+	case markerSet.Has(kubebuilderMaxLength),
+		markerSet.Has(kubebuilderEnum),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+		return false
+	}
+
+	return true
+}
+
+func needsItemsMaxLength(markerSet markers.MarkerSet) bool {
+	switch {
+	case markerSet.Has(kubebuilderItemsMaxLength),
+		markerSet.Has(kubebuilderItemsEnum),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
+		return false
+	}
+
+	return true
+}
+
+func kubebuilderFormatWithValue(value string) string {
+	return fmt.Sprintf("%s:=%s", kubebuilderFormat, value)
+}
+
+func kubebuilderItemsFormatWithValue(value string) string {
+	return fmt.Sprintf("%s:=%s", kubebuilderItemsFormat, value)
+}

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -86,13 +86,7 @@ func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Mar
 
 func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
 	if ident.Obj == nil { // Built-in type
-		if ident.Name == "string" {
-			markers := getCombinedMarkers(markersAccess, node, aliases)
-
-			if needsMaxLength(markers) {
-				pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
-			}
-		}
+		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 
 		return
 	}
@@ -103,6 +97,18 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 	}
 
 	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+}
+
+func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if ident.Name != "string" {
+		return
+	}
+
+	markers := getCombinedMarkers(markersAccess, node, aliases)
+
+	if needsMaxLength(markers) {
+		pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
+	}
 }
 
 func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
@@ -143,13 +149,7 @@ func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node
 
 func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
-		if ident.Name == "string" {
-			markers := getCombinedMarkers(markersAccess, node, aliases)
-
-			if needsItemsMaxLength(markers) {
-				pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, kubebuilderItemsMaxLength)
-			}
-		}
+		checkString(pass, ident, node, aliases, markersAccess, prefix, kubebuilderItemsMaxLength, needsItemsMaxLength)
 
 		return
 	}

--- a/pkg/analysis/maxlength/analyzer_test.go
+++ b/pkg/analysis/maxlength/analyzer_test.go
@@ -1,0 +1,14 @@
+package maxlength_test
+
+import (
+	"testing"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/maxlength"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestMaxLength(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analysistest.Run(t, testdata, maxlength.Analyzer, "a")
+}

--- a/pkg/analysis/maxlength/doc.go
+++ b/pkg/analysis/maxlength/doc.go
@@ -1,0 +1,19 @@
+/*
+maxlength is an analyzer that checks that all string fields have a maximum length, and that all array fields have a maximum number of items.
+
+String fields that are not otherwise bound in length, through being an enum or formatted in a certain way, should have a maximum length.
+This ensures that CEL validations on the field are not overly costly in terms of time and memory.
+
+Array fields should have a maximum number of items.
+This ensures that any CEL validations on the field are not overly costly in terms of time and memory.
+Where arrays are used to represent a list of structures, CEL rules may exist within the array.
+Limiting the array length ensures the cardinality of the rules within the array is not unbounded.
+
+For strings, the maximum length can be set using the `kubebuilder:validation:MaxLength` tag.
+For arrays, the maximum number of items can be set using the `kubebuilder:validation:MaxItems` tag.
+
+For arrays of strings, the maximum length of each string can be set using the `kubebuilder:validation:items:MaxLength` tag,
+on the array field itself.
+Or, if the array uses a string type alias, the `kubebuilder:validation:MaxLength` tag can be used on the alias.
+*/
+package maxlength

--- a/pkg/analysis/maxlength/initializer.go
+++ b/pkg/analysis/maxlength/initializer.go
@@ -1,0 +1,30 @@
+package maxlength
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return Analyzer, nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return false // For now, CRD only, and so not on by default.
+}

--- a/pkg/analysis/maxlength/testdata/src/a/a.go
+++ b/pkg/analysis/maxlength/testdata/src/a/a.go
@@ -1,0 +1,74 @@
+package a
+
+type MaxLength struct {
+	// +kubebuilder:validation:MaxLength:=256
+	StringWithMaxLength string
+
+	// +kubebuilder:validation:MaxLength:=128
+	StringAliasWithMaxLengthOnField StringAlias
+
+	StringAliasWithMaxLengthOnAlias StringAliasWithMaxLength
+
+	StringWithoutMaxLength string // want "field StringWithoutMaxLength must have a maximum length, add kubebuilder:validation:MaxLength marker"
+
+	StringAliasWithoutMaxLength StringAlias // want "field StringAliasWithoutMaxLength type StringAlias must have a maximum length, add kubebuilder:validation:MaxLength marker"
+
+	// +kubebuilder:validation:Enum:="A";"B";"C"
+	EnumString string
+
+	EnumStringAlias EnumStringAlias
+
+	// +kubebuilder:validation:Format:=duration
+	DurationFormat string
+
+	// +kubebuilder:validation:Format:=date-time
+	DateTimeFormat string
+
+	// +kubebuilder:validation:Format:=date
+	DateFormat string
+
+	// +kubebuilder:validation:MaxItems:=256
+	ArrayWithMaxItems []int
+
+	ArrayWithoutMaxItems []int // want "field ArrayWithoutMaxItems must have a maximum items, add kubebuilder:validation:MaxItems"
+
+	// +kubebuilder:validation:MaxItems:=128
+	StringArrayWithMaxItemsWithoutMaxElementLength []string // want "field StringArrayWithMaxItemsWithoutMaxElementLength array element must have a maximum length, add kubebuilder:validation:items:MaxLength"
+
+	StringArrayWithoutMaxItemsWithoutMaxElementLength []string // want "field StringArrayWithoutMaxItemsWithoutMaxElementLength must have a maximum items, add kubebuilder:validation:MaxItems" "field StringArrayWithoutMaxItemsWithoutMaxElementLength array element must have a maximum length, add kubebuilder:validation:items:MaxLength"
+
+	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:items:MaxLength:=64
+	StringArrayWithMaxItemsAndMaxElementLength []string
+
+	// +kubebuilder:validation:items:MaxLength:=512
+	StringArrayWithoutMaxItemsWithMaxElementLength []string // want  "field StringArrayWithoutMaxItemsWithMaxElementLength must have a maximum items, add kubebuilder:validation:MaxItems marker"
+
+	// +kubebuilder:validation:MaxItems:=128
+	StringAliasArrayWithMaxItemsWithoutMaxElementLength []StringAlias // want "field StringAliasArrayWithMaxItemsWithoutMaxElementLength array element type StringAlias must have a maximum length, add kubebuilder:validation:MaxLength marker"
+
+	StringAliasArrayWithoutMaxItemsWithoutMaxElementLength []StringAlias // want "field StringAliasArrayWithoutMaxItemsWithoutMaxElementLength must have a maximum items, add kubebuilder:validation:MaxItems" "field StringAliasArrayWithoutMaxItemsWithoutMaxElementLength array element type StringAlias must have a maximum length, add kubebuilder:validation:MaxLength"
+
+	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:items:MaxLength:=64
+	StringAliasArrayWithMaxItemsAndMaxElementLength []StringAlias
+
+	// +kubebuilder:validation:items:MaxLength:=512
+	StringAliasArrayWithoutMaxItemsWithMaxElementLength []StringAlias // want  "field StringAliasArrayWithoutMaxItemsWithMaxElementLength must have a maximum items, add kubebuilder:validation:MaxItems"
+
+	// +kubebuilder:validation:MaxItems:=64
+	StringAliasArrayWithMaxItemsAndMaxElementLengthOnAlias []StringAliasWithMaxLength
+
+	StringAliasArrayWithoutMaxItemsWithMaxElementLengthOnAlias []StringAliasWithMaxLength // want  "field StringAliasArrayWithoutMaxItemsWithMaxElementLengthOnAlias must have a maximum items, add kubebuilder:validation:MaxItems"
+}
+
+// StringAlias is a string without a MaxLength.
+type StringAlias string
+
+// StringAliasWithMaxLength is a string with a MaxLength.
+// +kubebuilder:validation:MaxLength:=512
+type StringAliasWithMaxLength string
+
+// EnumStringAlias is a string alias that is an enum.
+// +kubebuilder:validation:Enum:="A";"B";"C"
+type EnumStringAlias string

--- a/pkg/analysis/registry.go
+++ b/pkg/analysis/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
 	"github.com/JoelSpeed/kal/pkg/analysis/integers"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/maxlength"
 	"github.com/JoelSpeed/kal/pkg/analysis/nobools"
 	"github.com/JoelSpeed/kal/pkg/analysis/nophase"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
@@ -57,6 +58,7 @@ func NewRegistry() Registry {
 			commentstart.Initializer(),
 			integers.Initializer(),
 			jsontags.Initializer(),
+			maxlength.Initializer(),
 			nobools.Initializer(),
 			nophase.Initializer(),
 			optionalorrequired.Initializer(),

--- a/pkg/analysis/registry_test.go
+++ b/pkg/analysis/registry_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Registry", func() {
 				"commentstart",
 				"integers",
 				"jsontags",
+				"maxlength",
 				"nobools",
 				"nophase",
 				"optionalorrequired",


### PR DESCRIPTION
This adds a new linter, `maxlength`, not enabled by default, that checks fields that are either strings, or arrays, and checks that they have an appropriate bound set. This is useful to prevent CEL cost estimates from ballooning.

Every string field, unless it is an enum, or has format: date | date-time | duration, must have a max length.

Every array must have a maxitems set.

Fixed a couple of other bits while writing this:
* Markers now always copy when you read them, so we don't have the chance to overwrite the central state
* Switched to type declarations from structs, so that we gather the correct comments on a struct type