### PR TITLE
fix: anonymous/inaccessible structs for commentstart

### DIFF
--- a/pkg/analysis/commentstart/analyzer.go
+++ b/pkg/analysis/commentstart/analyzer.go
@@ -62,6 +62,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if decl.Tok != token.TYPE {
+			// Returning false here means we won't inspect non-type declarations (e.g. var, const, import).
 			return false
 		}
 
@@ -78,11 +79,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 func checkField(pass *analysis.Pass, field *ast.Field, jsonTags extractjsontags.StructFieldTags) (proceed bool) {
 	if field == nil || len(field.Names) == 0 {
+		// Returning false here means we don't inspect inline fields.
+		// Types of inline fields will be inspected on its declaration.
 		return false
 	}
 
 	tagInfo := jsonTags.FieldTags(field)
 	if tagInfo.Ignored {
+		// Returning false here means we won't inspect the children of an ignored field.
 		return false
 	}
 

--- a/pkg/analysis/commentstart/testdata/src/a/a.go
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go
@@ -20,6 +20,8 @@ type CommentStartTestStruct struct {
 		NoComment string `json:"noComment"`
 	} `json:"-"`
 
+	StructForInlineField `json:",inline"`
+
 	// IncorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`
 
@@ -46,6 +48,10 @@ type CommentStartTestStruct struct {
 
 // DoNothing is used to check that the analyser doesn't report on methods.
 func (CommentStartTestStruct) DoNothing() {}
+
+type StructForInlineField struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
 
 type unexportedStruct struct {
 	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"

--- a/pkg/analysis/commentstart/testdata/src/a/a.go
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go
@@ -8,6 +8,18 @@ type CommentStartTestStruct struct {
 	Ignored       string `json:"-"`
 	Hyphen        string `json:"-,"` // want "field Hyphen is missing godoc comment"
 
+	AnonymousStruct struct { // want "field AnonymousStruct is missing godoc comment"
+		NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	} `json:"anonymousStruct"`
+
+	AnonymousStructInlineJSONTag struct {
+		NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	} `json:",inline"`
+
+	IgnoredAnonymousStruct struct {
+		NoComment string `json:"noComment"`
+	} `json:"-"`
+
 	// IncorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`
 
@@ -34,3 +46,13 @@ type CommentStartTestStruct struct {
 
 // DoNothing is used to check that the analyser doesn't report on methods.
 func (CommentStartTestStruct) DoNothing() {}
+
+type unexportedStruct struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
+
+func FunctionWithStructs() {
+	type InaccessibleStruct struct {
+		NoComment string `json:"noComment"`
+	}
+}

--- a/pkg/analysis/commentstart/testdata/src/a/a.go.golden
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go.golden
@@ -8,6 +8,18 @@ type CommentStartTestStruct struct {
 	Ignored       string `json:"-"`
 	Hyphen        string `json:"-,"` // want "field Hyphen is missing godoc comment"
 
+	AnonymousStruct struct { // want "field AnonymousStruct is missing godoc comment"
+		NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	} `json:"anonymousStruct"`
+
+	AnonymousStructInlineJSONTag struct {
+		NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+	} `json:",inline"`
+
+	IgnoredAnonymousStruct struct {
+		NoComment string `json:"noComment"`
+	} `json:"-"`
+
 	// incorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`
 
@@ -34,3 +46,13 @@ type CommentStartTestStruct struct {
 
 // DoNothing is used to check that the analyser doesn't report on methods.
 func (CommentStartTestStruct) DoNothing() {}
+
+type unexportedStruct struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
+
+func FunctionWithStructs() {
+	type InaccessibleStruct struct {
+		NoComment string `json:"noComment"`
+	}
+}

--- a/pkg/analysis/commentstart/testdata/src/a/a.go.golden
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go.golden
@@ -20,6 +20,8 @@ type CommentStartTestStruct struct {
 		NoComment string `json:"noComment"`
 	} `json:"-"`
 
+	StructForInlineField `json:",inline"`
+
 	// incorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`
 
@@ -46,6 +48,10 @@ type CommentStartTestStruct struct {
 
 // DoNothing is used to check that the analyser doesn't report on methods.
 func (CommentStartTestStruct) DoNothing() {}
+
+type StructForInlineField struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
 
 type unexportedStruct struct {
 	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"


### PR DESCRIPTION
related: https://github.com/kubernetes-sigs/cluster-api/pull/11870#issuecomment-2669202656

depends on #39 

* Don't check structs defined in functions
* Don't check anonysmous structs with `json:"-"`
* Check other anonysmous structs
* Check unexported structs
    * Exported structs can depend on unexported structs