### PR TITLE
Ensure []byte is treated correctly by maxlength analyzer

### DIFF
--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -136,6 +136,18 @@ func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliase
 func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
+			if ident.Name == "byte" {
+				// byte slices are a special case as they are treated as strings.
+				// Pretend the ident is a string so that checkString can process it as expected.
+				i := &ast.Ident{
+					NamePos: ident.NamePos,
+					Name:    "string",
+				}
+				checkString(pass, i, node, aliases, markersAccess, prefix, kubebuilderMaxLength, needsStringMaxLength)
+
+				return
+			}
+
 			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
 		}
 	}

--- a/pkg/analysis/maxlength/testdata/src/a/a.go
+++ b/pkg/analysis/maxlength/testdata/src/a/a.go
@@ -32,6 +32,18 @@ type MaxLength struct {
 
 	ArrayWithoutMaxItems []int // want "field ArrayWithoutMaxItems must have a maximum items, add kubebuilder:validation:MaxItems"
 
+	ByteSlice []byte // want "field ByteSlice must have a maximum length, add kubebuilder:validation:MaxLength marker"
+
+	// +kubebuilder:validation:MaxLength:=512
+	ByteSliceWithMaxLength []byte
+
+	ByteSliceAlias ByteSliceAlias // want "field ByteSliceAlias type ByteSliceAlias must have a maximum length, add kubebuilder:validation:MaxLength marker"
+
+	// +kubebuilder:validation:MaxLength:=512
+	ByteSliceAliasWithMaxLength ByteSliceAlias
+
+	ByteSliceAliasWithMaxLengthOnAlias ByteSliceAliasWithMaxLength
+
 	// +kubebuilder:validation:MaxItems:=128
 	StringArrayWithMaxItemsWithoutMaxElementLength []string // want "field StringArrayWithMaxItemsWithoutMaxElementLength array element must have a maximum length, add kubebuilder:validation:items:MaxLength"
 
@@ -72,3 +84,10 @@ type StringAliasWithMaxLength string
 // EnumStringAlias is a string alias that is an enum.
 // +kubebuilder:validation:Enum:="A";"B";"C"
 type EnumStringAlias string
+
+// ByteSliceAlias is a byte slice without a MaxLength.
+type ByteSliceAlias []byte
+
+// ByteSliceAliasWithMaxLength is a byte slice with a MaxLength.
+// +kubebuilder:validation:MaxLength:=512
+type ByteSliceAliasWithMaxLength []byte


### PR DESCRIPTION
Fixes #42 

`[]byte` is treated as a `format: string` in terms of the openapi schema and therefore it needs a `maxlength` and not `maxitems` entry.