### PR TITLE
Allow pointer-to-slice/map with explicit MinItems=0/MinProperties=0

### DIFF
--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go
@@ -16,10 +16,10 @@ type TestArrays struct {
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag." "field ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
+	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	ByteArray []byte `json:"byteArray"` // want "field ByteArray should have the omitempty tag."
 

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go.golden
@@ -16,10 +16,10 @@ type TestArrays struct {
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems *[]string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag." "field ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
+	ArrayWithZeroMinItemsWithOmitEmpty *[]string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	ByteArray []byte `json:"byteArray,omitempty"` // want "field ByteArray should have the omitempty tag."
 

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go
@@ -16,8 +16,8 @@ type TestMaps struct {
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag." "field MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`
+	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go.golden
@@ -16,8 +16,8 @@ type TestMaps struct {
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties *map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag." "field MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`
+	MapWithZeroMinPropertiesWithOmitEmpty *map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go
@@ -1,6 +1,9 @@
 package a
 
 type TestPointerToSliceWithMinZeroAlways struct {
+	// Pointer to slice with MinItems=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - [] (explicitly empty)
 	// +kubebuilder:validation:MinItems=0
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
@@ -9,11 +12,24 @@ type TestPointerToSliceWithMinZeroAlways struct {
 }
 
 type TestPointerToMapWithMinZeroAlways struct {
+	// Pointer to map with MinProperties=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - {} (explicitly empty)
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+
+	// Non-pointer version should suggest adding pointer
+	// +kubebuilder:validation:MinProperties=0
+	MapWithZeroMinPropertiesNoPtr map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+}
+
+// Test that slices WITHOUT pointers are flagged when MinItems is zero
+type TestSliceWithMinZeroAlways struct {
+	// +kubebuilder:validation:MinItems=0
+	ArrayWithZeroMinItemsNoPtr []string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go.golden
@@ -1,6 +1,9 @@
 package a
 
 type TestPointerToSliceWithMinZeroAlways struct {
+	// Pointer to slice with MinItems=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - [] (explicitly empty)
 	// +kubebuilder:validation:MinItems=0
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
@@ -9,11 +12,24 @@ type TestPointerToSliceWithMinZeroAlways struct {
 }
 
 type TestPointerToMapWithMinZeroAlways struct {
+	// Pointer to map with MinProperties=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - {} (explicitly empty)
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty,omitempty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+
+	// Non-pointer version should suggest adding pointer
+	// +kubebuilder:validation:MinProperties=0
+	MapWithZeroMinPropertiesNoPtr *map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+}
+
+// Test that slices WITHOUT pointers are flagged when MinItems is zero
+type TestSliceWithMinZeroAlways struct {
+	// +kubebuilder:validation:MinItems=0
+	ArrayWithZeroMinItemsNoPtr *[]string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go
@@ -1,6 +1,9 @@
 package a
 
 type TestPointerToSliceWithMinZero struct {
+	// Pointer to slice with MinItems=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - [] (explicitly empty)
 	// +kubebuilder:validation:MinItems=0
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
@@ -9,6 +12,9 @@ type TestPointerToSliceWithMinZero struct {
 }
 
 type TestPointerToMapWithMinZero struct {
+	// Pointer to map with MinProperties=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - {} (explicitly empty)
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go.golden
@@ -1,6 +1,9 @@
 package a
 
 type TestPointerToSliceWithMinZero struct {
+	// Pointer to slice with MinItems=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - [] (explicitly empty)
 	// +kubebuilder:validation:MinItems=0
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
@@ -9,6 +12,9 @@ type TestPointerToSliceWithMinZero struct {
 }
 
 type TestPointerToMapWithMinZero struct {
+	// Pointer to map with MinProperties=0 allows distinguishing:
+	// - nil (unset, use defaults)
+	// - {} (explicitly empty)
 	// +kubebuilder:validation:MinProperties=0
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 


### PR DESCRIPTION
This change fixes the linter incorrectly suggesting removal of pointers for slice and map fields that have explicit MinItems=0 or MinProperties=0 markers.

- Added logic to allow pointer-to-slice/map when MinItems=0 or MinProperties=0 is explicitly set
- Added helper function hasExplicitZeroMinValidation() to detect these markers
- Updated function signatures to pass necessary parameters through the call chain
- Updated tests for both new cases

Fixes #116

#### The overall logic is now

  | Scenario                 | Pointer? | MinItems/MinProperties | Expected Behavior                  |
  |--------------------------|----------|------------------------|------------------------------------|
  | Slice with MinItems=0    | Yes      | 0                      | No warning (pointer allowed)       |
  | Slice with MinItems=0    | No       | 0                      | Suggest pointer (in "always" mode) |
  | Slice with MinItems=1    | Yes      | 1                      | Remove pointer                     |
  | Slice without validation | Yes      | N/A                    | Remove pointer                     |
  | Map with MinProperties=0 | Yes      | 0                      | No warning (pointer allowed)       |