### PR TITLE
(bugfix): analysis: markers: handle backticks for attribute values

### DIFF
--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -230,7 +230,7 @@ func extractKnownMarkerIDAndExpressions(id string, marker string) (string, map[s
 	return id, extractExpressions(strings.TrimPrefix(marker, id))
 }
 
-var expressionRegex = regexp.MustCompile(`\w*=(?:'[^']*'|"(\\"|[^"])*"|[\w;\-"]+)`)
+var expressionRegex = regexp.MustCompile("\\w*=(?:'[^']*'|\"(\\\\\"|[^\"])*\"|[\\w;\\-\"]+|`[^`]*`)")
 
 func extractExpressions(expressionStr string) map[string]string {
 	expressionsMap := map[string]string{}

--- a/pkg/analysis/helpers/markers/analyzer_test.go
+++ b/pkg/analysis/helpers/markers/analyzer_test.go
@@ -121,6 +121,15 @@ func TestExtractMarkerIdAndExpressions(t *testing.T) {
 				"": "-10",
 			},
 		},
+		{
+			name:       "registered marker with named expression using backtick ('`') for strings",
+			marker:     "kubebuilder:validation:XValidation:rule=`has(self.field)`,message=`must have field!`",
+			expectedID: "kubebuilder:validation:XValidation",
+			expectedExpressions: map[string]string{
+				"rule":    "`has(self.field)`",
+				"message": "`must have field!`",
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Updates the `pkg/analysis/helpers/markers` package expression extraction regular expression to handle backticks ('`') for attribute values. For example, a marker like:
```
kubebuilder:validation:XValidation:rule=`has(self.thing)`
``` 
Would have resulted in parsing out an empty rule attribute. With this PR, it now properly extracts the attribute value.