### PR TITLE
fix: ignore fields of json:"-"

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/pkg/analysis/commentstart/testdata/src/a/a.go
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go
@@ -5,6 +5,8 @@ type CommentStartTestStruct struct {
 	EmptyJSONTag  string `json:""`
 	InlineJSONTag string `json:",inline"`
 	NoComment     string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	Ignored       string `json:"-"`
+	Hyphen        string `json:"-,"` // want "field Hyphen is missing godoc comment"
 
 	// IncorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`

--- a/pkg/analysis/commentstart/testdata/src/a/a.go.golden
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go.golden
@@ -5,6 +5,8 @@ type CommentStartTestStruct struct {
 	EmptyJSONTag  string `json:""`
 	InlineJSONTag string `json:",inline"`
 	NoComment     string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	Ignored       string `json:"-"`
+	Hyphen        string `json:"-,"` // want "field Hyphen is missing godoc comment"
 
 	// incorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`

--- a/pkg/analysis/helpers/extractjsontags/analyzer.go
+++ b/pkg/analysis/helpers/extractjsontags/analyzer.go
@@ -81,6 +81,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return results, nil
 }
 
+//nolint:cyclop
 func extractTagInfo(tag *ast.BasicLit) FieldTagInfo {
 	if tag == nil || tag.Value == "" {
 		return FieldTagInfo{Missing: true}
@@ -105,6 +106,15 @@ func extractTagInfo(tag *ast.BasicLit) FieldTagInfo {
 	end := pos + token.Pos(len(tagValue))
 
 	tagValues := strings.Split(tagValue, ",")
+
+	if len(tagValues) == 1 && tagValues[0] == "-" {
+		return FieldTagInfo{
+			Ignored:  true,
+			RawValue: tagValue,
+			Pos:      pos,
+			End:      end,
+		}
+	}
 
 	if len(tagValues) == 2 && tagValues[0] == "" && tagValues[1] == "inline" {
 		return FieldTagInfo{
@@ -131,6 +141,9 @@ func extractTagInfo(tag *ast.BasicLit) FieldTagInfo {
 type FieldTagInfo struct {
 	// Name is the name of the field extracted from the json tag.
 	Name string
+
+	// Ignored is true if the field is ignored by json package.
+	Ignored bool
 
 	// OmitEmpty is true if the field has the omitempty option in the json tag.
 	OmitEmpty bool


### PR DESCRIPTION
https://pkg.go.dev/encoding/json#Marshal

* Ignore `json:"-"` fields in extractjsontags helper and commentstart analyzer
```go
// Field is ignored by this package.
Field int `json:"-"`
```

* Don't ignore `json:"-,"`
```go
// Field appears in JSON as key "-".
Field int `json:"-,"`
```