### PR TITLE
Add `preferredmarkers` linter

### DIFF
--- a/pkg/analysis/preferredmarkers/analyzer.go
+++ b/pkg/analysis/preferredmarkers/analyzer.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package preferredmarkers
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+)
+
+const name = "preferredmarkers"
+
+type analyzer struct {
+	// equivalentToPreferred maps equivalent marker identifiers to their preferred identifiers
+	equivalentToPreferred map[string]string
+}
+
+// newAnalyzer creates a new analysis.Analyzer for the preferredmarkers
+// linter based on the provided Config.
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	a := &analyzer{
+		equivalentToPreferred: make(map[string]string),
+	}
+
+	// Build the mapping from equivalent identifiers to preferred identifiers
+	for _, marker := range cfg.Markers {
+		for _, equivalent := range marker.EquivalentIdentifiers {
+			a.equivalentToPreferred[equivalent.Identifier] = marker.PreferredIdentifier
+		}
+	}
+
+	analyzer := &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Check that preferred markers are used instead of equivalent markers.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+
+	// Register all equivalent identifiers so they can be parsed.
+	// Note: The marker registry is thread-safe and idempotent, so it's safe
+	// to register the same marker multiple times or from concurrent goroutines.
+	for equivalent := range a.equivalentToPreferred {
+		markers.DefaultRegistry().Register(equivalent)
+	}
+
+	return analyzer
+}
+
+// run is the main analysis function that inspects all types and fields in the package.
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+		checkField(pass, field, markersAccess, a.equivalentToPreferred)
+	})
+
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
+		checkType(pass, typeSpec, markersAccess, a.equivalentToPreferred)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+// checkField validates a single struct field for marker usage.
+// Only checks markers directly on the field, not inherited from type aliases,
+// since inherited markers are already reported at the type level.
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Markers, equivalentToPreferred map[string]string) {
+	if field == nil || len(field.Names) == 0 {
+		return
+	}
+
+	markerSet := markersAccess.FieldMarkers(field)
+	check(markerSet, equivalentToPreferred, func(marks []markers.Marker, preferredIdentifier string, preferredExists bool) {
+		reportMarkers(pass, marks, preferredIdentifier, field.Names[0].Name, field.Pos(), "field", preferredExists)
+	})
+}
+
+// checkType validates a single type definition for marker usage.
+func checkType(pass *analysis.Pass, typeSpec *ast.TypeSpec, markersAccess markers.Markers, equivalentToPreferred map[string]string) {
+	if typeSpec == nil {
+		return
+	}
+
+	markerSet := markersAccess.TypeMarkers(typeSpec)
+	check(markerSet, equivalentToPreferred, func(marks []markers.Marker, preferredIdentifier string, preferredExists bool) {
+		reportMarkers(pass, marks, preferredIdentifier, typeSpec.Name.Name, typeSpec.Pos(), "type", preferredExists)
+	})
+}
+
+// check examines a set of markers for equivalent identifiers that should be replaced.
+func check(markerSet markers.MarkerSet, equivalentToPreferred map[string]string, reportFunc func(markers []markers.Marker, preferredIdentifier string, preferredExists bool)) {
+	// Group markers by their preferred identifier to handle duplicates correctly
+	preferredToMarkers := make(map[string][]markers.Marker)
+
+	for equivalentIdentifier, preferredIdentifier := range equivalentToPreferred {
+		marks := markerSet.Get(equivalentIdentifier)
+		if len(marks) > 0 {
+			preferredToMarkers[preferredIdentifier] = append(preferredToMarkers[preferredIdentifier], marks...)
+		}
+	}
+
+	// Sort preferred identifiers for deterministic reporting
+	preferredIdentifiers := make([]string, 0, len(preferredToMarkers))
+	for preferredIdentifier := range preferredToMarkers {
+		preferredIdentifiers = append(preferredIdentifiers, preferredIdentifier)
+	}
+
+	sort.Strings(preferredIdentifiers)
+
+	// Report each group of markers
+	for _, preferredIdentifier := range preferredIdentifiers {
+		marks := preferredToMarkers[preferredIdentifier]
+		// Check if the preferred marker already exists
+		preferredExists := len(markerSet.Get(preferredIdentifier)) > 0
+		reportFunc(marks, preferredIdentifier, preferredExists)
+	}
+}
+
+// formatMarkerList formats a list of markers as a sorted, quoted, comma-separated string.
+// For example, [marker1, marker2] becomes `"marker1", "marker2"`.
+func formatMarkerList(marks []markers.Marker) string {
+	names := make([]string, len(marks))
+	for i, m := range marks {
+		names[i] = fmt.Sprintf("%q", m.Identifier)
+	}
+
+	sort.Strings(names)
+
+	return strings.Join(names, ", ")
+}
+
+// buildTextEdits generates the text edits to fix equivalent markers.
+// If preferredExists is true, all markers are deleted. Otherwise, the first
+// marker is replaced with the preferred identifier and the rest are deleted.
+func buildTextEdits(marks []markers.Marker, preferredIdentifier string, preferredExists bool) []analysis.TextEdit {
+	// Sort markers by position to ensure deterministic text edits
+	sort.Slice(marks, func(i, j int) bool {
+		return marks[i].Pos < marks[j].Pos
+	})
+
+	edits := make([]analysis.TextEdit, 0, len(marks))
+
+	// If the preferred marker doesn't exist, replace the first equivalent marker
+	if !preferredExists {
+		edits = append(edits, analysis.TextEdit{
+			Pos:     marks[0].Pos,
+			End:     marks[0].End,
+			NewText: []byte(buildReplacementMarker(marks[0], preferredIdentifier)),
+		})
+		marks = marks[1:] // Process remaining markers for deletion
+	}
+
+	// Delete remaining markers to avoid duplicates
+	// Note: We add 1 to the end position to include the newline character,
+	// which removes the entire line and prevents blank lines in the output.
+	// This works correctly for most cases. At end of file without a trailing
+	// newline, the go/analysis framework handles the extra position gracefully.
+	for _, mark := range marks {
+		edits = append(edits, analysis.TextEdit{
+			Pos:     mark.Pos,
+			End:     mark.End + 1, // +1 to include the newline character
+			NewText: []byte(""),
+		})
+	}
+
+	return edits
+}
+
+// reportMarkers generates a diagnostic report for markers that should be
+// replaced. This function handles the common logic for both field and type
+// reporting.
+func reportMarkers(pass *analysis.Pass, marks []markers.Marker, preferredIdentifier, elementName string, pos token.Pos, elementType string, preferredExists bool) {
+	if len(marks) == 0 {
+		return
+	}
+
+	markerWord := "marker"
+	if len(marks) > 1 {
+		markerWord = "markers"
+	}
+
+	message := fmt.Sprintf("%s %s uses %s %s, should use preferred marker %q instead",
+		elementType, elementName, markerWord, formatMarkerList(marks), preferredIdentifier)
+
+	fixMessage := "remove equivalent markers"
+	if !preferredExists {
+		fixMessage = fmt.Sprintf("replace with %q", preferredIdentifier)
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     pos,
+		Message: message,
+		SuggestedFixes: []analysis.SuggestedFix{
+			{
+				Message:   fixMessage,
+				TextEdits: buildTextEdits(marks, preferredIdentifier, preferredExists),
+			},
+		},
+	})
+}
+
+// buildReplacementMarker constructs the replacement marker text with the
+// preferred identifier while preserving the structure from the original marker.
+// It handles different marker types (DeclarativeValidation vs Kubebuilder) and
+// properly reconstructs arguments and payloads.
+func buildReplacementMarker(marker markers.Marker, preferredIdentifier string) string {
+	// Determine the target marker type based on the preferred identifier
+	// DeclarativeValidation markers start with "k8s:", others are Kubebuilder style
+	targetType := markers.MarkerTypeKubebuilder
+	if strings.HasPrefix(preferredIdentifier, "k8s:") {
+		targetType = markers.MarkerTypeDeclarativeValidation
+	}
+
+	switch targetType {
+	case markers.MarkerTypeDeclarativeValidation:
+		return buildDeclarativeValidationMarker(marker, preferredIdentifier)
+	case markers.MarkerTypeKubebuilder:
+		return buildKubebuilderMarker(marker, preferredIdentifier)
+	default:
+		// Fallback for unknown marker types (should not happen in practice)
+		return "// +" + preferredIdentifier
+	}
+}
+
+// getSortedKeys returns sorted keys from a map for deterministic output.
+func getSortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// buildDeclarativeValidationMarker reconstructs a DeclarativeValidation marker.
+// Format: // +identifier(argName: argValue, ...)={payload.Value || reconstruct(payload.Marker)}.
+func buildDeclarativeValidationMarker(marker markers.Marker, preferredIdentifier string) string {
+	result := "// +" + preferredIdentifier
+
+	// Add arguments if present
+	if len(marker.Arguments) > 0 {
+		parts := make([]string, 0, len(marker.Arguments))
+
+		for _, key := range getSortedKeys(marker.Arguments) {
+			if key == "" {
+				parts = append(parts, marker.Arguments[key])
+			} else {
+				parts = append(parts, fmt.Sprintf("%s: %s", key, marker.Arguments[key]))
+			}
+		}
+
+		result += "(" + strings.Join(parts, ", ") + ")"
+	}
+
+	// Add payload if present
+	if marker.Payload.Value != "" {
+		result += "=" + marker.Payload.Value
+	} else if marker.Payload.Marker != nil {
+		// Nested marker - reconstruct without "// +" prefix
+		nested := buildReplacementMarker(*marker.Payload.Marker, marker.Payload.Marker.Identifier)
+		result += "=" + strings.TrimPrefix(nested, "// +")
+	}
+
+	return result
+}
+
+// buildKubebuilderMarker reconstructs a Kubebuilder marker.
+// Format with arguments: // +identifier:argOne="valueOne",argTwo="valueTwo".
+// Format without arguments: // +identifier={payload.Value}.
+func buildKubebuilderMarker(marker markers.Marker, preferredIdentifier string) string {
+	result := "// +" + preferredIdentifier
+
+	// Handle case with arguments
+	if len(marker.Arguments) > 0 {
+		parts := make([]string, 0, len(marker.Arguments))
+		for _, key := range getSortedKeys(marker.Arguments) {
+			parts = append(parts, fmt.Sprintf("%s=%s", key, marker.Arguments[key]))
+		}
+
+		return result + ":" + strings.Join(parts, ",")
+	}
+
+	// Handle case without arguments but with payload
+	if marker.Payload.Value != "" {
+		result += "=" + marker.Payload.Value
+	}
+
+	return result
+}

--- a/pkg/analysis/preferredmarkers/analyzer_test.go
+++ b/pkg/analysis/preferredmarkers/analyzer_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package preferredmarkers
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestWithConfiguration(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, newAnalyzer(&Config{
+		Markers: []Marker{
+			{
+				PreferredIdentifier: "k8s:optional",
+				EquivalentIdentifiers: []EquivalentIdentifier{
+					{Identifier: "kubebuilder:validation:Optional"},
+					{Identifier: "custom:optional"},
+				},
+			},
+			{
+				PreferredIdentifier: "k8s:required",
+				EquivalentIdentifiers: []EquivalentIdentifier{
+					{Identifier: "kubebuilder:validation:Required"},
+				},
+			},
+			{
+				PreferredIdentifier: "custom:preferred",
+				EquivalentIdentifiers: []EquivalentIdentifier{
+					{Identifier: "custom:old"},
+					{Identifier: "custom:deprecated"},
+				},
+			},
+		},
+	}), "a/...")
+}

--- a/pkg/analysis/preferredmarkers/config.go
+++ b/pkg/analysis/preferredmarkers/config.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package preferredmarkers
+
+// Config is the configuration type
+// for the preferredmarkers linter.
+type Config struct {
+	// markers is the unique set of preferred markers
+	// and their equivalent identifiers.
+	// Uniqueness is keyed on the `preferredIdentifier`
+	// field of entries.
+	// Must have at least one entry.
+	Markers []Marker `json:"markers"`
+}
+
+// Marker is a representation of a preferred marker
+// and its equivalent identifiers that should be replaced.
+type Marker struct {
+	// preferredIdentifier is the identifier for the preferred marker.
+	PreferredIdentifier string `json:"preferredIdentifier"`
+
+	// equivalentIdentifiers is a unique set of marker identifiers
+	// that are equivalent to the preferred identifier.
+	// When any of these markers are found, they will be reported
+	// and a fix will be suggested to replace them with the
+	// preferred identifier.
+	// Must have at least one entry.
+	EquivalentIdentifiers []EquivalentIdentifier `json:"equivalentIdentifiers"`
+}
+
+// EquivalentIdentifier represents a marker identifier that should be
+// replaced with the preferred identifier.
+type EquivalentIdentifier struct {
+	// identifier is the marker identifier to replace.
+	Identifier string `json:"identifier"`
+}

--- a/pkg/analysis/preferredmarkers/doc.go
+++ b/pkg/analysis/preferredmarkers/doc.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+* The `preferredmarkers` linter ensures that types and fields use preferred markers
+* instead of equivalent but different marker identifiers.
+*
+* By default, `preferredmarkers` is not enabled.
+*
+* This linter is useful for projects that want to enforce consistent marker usage
+* across their codebase, especially when multiple equivalent markers exist.
+* For example, Kubernetes has multiple ways to mark fields as optional:
+* - `+k8s:optional`
+* - `+kubebuilder:validation:Optional`
+*
+* The linter can be configured to enforce using one preferred marker identifier
+* and report any equivalent markers that should be replaced.
+*
+* **Configuration:**
+*
+* The linter requires a configuration that specifies preferred markers and their
+* equivalent identifiers.
+*
+* **Scenario:** Enforce using `+k8s:optional` instead of `+kubebuilder:validation:Optional`
+*
+* ```yaml
+* linterConfig:
+*   preferredmarkers:
+*     markers:
+*       - preferredIdentifier: "k8s:optional"
+*         equivalentIdentifiers:
+*           - "kubebuilder:validation:Optional"
+* ```
+*
+* **Scenario:** Enforce using a custom marker instead of multiple equivalent markers
+*
+* ```yaml
+* linterConfig:
+*   preferredmarkers:
+*     markers:
+*       - preferredIdentifier: "custom:preferred"
+*         equivalentIdentifiers:
+*           - "custom:old:marker"
+*           - "custom:deprecated:marker"
+*           - "custom:legacy:marker"
+* ```
+*
+* **Scenario:** Multiple preferred markers with different equivalents
+*
+* ```yaml
+* linterConfig:
+*   preferredmarkers:
+*     markers:
+*       - preferredIdentifier: "k8s:optional"
+*         equivalentIdentifiers:
+*           - "kubebuilder:validation:Optional"
+*       - preferredIdentifier: "k8s:required"
+*         equivalentIdentifiers:
+*           - "kubebuilder:validation:Required"
+* ```
+*
+* **Behavior:**
+*
+* When one or more equivalent markers are found, the linter will:
+* 1. Report a diagnostic message indicating which marker(s) should be preferred
+* 2. Suggest a fix that:
+*    - If the preferred marker does not already exist: replaces the first equivalent
+*      marker with the preferred identifier and preserves any marker expressions
+*      (e.g., `=value` or `:key=value`)
+*    - If the preferred marker already exists: removes all equivalent markers to
+*      avoid duplicates
+*    - Removes any additional equivalent markers
+*
+* For example, if both `+kubebuilder:validation:Optional` and `+custom:optional`
+* are configured as equivalents to `+k8s:optional`, they will both be replaced
+* with a single `+k8s:optional` marker. If `+k8s:optional` already exists alongside
+* equivalent markers, only the equivalent markers will be removed.
+*
+* The linter checks both type-level and field-level markers, including markers
+* inherited from type aliases.
+*
+ */
+package preferredmarkers

--- a/pkg/analysis/preferredmarkers/initializer.go
+++ b/pkg/analysis/preferredmarkers/initializer.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package preferredmarkers
+
+import (
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewConfigurableInitializer(
+		name,
+		initAnalyzer,
+		false,
+		validateConfig,
+	)
+}
+
+func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+// validateConfig implements validation of the preferredmarkers linter config.
+func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{field.Required(fldPath, "configuration is required for the preferredmarkers linter when it is enabled")}
+	}
+
+	return validateMarkers(fldPath.Child("markers"), cfg.Markers...)
+}
+
+// validateEquivalentIdentifiers validates a single marker's equivalent identifiers.
+func validateEquivalentIdentifiers(
+	equivalents []EquivalentIdentifier,
+	fldPath *field.Path,
+	knownPreferredMarkers,
+	knownEquivalentMarkers sets.Set[string],
+) field.ErrorList {
+	if len(equivalents) == 0 {
+		return field.ErrorList{field.Required(fldPath, "must contain at least one equivalent identifier")}
+	}
+
+	var (
+		errs             field.ErrorList
+		localEquivalents = sets.New[string]()
+	)
+
+	for i, equivalent := range equivalents {
+		equivalentPath := fldPath.Index(i)
+		identifier := equivalent.Identifier
+
+		// Check for duplicates within this marker's equivalent identifiers
+		if localEquivalents.Has(identifier) {
+			errs = append(errs, field.Duplicate(equivalentPath.Child("identifier"), identifier))
+			continue
+		}
+
+		localEquivalents.Insert(identifier)
+
+		// Check if this equivalent identifier is already used as a preferred identifier
+		if knownPreferredMarkers.Has(identifier) {
+			errs = append(errs, field.Invalid(equivalentPath.Child("identifier"), identifier, "equivalent identifier cannot be the same as a preferred identifier"))
+			continue
+		}
+
+		// Check if this equivalent identifier was already used in another marker's equivalent list
+		if knownEquivalentMarkers.Has(identifier) {
+			errs = append(errs, field.Duplicate(equivalentPath.Child("identifier"), identifier))
+			continue
+		}
+
+		knownEquivalentMarkers.Insert(identifier)
+	}
+
+	return errs
+}
+
+func validateMarkers(fldPath *field.Path, markers ...Marker) field.ErrorList {
+	if len(markers) == 0 {
+		return field.ErrorList{field.Required(fldPath, "must contain at least one preferred marker")}
+	}
+
+	var (
+		errs                   field.ErrorList
+		knownPreferredMarkers  = sets.New[string]()
+		knownEquivalentMarkers = sets.New[string]()
+	)
+
+	for i, marker := range markers {
+		indexPath := fldPath.Index(i)
+
+		// Check for duplicate preferred identifiers
+		if knownPreferredMarkers.Has(marker.PreferredIdentifier) {
+			errs = append(errs, field.Duplicate(indexPath.Child("preferredIdentifier"), marker.PreferredIdentifier))
+			continue // Skip equivalent validation for duplicate preferred identifiers
+		}
+
+		knownPreferredMarkers.Insert(marker.PreferredIdentifier)
+
+		// Validate equivalent identifiers
+		errs = append(errs, validateEquivalentIdentifiers(
+			marker.EquivalentIdentifiers,
+			indexPath.Child("equivalentIdentifiers"),
+			knownPreferredMarkers,
+			knownEquivalentMarkers,
+		)...)
+	}
+
+	return errs
+}

--- a/pkg/analysis/preferredmarkers/initializer_test.go
+++ b/pkg/analysis/preferredmarkers/initializer_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preferredmarkers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/preferredmarkers"
+)
+
+var _ = Describe("preferredmarkers initializer", func() {
+	Context("config validation", func() {
+		type testCase struct {
+			config      *preferredmarkers.Config
+			expectedErr string
+		}
+
+		DescribeTable("should validate the provided config", func(in testCase) {
+			ci, ok := preferredmarkers.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+			Expect(ok).To(BeTrue())
+
+			errs := ci.ValidateConfig(in.config, field.NewPath("preferredmarkers"))
+			if len(in.expectedErr) > 0 {
+				Expect(errs.ToAggregate()).To(MatchError(in.expectedErr))
+			} else {
+				Expect(errs).To(HaveLen(0), "No errors were expected")
+			}
+		},
+			Entry("With a valid preferredmarkers configuration", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "",
+			}),
+			Entry("With a valid preferredmarkers configuration with multiple equivalents", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "custom:preferred",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "custom:old"},
+								{Identifier: "custom:deprecated"},
+								{Identifier: "custom:legacy"},
+							},
+						},
+					},
+				},
+				expectedErr: "",
+			}),
+			Entry("With a valid preferredmarkers configuration with multiple markers", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+							},
+						},
+						{
+							PreferredIdentifier: "k8s:required",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Required"},
+							},
+						},
+					},
+				},
+				expectedErr: "",
+			}),
+			Entry("With an invalid preferredmarkers configuration, duplicate preferred markers", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+							},
+						},
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "custom:optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[1].preferredIdentifier: Duplicate value: \"k8s:optional\"",
+			}),
+			Entry("With an invalid preferredmarkers configuration, duplicate equivalent identifiers within a marker", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+								{Identifier: "kubebuilder:validation:Optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[0].equivalentIdentifiers[1].identifier: Duplicate value: \"kubebuilder:validation:Optional\"",
+			}),
+			Entry("With an invalid preferredmarkers configuration, duplicate equivalent identifiers across markers", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "custom:optional"},
+							},
+						},
+						{
+							PreferredIdentifier: "k8s:required",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "custom:optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[1].equivalentIdentifiers[0].identifier: Duplicate value: \"custom:optional\"",
+			}),
+			Entry("With an invalid preferredmarkers configuration, equivalent identifier is same as preferred identifier", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+							},
+						},
+						{
+							PreferredIdentifier: "k8s:required",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "k8s:optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[1].equivalentIdentifiers[0].identifier: Invalid value: \"k8s:optional\": equivalent identifier cannot be the same as a preferred identifier",
+			}),
+			Entry("With an invalid preferredmarkers configuration, preferred identifier in its own equivalent identifiers list", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier: "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{
+								{Identifier: "kubebuilder:validation:Optional"},
+								{Identifier: "k8s:optional"},
+							},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[0].equivalentIdentifiers[1].identifier: Invalid value: \"k8s:optional\": equivalent identifier cannot be the same as a preferred identifier",
+			}),
+			Entry("With an invalid preferredmarkers configuration, no equivalent identifiers", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{
+						{
+							PreferredIdentifier:   "k8s:optional",
+							EquivalentIdentifiers: []preferredmarkers.EquivalentIdentifier{},
+						},
+					},
+				},
+				expectedErr: "preferredmarkers.markers[0].equivalentIdentifiers: Required value: must contain at least one equivalent identifier",
+			}),
+			Entry("With a nil config", testCase{
+				config:      nil,
+				expectedErr: "preferredmarkers: Required value: configuration is required for the preferredmarkers linter when it is enabled",
+			}),
+			Entry("With an invalid preferredmarkers configuration with no markers", testCase{
+				config: &preferredmarkers.Config{
+					Markers: []preferredmarkers.Marker{},
+				},
+				expectedErr: "preferredmarkers.markers: Required value: must contain at least one preferred marker",
+			}),
+		)
+	})
+})

--- a/pkg/analysis/preferredmarkers/preferredmarkers_suite_test.go
+++ b/pkg/analysis/preferredmarkers/preferredmarkers_suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package preferredmarkers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPreferredMarkers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "preferredmarkers")
+}

--- a/pkg/analysis/preferredmarkers/testdata/src/a/a.go
+++ b/pkg/analysis/preferredmarkers/testdata/src/a/a.go
@@ -1,0 +1,154 @@
+package a
+
+// Type with kubebuilder optional marker (should be k8s:optional)
+// +kubebuilder:validation:Optional
+type OptionalTypeKubebuilder string // want `type OptionalTypeKubebuilder uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+// Type with custom optional marker (should be k8s:optional)
+// +custom:optional
+type OptionalTypeCustom string // want `type OptionalTypeCustom uses marker "custom:optional", should use preferred marker "k8s:optional" instead`
+
+// Type with kubebuilder required marker (should be k8s:required)
+// +kubebuilder:validation:Required
+type RequiredTypeKubebuilder string // want `type RequiredTypeKubebuilder uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+// Type with custom old marker (should be custom:preferred)
+// +custom:old
+type CustomOldType string // want `type CustomOldType uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+
+// Type with custom deprecated marker (should be custom:preferred)
+// +custom:deprecated
+type CustomDeprecatedType string // want `type CustomDeprecatedType uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+// Type with preferred marker (should not report)
+// +k8s:optional
+type OptionalTypePreferred string
+
+// Type with preferred marker (should not report)
+// +k8s:required
+type RequiredTypePreferred string
+
+// Type with preferred marker (should not report)
+// +custom:preferred
+type CustomPreferredType string
+
+// Type with unrelated marker (should not report)
+// +unrelated:marker
+type UnrelatedMarkerType string
+
+// Type with multiple equivalent markers (both should be reported)
+// +kubebuilder:validation:Optional
+// +custom:optional
+type MultipleEquivalentMarkersType string // want `type MultipleEquivalentMarkersType uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+type Test struct {
+	// Field with kubebuilder optional marker (should be k8s:optional)
+	// +kubebuilder:validation:Optional
+	OptionalFieldKubebuilder string `json:"optionalFieldKubebuilder"` // want `field OptionalFieldKubebuilder uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	OptionalFieldKubebuilderTypeAlias OptionalTypeKubebuilder `json:"optionalFieldKubebuilderTypeAlias"`
+
+	// Field with custom optional marker (should be k8s:optional)
+	// +custom:optional
+	OptionalFieldCustom string `json:"optionalFieldCustom"` // want `field OptionalFieldCustom uses marker "custom:optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	OptionalFieldCustomTypeAlias OptionalTypeCustom `json:"optionalFieldCustomTypeAlias"`
+
+	// Field with kubebuilder required marker (should be k8s:required)
+	// +kubebuilder:validation:Required
+	RequiredFieldKubebuilder string `json:"requiredFieldKubebuilder"` // want `field RequiredFieldKubebuilder uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	RequiredFieldKubebuilderTypeAlias RequiredTypeKubebuilder `json:"requiredFieldKubebuilderTypeAlias"`
+
+	// Field with custom old marker (should be custom:preferred)
+	// +custom:old
+	CustomOldField string `json:"customOldField"` // want `field CustomOldField uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	CustomOldFieldTypeAlias CustomOldType `json:"customOldFieldTypeAlias"`
+
+	// Field with custom deprecated marker (should be custom:preferred)
+	// +custom:deprecated
+	CustomDeprecatedField string `json:"customDeprecatedField"` // want `field CustomDeprecatedField uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	CustomDeprecatedFieldTypeAlias CustomDeprecatedType `json:"customDeprecatedFieldTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +k8s:optional
+	OptionalFieldPreferred string `json:"optionalFieldPreferred"`
+
+	// Inherited from type alias (should not report)
+	OptionalFieldPreferredTypeAlias OptionalTypePreferred `json:"optionalFieldPreferredTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +k8s:required
+	RequiredFieldPreferred string `json:"requiredFieldPreferred"`
+
+	// Inherited from type alias (should not report)
+	RequiredFieldPreferredTypeAlias RequiredTypePreferred `json:"requiredFieldPreferredTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +custom:preferred
+	CustomPreferredField string `json:"customPreferredField"`
+
+	// Inherited from type alias (should not report)
+	CustomPreferredFieldTypeAlias CustomPreferredType `json:"customPreferredFieldTypeAlias"`
+
+	// Field with unrelated marker (should not report)
+	// +unrelated:marker
+	UnrelatedMarkerField string `json:"unrelatedMarkerField"`
+
+	// Inherited from type alias (should not report)
+	UnrelatedMarkerFieldTypeAlias UnrelatedMarkerType `json:"unrelatedMarkerFieldTypeAlias"`
+
+	// Field with multiple equivalent markers (both should be reported)
+	// +kubebuilder:validation:Optional
+	// +custom:optional
+	MultipleEquivalentMarkersField string `json:"multipleEquivalentMarkersField"` // want `field MultipleEquivalentMarkersField uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias with multiple markers (not reported since type is already checked)
+	MultipleEquivalentMarkersFieldTypeAlias MultipleEquivalentMarkersType `json:"multipleEquivalentMarkersFieldTypeAlias"`
+
+	// Test marker with unnamed expression (should preserve expression)
+	// +kubebuilder:validation:Optional:=someValue
+	OptionalWithUnnamedExpression string `json:"optionalWithUnnamedExpression"` // want `field OptionalWithUnnamedExpression uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Test marker with named expressions (should preserve expressions)
+	// +custom:old:key1=val1,key2=val2
+	CustomWithNamedExpressions string `json:"customWithNamedExpressions"` // want `field CustomWithNamedExpressions uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+}
+
+// Type with unnamed expression (should preserve expression)
+// +kubebuilder:validation:Required:=requiredValue
+type RequiredWithUnnamedExpression string // want `type RequiredWithUnnamedExpression uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+// Type with named expressions (should preserve expressions)
+// +custom:deprecated:foo=bar,baz=qux
+type CustomDeprecatedWithExpressions string // want `type CustomDeprecatedWithExpressions uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+// Type with both preferred and equivalent markers (should only remove equivalent)
+// +k8s:optional
+// +kubebuilder:validation:Optional
+type TypeWithBothPreferredAndEquivalent string // want `type TypeWithBothPreferredAndEquivalent uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+// Type with both preferred and multiple equivalent markers (should remove all equivalents)
+// +k8s:optional
+// +kubebuilder:validation:Optional
+// +custom:optional
+type TypeWithPreferredAndMultipleEquivalents string // want `type TypeWithPreferredAndMultipleEquivalents uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+type EdgeCaseTest struct {
+	// Field with both preferred and equivalent markers (should only remove equivalent)
+	// +k8s:optional
+	// +kubebuilder:validation:Optional
+	FieldWithBothPreferredAndEquivalent string `json:"fieldWithBothPreferredAndEquivalent"` // want `field FieldWithBothPreferredAndEquivalent uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Field with both preferred and multiple equivalent markers (should remove all equivalents)
+	// +k8s:required
+	// +kubebuilder:validation:Required
+	FieldWithPreferredAndMultipleEquivalents string `json:"fieldWithPreferredAndMultipleEquivalents"` // want `field FieldWithPreferredAndMultipleEquivalents uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+}

--- a/pkg/analysis/preferredmarkers/testdata/src/a/a.go.golden
+++ b/pkg/analysis/preferredmarkers/testdata/src/a/a.go.golden
@@ -1,0 +1,147 @@
+package a
+
+// Type with kubebuilder optional marker (should be k8s:optional)
+// +k8s:optional
+type OptionalTypeKubebuilder string // want `type OptionalTypeKubebuilder uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+// Type with custom optional marker (should be k8s:optional)
+// +k8s:optional
+type OptionalTypeCustom string // want `type OptionalTypeCustom uses marker "custom:optional", should use preferred marker "k8s:optional" instead`
+
+// Type with kubebuilder required marker (should be k8s:required)
+// +k8s:required
+type RequiredTypeKubebuilder string // want `type RequiredTypeKubebuilder uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+// Type with custom old marker (should be custom:preferred)
+// +custom:preferred
+type CustomOldType string // want `type CustomOldType uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+
+// Type with custom deprecated marker (should be custom:preferred)
+// +custom:preferred
+type CustomDeprecatedType string // want `type CustomDeprecatedType uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+// Type with preferred marker (should not report)
+// +k8s:optional
+type OptionalTypePreferred string
+
+// Type with preferred marker (should not report)
+// +k8s:required
+type RequiredTypePreferred string
+
+// Type with preferred marker (should not report)
+// +custom:preferred
+type CustomPreferredType string
+
+// Type with unrelated marker (should not report)
+// +unrelated:marker
+type UnrelatedMarkerType string
+
+// Type with multiple equivalent markers (both should be reported)
+// +k8s:optional
+type MultipleEquivalentMarkersType string // want `type MultipleEquivalentMarkersType uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+type Test struct {
+	// Field with kubebuilder optional marker (should be k8s:optional)
+	// +k8s:optional
+	OptionalFieldKubebuilder string `json:"optionalFieldKubebuilder"` // want `field OptionalFieldKubebuilder uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	OptionalFieldKubebuilderTypeAlias OptionalTypeKubebuilder `json:"optionalFieldKubebuilderTypeAlias"`
+
+	// Field with custom optional marker (should be k8s:optional)
+	// +k8s:optional
+	OptionalFieldCustom string `json:"optionalFieldCustom"` // want `field OptionalFieldCustom uses marker "custom:optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	OptionalFieldCustomTypeAlias OptionalTypeCustom `json:"optionalFieldCustomTypeAlias"`
+
+	// Field with kubebuilder required marker (should be k8s:required)
+	// +k8s:required
+	RequiredFieldKubebuilder string `json:"requiredFieldKubebuilder"` // want `field RequiredFieldKubebuilder uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	RequiredFieldKubebuilderTypeAlias RequiredTypeKubebuilder `json:"requiredFieldKubebuilderTypeAlias"`
+
+	// Field with custom old marker (should be custom:preferred)
+	// +custom:preferred
+	CustomOldField string `json:"customOldField"` // want `field CustomOldField uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	CustomOldFieldTypeAlias CustomOldType `json:"customOldFieldTypeAlias"`
+
+	// Field with custom deprecated marker (should be custom:preferred)
+	// +custom:preferred
+	CustomDeprecatedField string `json:"customDeprecatedField"` // want `field CustomDeprecatedField uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+	// Inherited from type alias (not reported since type is already checked)
+	CustomDeprecatedFieldTypeAlias CustomDeprecatedType `json:"customDeprecatedFieldTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +k8s:optional
+	OptionalFieldPreferred string `json:"optionalFieldPreferred"`
+
+	// Inherited from type alias (should not report)
+	OptionalFieldPreferredTypeAlias OptionalTypePreferred `json:"optionalFieldPreferredTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +k8s:required
+	RequiredFieldPreferred string `json:"requiredFieldPreferred"`
+
+	// Inherited from type alias (should not report)
+	RequiredFieldPreferredTypeAlias RequiredTypePreferred `json:"requiredFieldPreferredTypeAlias"`
+
+	// Field with preferred marker (should not report)
+	// +custom:preferred
+	CustomPreferredField string `json:"customPreferredField"`
+
+	// Inherited from type alias (should not report)
+	CustomPreferredFieldTypeAlias CustomPreferredType `json:"customPreferredFieldTypeAlias"`
+
+	// Field with unrelated marker (should not report)
+	// +unrelated:marker
+	UnrelatedMarkerField string `json:"unrelatedMarkerField"`
+
+	// Inherited from type alias (should not report)
+	UnrelatedMarkerFieldTypeAlias UnrelatedMarkerType `json:"unrelatedMarkerFieldTypeAlias"`
+
+	// Field with multiple equivalent markers (both should be reported)
+	// +k8s:optional
+	MultipleEquivalentMarkersField string `json:"multipleEquivalentMarkersField"` // want `field MultipleEquivalentMarkersField uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Inherited from type alias with multiple markers (not reported since type is already checked)
+	MultipleEquivalentMarkersFieldTypeAlias MultipleEquivalentMarkersType `json:"multipleEquivalentMarkersFieldTypeAlias"`
+
+	// Test marker with unnamed expression (should preserve expression)
+	// +k8s:optional=someValue
+	OptionalWithUnnamedExpression string `json:"optionalWithUnnamedExpression"` // want `field OptionalWithUnnamedExpression uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Test marker with named expressions (should preserve expressions)
+	// +custom:preferred:key1=val1,key2=val2
+	CustomWithNamedExpressions string `json:"customWithNamedExpressions"` // want `field CustomWithNamedExpressions uses marker "custom:old", should use preferred marker "custom:preferred" instead`
+}
+
+// Type with unnamed expression (should preserve expression)
+// +k8s:required=requiredValue
+type RequiredWithUnnamedExpression string // want `type RequiredWithUnnamedExpression uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+
+// Type with named expressions (should preserve expressions)
+// +custom:preferred:baz=qux,foo=bar
+type CustomDeprecatedWithExpressions string // want `type CustomDeprecatedWithExpressions uses marker "custom:deprecated", should use preferred marker "custom:preferred" instead`
+
+// Type with both preferred and equivalent markers (should only remove equivalent)
+// +k8s:optional
+type TypeWithBothPreferredAndEquivalent string // want `type TypeWithBothPreferredAndEquivalent uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+// Type with both preferred and multiple equivalent markers (should remove all equivalents)
+// +k8s:optional
+type TypeWithPreferredAndMultipleEquivalents string // want `type TypeWithPreferredAndMultipleEquivalents uses markers "custom:optional", "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+type EdgeCaseTest struct {
+	// Field with both preferred and equivalent markers (should only remove equivalent)
+	// +k8s:optional
+	FieldWithBothPreferredAndEquivalent string `json:"fieldWithBothPreferredAndEquivalent"` // want `field FieldWithBothPreferredAndEquivalent uses marker "kubebuilder:validation:Optional", should use preferred marker "k8s:optional" instead`
+
+	// Field with both preferred and multiple equivalent markers (should remove all equivalents)
+	// +k8s:required
+	FieldWithPreferredAndMultipleEquivalents string `json:"fieldWithPreferredAndMultipleEquivalents"` // want `field FieldWithPreferredAndMultipleEquivalents uses marker "kubebuilder:validation:Required", should use preferred marker "k8s:required" instead`
+}

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -42,6 +42,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalfields"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/preferredmarkers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/requiredfields"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/ssatags"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/statusoptional"


### PR DESCRIPTION
Add a new linter that allows projects to enforce using preferred markers instead of equivalent but different marker identifiers.

- Marker preferences are configurable
- Auto-fix support
- Maintains marker expressions (e.g., :=value, :key=value) during replacement
- When multiple equivalent markers exist on the same field/type, consolidates them into a single preferred marker
- Handles markers inherited from type aliases
- Sorted processing ensures consistent, reproducible results

The linter is disabled by default and requires explicit configuration to enable.

Fixes https://github.com/kubernetes-sigs/kube-api-linter/issues/139