### PR TITLE
docs: Fix installation instructions for golangci-lint v2 compatibility

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -2,5 +2,5 @@ version: v2.5.0
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:
-  - module: 'sigs.k8s.io/kube-api-linter'
-    version: 'v0.0.0-20251029172002-9992248f8813'
+- module: 'sigs.k8s.io/kube-api-linter'
+  path: ./

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ unit: ## Run unit tests.
 
 .PHONY: build
 build: ## Build the golangci-lint custom plugin binary.
-	go build -o ./bin/golangci-lint-kube-api-linter ./cmd/golangci-lint-kube-api-linter 
+	go build -o ./bin ./cmd/golangci-lint-kube-api-linter 
 
 .PHONY: verify-%
 verify-%:


### PR DESCRIPTION
@JoelSpeed I've updated the README to fix the installation issues.

Main changes:
- Module mode now uses v2.5.0 and includes the pseudo-version format you showed in the cluster-api example, plus instructions on how to generate it
- Fixed the plugin build instructions to use the vendor directory like you suggested:
  ```bash
  go mod vendor
  go build -mod=vendor -buildmode=plugin -o bin/kube-api-linter.so ./vendor/sigs.k8s.io/kube-api-linter
  ```
- Added `version: "2"` to all the `.golangci.yml` examples
- Fixed up the Makefile and standalone build docs to be consistent with the actual directory structure

Fixes #145

