### PR TITLE
Minor changes to function definition for consitency

### DIFF
--- a/pkg/analysis/arrayofstruct/analyzer.go
+++ b/pkg/analysis/arrayofstruct/analyzer.go
@@ -45,7 +45,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		checkField(pass, field, markersAccess)
 	})
 

--- a/pkg/analysis/commentstart/analyzer.go
+++ b/pkg/analysis/commentstart/analyzer.go
@@ -47,7 +47,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers) {
 		checkField(pass, field, jsonTagInfo)
 	})
 

--- a/pkg/analysis/conflictingmarkers/analyzer.go
+++ b/pkg/analysis/conflictingmarkers/analyzer.go
@@ -67,7 +67,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		checkField(pass, field, markersAccess, a.conflictSets)
 	})
 
@@ -119,7 +119,7 @@ func reportConflict(pass *analysis.Pass, field *ast.Field, conflictSet ConflictS
 		setDescriptions = append(setDescriptions, fmt.Sprintf("%v", markersList))
 	}
 
-	fieldName := field.Names[0].Name
+	fieldName := utils.FieldName(field)
 	structName := utils.GetStructNameForField(pass, field)
 
 	if structName != "" {

--- a/pkg/analysis/duplicatemarkers/analyzer.go
+++ b/pkg/analysis/duplicatemarkers/analyzer.go
@@ -48,7 +48,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		checkField(pass, field, markersAccess)
 	})
 

--- a/pkg/analysis/forbiddenmarkers/analyzer.go
+++ b/pkg/analysis/forbiddenmarkers/analyzer.go
@@ -61,7 +61,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		checkField(pass, field, markersAccess, a.forbiddenMarkers)
 	})
 

--- a/pkg/analysis/helpers/inspector/analyzer_test.go
+++ b/pkg/analysis/helpers/inspector/analyzer_test.go
@@ -49,7 +49,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, errCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers) {
 		pass.Reportf(field.Pos(), "field: %v", utils.FieldName(field))
 
 		if jsonTagInfo.Name != "" {

--- a/pkg/analysis/helpers/inspector/inspector.go
+++ b/pkg/analysis/helpers/inspector/inspector.go
@@ -30,7 +30,7 @@ import (
 // Inspector is an interface that allows for the inspection of fields in structs.
 type Inspector interface {
 	// InspectFields is a function that iterates over fields in structs.
-	InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers))
+	InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers))
 
 	// InspectTypeSpec is a function that inspects the type spec and calls the provided inspectTypeSpec function.
 	InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers))
@@ -55,7 +55,7 @@ func newInspector(astinspector *astinspector.Inspector, jsonTags extractjsontags
 // InspectFields iterates over fields in structs, ignoring any struct that is not a type declaration, and any field that is ignored and
 // therefore would not be included in the CRD spec.
 // For the remaining fields, it calls the provided inspectField function to apply analysis logic.
-func (i *inspector) InspectFields(inspectField func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers)) {
+func (i *inspector) InspectFields(inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers)) {
 	// Filter to fields so that we can iterate over fields in a struct.
 	nodeFilter := []ast.Node{
 		(*ast.Field)(nil),
@@ -75,7 +75,7 @@ func (i *inspector) InspectFields(inspectField func(field *ast.Field, stack []as
 			return false
 		}
 
-		i.processFieldWithRecovery(field, stack, inspectField)
+		i.processFieldWithRecovery(field, inspectField)
 
 		return true
 	})
@@ -117,7 +117,7 @@ func (i *inspector) shouldSkipField(field *ast.Field) bool {
 }
 
 // processFieldWithRecovery processes a field with panic recovery.
-func (i *inspector) processFieldWithRecovery(field *ast.Field, stack []ast.Node, inspectField func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers)) {
+func (i *inspector) processFieldWithRecovery(field *ast.Field, inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers)) {
 	tagInfo := i.jsonTags.FieldTags(field)
 
 	defer func() {
@@ -128,7 +128,7 @@ func (i *inspector) processFieldWithRecovery(field *ast.Field, stack []ast.Node,
 		}
 	}()
 
-	inspectField(field, stack, tagInfo, i.markers)
+	inspectField(field, tagInfo, i.markers)
 }
 
 // InspectTypeSpec inspects the type spec and calls the provided inspectTypeSpec function.

--- a/pkg/analysis/jsontags/analyzer.go
+++ b/pkg/analysis/jsontags/analyzer.go
@@ -71,7 +71,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers) {
 		a.checkField(pass, field, jsonTagInfo)
 	})
 

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -47,7 +47,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		checkField(pass, field, markersAccess)
 	})
 

--- a/pkg/analysis/namingconventions/analyzer.go
+++ b/pkg/analysis/namingconventions/analyzer.go
@@ -59,7 +59,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTags extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTags extractjsontags.FieldTagInfo, _ markers.Markers) {
 		checkField(pass, field, jsonTags, a.conventions...)
 	})
 

--- a/pkg/analysis/nodurations/analyzer.go
+++ b/pkg/analysis/nodurations/analyzer.go
@@ -45,7 +45,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		checkField(pass, field)
 	})
 

--- a/pkg/analysis/nomaps/analyzer.go
+++ b/pkg/analysis/nomaps/analyzer.go
@@ -63,7 +63,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers) {
 		a.checkField(pass, field)
 	})
 

--- a/pkg/analysis/optionalfields/analyzer.go
+++ b/pkg/analysis/optionalfields/analyzer.go
@@ -93,7 +93,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		a.checkField(pass, field, markersAccess, jsonTagInfo)
 	})
 

--- a/pkg/analysis/optionalorrequired/analyzer.go
+++ b/pkg/analysis/optionalorrequired/analyzer.go
@@ -93,7 +93,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		a.checkField(pass, field, markersAccess.FieldMarkers(field), jsonTagInfo)
 	})
 

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -92,7 +92,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		a.checkField(pass, field, markersAccess, jsonTagInfo)
 	})
 

--- a/pkg/analysis/ssatags/analyzer.go
+++ b/pkg/analysis/ssatags/analyzer.go
@@ -66,7 +66,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		a.checkField(pass, field, markersAccess)
 	})
 

--- a/pkg/analysis/statusoptional/analyzer.go
+++ b/pkg/analysis/statusoptional/analyzer.go
@@ -79,7 +79,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetJSONTags
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		if jsonTagInfo.Name != statusJSONTag {
 			return
 		}

--- a/pkg/analysis/uniquemarkers/analyzer.go
+++ b/pkg/analysis/uniquemarkers/analyzer.go
@@ -65,7 +65,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
 		checkField(pass, field, markersAccess, a.uniqueMarkers)
 	})
 

--- a/pkg/analysis/utils/serialization/serialization_check_test.go
+++ b/pkg/analysis/utils/serialization/serialization_check_test.go
@@ -107,7 +107,7 @@ func testSerializationAnalyzer(cfg *serialization.Config) *analysis.Analyzer {
 				return nil, errCouldNotGetInspector
 			}
 
-			inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+			inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 				serialization.New(cfg).Check(pass, field, markersAccess, jsonTagInfo)
 			})
 


### PR DESCRIPTION
While exploring on https://github.com/kubernetes-sigs/kube-api-linter/issues/158 found these things, Made changes to keep consistency across all the files.

Also I see that argument `[]ast.Node` of `InspectFields` method is never used. Any reason for keeping that?