### PR TITLE
nomaps: allow string based types in maps

### DIFF
--- a/pkg/analysis/nomaps/analyzer.go
+++ b/pkg/analysis/nomaps/analyzer.go
@@ -68,8 +68,6 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 }
 
 func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field) {
-	stringToStringMapType := types.NewMap(types.Typ[types.String], types.Typ[types.String])
-
 	underlyingType := pass.TypesInfo.TypeOf(field.Type).Underlying()
 
 	if ptr, ok := underlyingType.(*types.Pointer); ok {
@@ -87,7 +85,8 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field) {
 	}
 
 	if a.policy == config.NoMapsAllowStringToStringMaps {
-		if types.Identical(m, stringToStringMapType) {
+		if types.AssignableTo(m.Elem().Underlying(), types.Typ[types.String]) &&
+			types.AssignableTo(m.Key().Underlying(), types.Typ[types.String]) {
 			return
 		}
 

--- a/pkg/analysis/nomaps/testdata/src/c/c.go
+++ b/pkg/analysis/nomaps/testdata/src/c/c.go
@@ -64,3 +64,11 @@ type Component struct {
 	Key   string `json:"key"`
 	Value int32  `json:"value"`
 }
+
+type StringBasedType string
+
+type MapWithStringBasedTypes struct {
+	MapWithStringBasedElement    map[string]StringBasedType          `json:"stringBasedMapElem,omitempty"`
+	MapWithStringBasedKey        map[StringBasedType]string          `json:"stringBasedMapKey,omitempty"`
+	MapWithStringBasedKeyAndElem map[StringBasedType]StringBasedType `json:"stringBasedMapKey,omitempty"`
+}


### PR DESCRIPTION
This PR makes sure that APIs like

```
type TypeWithLabels struct {
	// Labels is a set of labels.
	//
	// +kubebuilder:validation:Optional
	// +kubebuilder:validation:MaxItems=5
	Labels map[LabelKey]LabelValue `json:"labels,omitempty"`
}

// LabelValue is a label value
//
// +kubebuilder:validation:MinLength=1
// +kubebuilder:validation:MaxLength=63
// +kubebuilder:validation:Pattern="^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
type LabelValue string

// LabelKey is a label key
//
// +kubebuilder:validation:MinLength=1
// +kubebuilder:validation:MaxLength=63
// +kubebuilder:validation:Pattern="^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
type LabelKey string
```

are allowed.