### PR TITLE
PatchStrategy is not required on CRD conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,17 @@ Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge"
 
 Conditions are idiomatically the first field within the status struct, and the linter will highlight when the Conditions are not the first field.
 
+Protobuf tags and patch strategy are required for in-tree API types, but not for CRDs.
+When linting CRD based types, set the `useProtobuf` and `usePatchStrategy` config option to `Ignore` or `Forbid`.
+
 ### Configuration
 
 ```yaml
 lintersConfig:
   conditions:
     isFirstField: Warn | Ignore # The policy for the Conditions field being the first field. Defaults to `Warn`.
-    useProtobuf: SuggestFix | Warn | Ignore # The policy for the protobuf tag on the Conditions field. Defaults to `SuggestFix`.
+    useProtobuf: SuggestFix | Warn | Ignore | Forbid # The policy for the protobuf tag on the Conditions field. Defaults to `SuggestFix`.
+    usePatchStrategy: SuggestFix | Warn | Ignore | Forbid # The policy for the patchStrategy tag on the Conditions field. Defaults to `SuggestFix`.
 ```
 
 ### Fixes (via standalone binary only)
@@ -165,10 +169,15 @@ lintersConfig:
 The `conditions` linter can automatically fix the tags on the `Conditions` field.
 When they do not match the expected format, the linter will suggest to update the tags to match the expected format.
 
-For CRDs, protobuf tags are not expected. By setting the `useProtobuf` configuration to `Ignore`, the linter will not suggest to add the protobuf tag to the `Conditions` field tags.
+For CRDs, protobuf tags and patch strategy are not expected.
+By setting the `useProtobuf`/`usePatchStrategy` configuration to `Ignore`, the linter will not suggest to add the protobuf/patch strategy tag to the `Conditions` field tags.
+By setting the `useProtobuf`/`usePatchStrategy` configuration to `Forbid`, the linter will suggest to remove the protobuf/patch strategy tag from the `Conditions` field tags.
 
 The linter will also suggest to add missing markers.
 If any of the 5 markers in the example above are missing, the linter will suggest to add them directly above the field.
+
+When `usePatchStrategy` is set to `Ignore`, the linter will not suggest to add the `patchStrategy` and `patchMergeKey` tags to the `Conditions` field markers.
+When `usePatchStrategy` is set to `Forbid`, the linter will suggest to remove the `patchStrategy` and `patchMergeKey` tags from the `Conditions` field markers.
 
 ## CommentStart
 

--- a/pkg/analysis/conditions/analyzer.go
+++ b/pkg/analysis/conditions/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"slices"
 	"strings"
 
 	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
@@ -23,14 +24,17 @@ const (
 	patchStrategyMarkerID = "patchStrategy"
 	patchMergeKeyMarkerID = "patchMergeKey"
 
-	listTypeMap       = "listType=map"
-	listMapKeyType    = "listMapKey=type"
-	patchStrategy     = "patchStrategy=merge"
-	patchMergeKeyType = "patchMergeKey=type"
-	optional          = "optional"
+	listTypeMap        = "listType=map"
+	listMapKeyType     = "listMapKey=type"
+	patchStrategy      = "patchStrategy"
+	patchStrategyMerge = "patchStrategy=merge"
+	patchMergeKey      = "patchMergeKey"
+	patchMergeKeyType  = "patchMergeKey=type"
+	optional           = "optional"
 
-	expectedTagWithProtobufFmt = "`json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,%d,rep,name=conditions\"`"
-	expectedTagWithoutProtobuf = "`json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	expectedJSONTag     = "json:\"conditions,omitempty\""
+	expectedPatchTag    = "patchStrategy:\"merge\" patchMergeKey:\"type\""
+	expectedProtobufTag = "protobuf:\"bytes,%d,rep,name=conditions\""
 )
 
 func init() {
@@ -49,8 +53,9 @@ var (
 )
 
 type analyzer struct {
-	isFirstField config.ConditionsFirstField
-	useProtobuf  config.ConditionsUseProtobuf
+	isFirstField     config.ConditionsFirstField
+	useProtobuf      config.ConditionsUseProtobuf
+	usePatchStrategy config.ConditionsUsePatchStrategy
 }
 
 // newAnalyzer creates a new analyzer.
@@ -58,8 +63,9 @@ func newAnalyzer(cfg config.ConditionsConfig) *analysis.Analyzer {
 	defaultConfig(&cfg)
 
 	a := &analyzer{
-		isFirstField: cfg.IsFirstField,
-		useProtobuf:  cfg.UseProtobuf,
+		isFirstField:     cfg.IsFirstField,
+		useProtobuf:      cfg.UseProtobuf,
+		usePatchStrategy: cfg.UsePatchStrategy,
 	}
 
 	return &analysis.Analyzer{
@@ -117,7 +123,7 @@ func (a *analyzer) checkField(pass *analysis.Pass, index int, field *ast.Field, 
 		return
 	}
 
-	checkFieldMarkers(pass, field, fieldMarkers)
+	checkFieldMarkers(pass, field, fieldMarkers, a.usePatchStrategy)
 	a.checkFieldTags(pass, index, field)
 
 	if a.isFirstField == config.ConditionsFirstFieldWarn && index != 0 {
@@ -125,8 +131,9 @@ func (a *analyzer) checkField(pass *analysis.Pass, index int, field *ast.Field, 
 	}
 }
 
-func checkFieldMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet) {
+func checkFieldMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet, usePatchStrategy config.ConditionsUsePatchStrategy) {
 	missingMarkers := []string{}
+	additionalMarkers := []markers.Marker{}
 
 	if !fieldMarkers.HasWithValue(listTypeMap) {
 		missingMarkers = append(missingMarkers, listTypeMap)
@@ -136,37 +143,112 @@ func checkFieldMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers marke
 		missingMarkers = append(missingMarkers, listMapKeyType)
 	}
 
-	if !fieldMarkers.HasWithValue(patchStrategy) {
-		missingMarkers = append(missingMarkers, patchStrategy)
-	}
-
-	if !fieldMarkers.HasWithValue(patchMergeKeyType) {
-		missingMarkers = append(missingMarkers, patchMergeKeyType)
-	}
+	patchMissingMarkers, patchAdditionalMarkers := checkPatchStrategyMarkers(fieldMarkers, usePatchStrategy)
+	missingMarkers = append(missingMarkers, patchMissingMarkers...)
+	additionalMarkers = append(additionalMarkers, patchAdditionalMarkers...)
 
 	if !fieldMarkers.Has(optional) {
 		missingMarkers = append(missingMarkers, optional)
 	}
 
 	if len(missingMarkers) != 0 {
-		pass.Report(analysis.Diagnostic{
-			Pos:     field.Pos(),
-			End:     field.End(),
-			Message: "Conditions field is missing the following markers: " + strings.Join(missingMarkers, ", "),
-			SuggestedFixes: []analysis.SuggestedFix{
-				{
-					Message: "Add missing markers",
-					TextEdits: []analysis.TextEdit{
-						{
-							Pos:     field.Pos(),
-							End:     token.NoPos,
-							NewText: getNewMarkers(missingMarkers),
-						},
+		reportMissingMarkers(pass, field, missingMarkers, usePatchStrategy)
+	}
+
+	if len(additionalMarkers) != 0 {
+		reportAdditionalMarkers(pass, field, additionalMarkers)
+	}
+}
+
+func checkPatchStrategyMarkers(fieldMarkers markers.MarkerSet, usePatchStrategy config.ConditionsUsePatchStrategy) ([]string, []markers.Marker) {
+	missingMarkers := []string{}
+	additionalMarkers := []markers.Marker{}
+
+	switch usePatchStrategy {
+	case config.ConditionsUsePatchStrategySuggestFix, config.ConditionsUsePatchStrategyWarn:
+		if !fieldMarkers.HasWithValue(patchStrategyMerge) {
+			missingMarkers = append(missingMarkers, patchStrategyMerge)
+		}
+
+		if !fieldMarkers.HasWithValue(patchMergeKeyType) {
+			missingMarkers = append(missingMarkers, patchMergeKeyType)
+		}
+	case config.ConditionsUsePatchStrategyIgnore:
+		// If it's there, we don't care.
+	case config.ConditionsUsePatchStrategyForbid:
+		if fieldMarkers.HasWithValue(patchStrategyMerge) {
+			additionalMarkers = append(additionalMarkers, fieldMarkers[patchStrategy]...)
+		}
+
+		if fieldMarkers.HasWithValue(patchMergeKeyType) {
+			additionalMarkers = append(additionalMarkers, fieldMarkers[patchMergeKey]...)
+		}
+	default:
+		panic("unexpected usePatchStrategy value")
+	}
+
+	return missingMarkers, additionalMarkers
+}
+
+func reportMissingMarkers(pass *analysis.Pass, field *ast.Field, missingMarkers []string, usePatchStrategy config.ConditionsUsePatchStrategy) {
+	suggestedFixes := []analysis.SuggestedFix{}
+
+	// If patch strategy is warn, and the only markers in the list are patchStrategy and patchMergeKeyType, we don't need to suggest a fix.
+	if usePatchStrategy != config.ConditionsUsePatchStrategyWarn || slices.ContainsFunc[[]string, string](missingMarkers, func(marker string) bool {
+		switch marker {
+		case patchStrategyMerge, patchMergeKeyType:
+			return false
+		default:
+			return true
+		}
+	}) {
+		suggestedFixes = []analysis.SuggestedFix{
+			{
+				Message: "Add missing markers",
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos:     field.Pos(),
+						End:     token.NoPos,
+						NewText: getNewMarkers(missingMarkers),
 					},
+				},
+			},
+		}
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:            field.Pos(),
+		End:            field.End(),
+		Message:        "Conditions field is missing the following markers: " + strings.Join(missingMarkers, ", "),
+		SuggestedFixes: suggestedFixes,
+	})
+}
+
+func reportAdditionalMarkers(pass *analysis.Pass, field *ast.Field, additionalMarkers []markers.Marker) {
+	suggestedFixes := []analysis.SuggestedFix{}
+	additionalMarkerValues := []string{}
+
+	for _, marker := range additionalMarkers {
+		additionalMarkerValues = append(additionalMarkerValues, marker.String())
+
+		suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+			Message: "Remove additional marker",
+			TextEdits: []analysis.TextEdit{
+				{
+					Pos:     marker.Pos,
+					End:     marker.End + 1, // Add 1 to position to include the new line
+					NewText: nil,
 				},
 			},
 		})
 	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:            field.Pos(),
+		End:            field.End(),
+		Message:        "Conditions field has the following additional markers: " + strings.Join(additionalMarkerValues, ", "),
+		SuggestedFixes: suggestedFixes,
+	})
 }
 
 func getNewMarkers(missingMarkers []string) []byte {
@@ -181,7 +263,7 @@ func getNewMarkers(missingMarkers []string) []byte {
 
 func (a *analyzer) checkFieldTags(pass *analysis.Pass, index int, field *ast.Field) {
 	if field.Tag == nil {
-		expectedTag := getExpectedTag(a.useProtobuf, a.isFirstField, index)
+		expectedTag := getExpectedTag(a.usePatchStrategy, a.useProtobuf, a.isFirstField, index)
 
 		pass.Report(analysis.Diagnostic{
 			Pos:     field.Pos(),
@@ -204,9 +286,9 @@ func (a *analyzer) checkFieldTags(pass *analysis.Pass, index int, field *ast.Fie
 		return
 	}
 
-	asExpected, shouldFix := tagIsAsExpected(field.Tag.Value, a.useProtobuf, a.isFirstField, index)
+	asExpected, shouldFix := tagIsAsExpected(field.Tag.Value, a.usePatchStrategy, a.useProtobuf, a.isFirstField, index)
 	if !asExpected {
-		expectedTag := getExpectedTag(a.useProtobuf, a.isFirstField, index)
+		expectedTag := getExpectedTag(a.usePatchStrategy, a.useProtobuf, a.isFirstField, index)
 
 		if !shouldFix {
 			pass.Reportf(field.Tag.ValuePos, "Conditions field has incorrect tags, should be: %s", expectedTag)
@@ -232,27 +314,63 @@ func (a *analyzer) checkFieldTags(pass *analysis.Pass, index int, field *ast.Fie
 	}
 }
 
-func getExpectedTag(useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) string {
-	if useProtobuf == config.ConditionsUseProtobufSuggestFix || useProtobuf == config.ConditionsUseProtobufWarn {
-		i := 1
-		if isFirstField == config.ConditionsFirstFieldIgnore {
-			i = index + 1
-		}
+func getExpectedTag(usePatchStrategy config.ConditionsUsePatchStrategy, useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) string {
+	expectedTag := fmt.Sprintf("`%s", expectedJSONTag)
 
-		return fmt.Sprintf(expectedTagWithProtobufFmt, i)
+	if usePatchStrategy == config.ConditionsUsePatchStrategySuggestFix || usePatchStrategy == config.ConditionsUsePatchStrategyWarn {
+		expectedTag += fmt.Sprintf(" %s", expectedPatchTag)
 	}
 
-	return expectedTagWithoutProtobuf
+	if useProtobuf == config.ConditionsUseProtobufSuggestFix || useProtobuf == config.ConditionsUseProtobufWarn {
+		expectedTag += fmt.Sprintf(" %s", getExpectedProtobufTag(isFirstField, index))
+	}
+
+	expectedTag += "`"
+
+	return expectedTag
 }
 
-func tagIsAsExpected(tag string, useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) (bool, bool) {
+func getExpectedProtobufTag(isFirstField config.ConditionsFirstField, index int) string {
+	i := 1
+	if isFirstField == config.ConditionsFirstFieldIgnore {
+		i = index + 1
+	}
+
+	return fmt.Sprintf(expectedProtobufTag, i)
+}
+
+func tagIsAsExpected(tag string, usePatchStrategy config.ConditionsUsePatchStrategy, useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) (bool, bool) {
+	patchTagCorrect, patchShouldSuggestFix := patchStrategyTagIsAsExpected(tag, usePatchStrategy)
+	protoTagCorrect, protoShouldSuggestFix := protobufTagIsAsExpected(tag, useProtobuf, isFirstField, index)
+
+	return patchTagCorrect && protoTagCorrect, patchShouldSuggestFix || protoShouldSuggestFix
+}
+
+func patchStrategyTagIsAsExpected(tag string, usePatchStrategy config.ConditionsUsePatchStrategy) (bool, bool) {
+	switch usePatchStrategy {
+	case config.ConditionsUsePatchStrategySuggestFix:
+		return strings.Contains(tag, expectedPatchTag), true
+	case config.ConditionsUsePatchStrategyWarn:
+		return strings.Contains(tag, expectedPatchTag), false
+	case config.ConditionsUsePatchStrategyIgnore:
+		return true, false
+	case config.ConditionsUsePatchStrategyForbid:
+		return !strings.Contains(tag, expectedPatchTag), true
+	default:
+		panic("unexpected usePatchStrategy value")
+	}
+}
+
+func protobufTagIsAsExpected(tag string, useProtobuf config.ConditionsUseProtobuf, isFirstField config.ConditionsFirstField, index int) (bool, bool) {
 	switch useProtobuf {
 	case config.ConditionsUseProtobufSuggestFix:
-		return tag == getExpectedTag(config.ConditionsUseProtobufSuggestFix, isFirstField, index), true
+		return strings.Contains(tag, getExpectedProtobufTag(isFirstField, index)), true
 	case config.ConditionsUseProtobufWarn:
-		return tag == getExpectedTag(config.ConditionsUseProtobufWarn, isFirstField, index), false
+		return strings.Contains(tag, getExpectedProtobufTag(isFirstField, index)), false
 	case config.ConditionsUseProtobufIgnore:
-		return tag == getExpectedTag(config.ConditionsUseProtobufIgnore, isFirstField, index) || tag == getExpectedTag(config.ConditionsUseProtobufSuggestFix, isFirstField, index), true
+		return true, false
+	case config.ConditionsUseProtobufForbid:
+		return !strings.Contains(tag, getExpectedProtobufTag(isFirstField, index)), true
 	default:
 		panic("unexpected useProtobuf value")
 	}
@@ -308,5 +426,9 @@ func defaultConfig(cfg *config.ConditionsConfig) {
 
 	if cfg.UseProtobuf == "" {
 		cfg.UseProtobuf = config.ConditionsUseProtobufSuggestFix
+	}
+
+	if cfg.UsePatchStrategy == "" {
+		cfg.UsePatchStrategy = config.ConditionsUsePatchStrategySuggestFix
 	}
 }

--- a/pkg/analysis/conditions/analyzer_test.go
+++ b/pkg/analysis/conditions/analyzer_test.go
@@ -48,3 +48,48 @@ func TestIgnoreProtobuf(t *testing.T) {
 
 	analysistest.RunWithSuggestedFixes(t, testdata, a, "c")
 }
+
+func TestForbidProtobuf(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{
+		Conditions: config.ConditionsConfig{
+			UseProtobuf: config.ConditionsUseProtobufForbid,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "d")
+}
+
+func TestIgnorePatchStrategy(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{
+		Conditions: config.ConditionsConfig{
+			UsePatchStrategy: config.ConditionsUsePatchStrategyIgnore,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "e")
+}
+
+func TestForbidPatchStrategy(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := conditions.Initializer().Init(config.LintersConfig{
+		Conditions: config.ConditionsConfig{
+			UsePatchStrategy: config.ConditionsUsePatchStrategyForbid,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "f")
+}

--- a/pkg/analysis/conditions/doc.go
+++ b/pkg/analysis/conditions/doc.go
@@ -19,7 +19,7 @@ Where the tags and markers are incorrect, the linter will suggest fixes to impro
 Conditions are also idiomatically the first item in the struct, the linter will highlight when the conditions field is not the first field in the struct.
 If this is not a desired behaviour, set the linter config option `isFirstField` to `Ignore`.
 
-Protobuf tags are required for in-tree API types, but not for CRDs.
-When linting CRD based types, set the `useProtobuf` config option to `Ignore`.
+Protobuf tags and patch strategy are required for in-tree API types, but not for CRDs.
+When linting CRD based types, set the `useProtobuf` and `usePatchStrategy` config option to `Ignore` or `Forbid`.
 */
 package conditions

--- a/pkg/analysis/conditions/testdata/src/d/a.go
+++ b/pkg/analysis/conditions/testdata/src/d/a.go
@@ -1,0 +1,73 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ValidConditionsMissingProtobuf struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/d/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/d/a.go.golden
@@ -1,0 +1,73 @@
+package b
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ValidConditionsMissingProtobuf struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/e/a.go
+++ b/pkg/analysis/conditions/testdata/src/e/a.go
@@ -1,0 +1,106 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (ValidConditions) DoNothing() {}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/e/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/e/a.go.golden
@@ -1,0 +1,112 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (ValidConditions) DoNothing() {}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+}
+
+type MissingOptionalMarker struct {
+	// conditions is missng the optional marker.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/f/a.go
+++ b/pkg/analysis/conditions/testdata/src/f/a.go
@@ -1,0 +1,93 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (ValidConditions) DoNothing() {}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/conditions/testdata/src/f/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/f/a.go.golden
@@ -1,0 +1,92 @@
+package a
+
+import (
+	"go/ast"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ValidConditions struct {
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (ValidConditions) DoNothing() {}
+
+type ConditionsNotFirst struct {
+	// other fields
+	OtherField string `json:"otherField,omitempty"`
+
+	// conditions is an accurate representation of the desired state of a conditions object.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type ConditionsIncorrectType struct {
+	// conditions has an incorrect type.
+	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedSliceElement struct {
+	// conditions has an incorrect type.
+	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type ConditionsIncorrectImportedPackage struct {
+	// conditions has an incorrect type.
+	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+}
+
+type MissingAllMarkers struct {
+	// conditions is missing all markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type MissingListMarkers struct {
+	// conditions is missing list markers.
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`  // want "Conditions field is missing the following markers: listType=map, listMapKey=type" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+}
+
+type MissingPatchMarkers struct {
+	// conditions is missing patch markers.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type MissingFieldTag struct {
+	// conditions is missing the field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}
+
+type IncorrectFieldTag struct {
+	// conditions has an incorrect field tag.
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+}

--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -312,6 +312,11 @@ type Marker struct {
 	End token.Pos
 }
 
+// String returns the string representation of the marker.
+func (m Marker) String() string {
+	return strings.TrimPrefix(m.RawComment, "// +")
+}
+
 // MarkerSet is a set implementation for Markers that uses
 // the Marker identifier as the key, but returns all full Markers
 // with that identifier as the result.

--- a/pkg/config/linters_config.go
+++ b/pkg/config/linters_config.go
@@ -38,6 +38,26 @@ const (
 
 	// ConditionsUseProtobufIgnore indicates that the linter will not emit a warning if the conditions are not using protobuf tags.
 	ConditionsUseProtobufIgnore ConditionsUseProtobuf = "Ignore"
+
+	// ConditionsUseProtobufForbid indicates that the linter will emit an error if the conditions are using protobuf tags, a fix will also be suggested.
+	ConditionsUseProtobufForbid ConditionsUseProtobuf = "Forbid"
+)
+
+// ConditionsUsePatchStrategy is the policy for the conditions linter.
+type ConditionsUsePatchStrategy string
+
+const (
+	// ConditionsUsePatchStrategySuggestFix indicates that the linter will emit a warning if the conditions are not using patch strategy tags and suggest a fix.
+	ConditionsUsePatchStrategySuggestFix ConditionsUsePatchStrategy = "SuggestFix"
+
+	// ConditionsUsePatchStrategyWarn indicates that the linter will emit a warning if the conditions are not using patch strategy tags.
+	ConditionsUsePatchStrategyWarn ConditionsUsePatchStrategy = "Warn"
+
+	// ConditionsUsePatchStrategyIgnore indicates that the linter will not emit a warning if the conditions are not using patch strategy tags.
+	ConditionsUsePatchStrategyIgnore ConditionsUsePatchStrategy = "Ignore"
+
+	// ConditionsUsePatchStrategyForbid indicates that the linter will emit an error if the conditions are using patch strategy tags, a fix will also be suggested.
+	ConditionsUsePatchStrategyForbid ConditionsUsePatchStrategy = "Forbid"
 )
 
 // ConditionsConfig contains configuration for the conditions linter.
@@ -50,12 +70,22 @@ type ConditionsConfig struct {
 	IsFirstField ConditionsFirstField `json:"isFirstField"`
 
 	// useProtobuf indicates whether the linter should use protobuf tags.
-	// Valid values are SuggestFix, Warn and Ignore.
+	// Valid values are SuggestFix, Warn, Ignore and Forbid.
 	// When set to SuggestFix, the linter will emit a warning if the conditions are not using protobuf tags and suggest a fix.
 	// When set to Warn, the linter will emit a warning if the conditions are not using protobuf tags.
 	// When set to Ignore, the linter will not emit a warning if the conditions are not using protobuf tags.
+	// When set to Forbid, the linter will emit an error if the conditions are using protobuf tags, a fix will also be suggested.
 	// When otherwise not specified, the default value is SuggestFix.
 	UseProtobuf ConditionsUseProtobuf `json:"useProtobuf"`
+
+	// usePatchStrategy indicates whether the linter should enforce the patch strategy tags.
+	// Valid values are SuggestFix, Warn, Ignore and Forbid.
+	// When set to SuggestFix, the linter will emit a warning if the conditions are not using patch strategy tags and suggest a fix.
+	// When set to Warn, the linter will emit a warning if the conditions are not using patch strategy tags.
+	// When set to Ignore, the linter will not emit a warning if the conditions are not using patch strategy tags.
+	// When set to Forbid, the linter will emit an error if the conditions are using patch strategy tags, a fix will also be suggested.
+	// When otherwise not specified, the default value is SuggestFix.
+	UsePatchStrategy ConditionsUsePatchStrategy `json:"usePatchStrategy"`
 }
 
 // JSONTagsConfig contains configuration for the jsontags linter.

--- a/pkg/validation/linters_config.go
+++ b/pkg/validation/linters_config.go
@@ -33,9 +33,15 @@ func validateConditionsConfig(cc config.ConditionsConfig, fldPath *field.Path) f
 	}
 
 	switch cc.UseProtobuf {
-	case "", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore:
+	case "", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore, config.ConditionsUseProtobufForbid:
 	default:
-		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("useProtobuf"), cc.UseProtobuf, fmt.Sprintf("invalid value, must be one of %q, %q, %q or omitted", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore)))
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("useProtobuf"), cc.UseProtobuf, fmt.Sprintf("invalid value, must be one of %q, %q, %q, %q or omitted", config.ConditionsUseProtobufSuggestFix, config.ConditionsUseProtobufWarn, config.ConditionsUseProtobufIgnore, config.ConditionsUseProtobufForbid)))
+	}
+
+	switch cc.UsePatchStrategy {
+	case "", config.ConditionsUsePatchStrategySuggestFix, config.ConditionsUsePatchStrategyWarn, config.ConditionsUsePatchStrategyIgnore, config.ConditionsUsePatchStrategyForbid:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("usePatchStrategy"), cc.UsePatchStrategy, fmt.Sprintf("invalid value, must be one of %q, %q, %q, %q or omitted", config.ConditionsUsePatchStrategySuggestFix, config.ConditionsUsePatchStrategyWarn, config.ConditionsUsePatchStrategyIgnore, config.ConditionsUsePatchStrategyForbid)))
 	}
 
 	return fieldErrors

--- a/pkg/validation/linters_config_test.go
+++ b/pkg/validation/linters_config_test.go
@@ -88,13 +88,61 @@ var _ = Describe("LintersConfig", func() {
 			},
 			expectedErr: "",
 		}),
+		Entry("With a valid ConditionsConfig UseProtobuf: Forbid", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UseProtobuf: config.ConditionsUseProtobufForbid,
+				},
+			},
+			expectedErr: "",
+		}),
 		Entry("With an invalid ConditionsConfig UseProtobuf", validateLintersConfigTableInput{
 			config: config.LintersConfig{
 				Conditions: config.ConditionsConfig{
 					UseProtobuf: "invalid",
 				},
 			},
-			expectedErr: "lintersConfig.conditions.useProtobuf: Invalid value: \"invalid\": invalid value, must be one of \"SuggestFix\", \"Warn\", \"Ignore\" or omitted",
+			expectedErr: "lintersConfig.conditions.useProtobuf: Invalid value: \"invalid\": invalid value, must be one of \"SuggestFix\", \"Warn\", \"Ignore\", \"Forbid\" or omitted",
+		}),
+		Entry("With a valid ConditionsConfig UsePatchStrategy: SuggestFix", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UsePatchStrategy: config.ConditionsUsePatchStrategySuggestFix,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig UsePatchStrategy: Warn", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UsePatchStrategy: config.ConditionsUsePatchStrategyWarn,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig UsePatchStrategy: Ignore", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UsePatchStrategy: config.ConditionsUsePatchStrategyIgnore,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With a valid ConditionsConfig UsePatchStrategy: Forbid", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UsePatchStrategy: config.ConditionsUsePatchStrategyForbid,
+				},
+			},
+			expectedErr: "",
+		}),
+		Entry("With an invalid ConditionsConfig UsePatchStrategy", validateLintersConfigTableInput{
+			config: config.LintersConfig{
+				Conditions: config.ConditionsConfig{
+					UsePatchStrategy: "invalid",
+				},
+			},
+			expectedErr: "lintersConfig.conditions.usePatchStrategy: Invalid value: \"invalid\": invalid value, must be one of \"SuggestFix\", \"Warn\", \"Ignore\", \"Forbid\" or omitted",
 		}),
 
 		// JSONTagsConfig validation


### PR DESCRIPTION
Fixes #35 

CRDs are not compatible with `patchStrategy`.

This update adds a way to disable checking for the `patchStrategy`, and a `Forbid` option for protobuf and the patchStrategy tags that means we can now suggest to remove the proto and patch strategy if they are present on our API types.