### PR TITLE
Fix message for imported embedded structs

### DIFF
--- a/pkg/analysis/commentstart/analyzer.go
+++ b/pkg/analysis/commentstart/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strings"
 
 	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
@@ -49,8 +50,8 @@ func checkField(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.F
 	var fieldName string
 	if len(field.Names) > 0 {
 		fieldName = field.Names[0].Name
-	} else if ident, ok := field.Type.(*ast.Ident); ok {
-		fieldName = ident.Name
+	} else {
+		fieldName = types.ExprString(field.Type)
 	}
 
 	if field.Doc == nil {

--- a/pkg/analysis/commentstart/analyzer_test.go
+++ b/pkg/analysis/commentstart/analyzer_test.go
@@ -9,5 +9,5 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.RunWithSuggestedFixes(t, testdata, commentstart.Analyzer, "a")
+	analysistest.RunWithSuggestedFixes(t, testdata, commentstart.Analyzer, "a/...")
 }

--- a/pkg/analysis/commentstart/testdata/src/a/a.go
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go
@@ -1,5 +1,7 @@
 package a
 
+import "a/pkg"
+
 type CommentStartTestStruct struct {
 	NoJSONTag     string
 	EmptyJSONTag  string `json:""`
@@ -23,6 +25,12 @@ type CommentStartTestStruct struct {
 	StructForInlineField `json:",inline"`
 
 	A `json:"a"` // want "field A is missing godoc comment"
+
+	PkgA pkg.A `json:"pkgA"` // want "field PkgA is missing godoc comment"
+
+	pkg.Embedded `json:"embedded"` // want "field pkg.Embedded is missing godoc comment"
+
+	*pkg.EmbeddedPointer `json:"embeddedPointer"` // want "field \\*pkg.EmbeddedPointer is missing godoc comment"
 
 	// IncorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`

--- a/pkg/analysis/commentstart/testdata/src/a/a.go.golden
+++ b/pkg/analysis/commentstart/testdata/src/a/a.go.golden
@@ -1,5 +1,7 @@
 package a
 
+import "a/pkg"
+
 type CommentStartTestStruct struct {
 	NoJSONTag     string
 	EmptyJSONTag  string `json:""`
@@ -23,6 +25,12 @@ type CommentStartTestStruct struct {
 	StructForInlineField `json:",inline"`
 
 	A `json:"a"` // want "field A is missing godoc comment"
+
+	PkgA pkg.A `json:"pkgA"` // want "field PkgA is missing godoc comment"
+
+	pkg.Embedded `json:"embedded"` // want "field pkg.Embedded is missing godoc comment"
+
+	*pkg.EmbeddedPointer `json:"embeddedPointer"` // want "field \\*pkg.EmbeddedPointer is missing godoc comment"
 
 	// incorrectStartComment is a field with an incorrect start to the comment. // want "godoc for field IncorrectStartComment should start with 'incorrectStartComment ...'"
 	IncorrectStartComment string `json:"incorrectStartComment"`

--- a/pkg/analysis/commentstart/testdata/src/a/pkg/a.go
+++ b/pkg/analysis/commentstart/testdata/src/a/pkg/a.go
@@ -1,0 +1,9 @@
+package pkg
+
+type A struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
+
+// To embed the same struct multiple times, we need to rename the type.
+type Embedded A
+type EmbeddedPointer A

--- a/pkg/analysis/commentstart/testdata/src/a/pkg/a.go.golden
+++ b/pkg/analysis/commentstart/testdata/src/a/pkg/a.go.golden
@@ -1,0 +1,9 @@
+package pkg
+
+type A struct {
+	NoComment string `json:"noComment"` // want "field NoComment is missing godoc comment"
+}
+
+// To embed the same struct multiple times, we need to rename the type.
+type Embedded A
+type EmbeddedPointer A


### PR DESCRIPTION
Using embedded structs from external packages, I got an error as below:

```
field  is missing godoc comment
```