### PR TITLE
NumericBounds Linter

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -596,65 +596,34 @@ linterConfig:
 
 ## NumericBounds
 
-The `numericbounds` linter checks that numeric fields (`int32` and `int64`) have appropriate bounds validation markers.
+The `numericbounds` linter checks that numeric fields (`int32`, `int64`, `float32`, `float64`) have appropriate bounds validation markers.
 
 According to Kubernetes API conventions, numeric fields should have bounds checking to prevent values that are too small, negative (when not intended), or too large.
 
 This linter ensures that:
-- `int32` and `int64` fields have both `+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum` markers
-- `int64` fields with bounds outside the JavaScript safe integer range are flagged
+- Numeric fields have both `+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum` markers
+- K8s declarative validation markers (`+k8s:minimum` and `+k8s:maximum`) are also supported
+- Bounds values are within the type's valid range (e.g., int32 bounds must fit in int32)
+- `int64` fields with bounds outside the JavaScript safe integer range (±2^53-1) are flagged
 
-### JavaScript Safe Integer Range
+**Note:** While `+k8s:minimum` is documented in the official Kubernetes declarative validation spec, `+k8s:maximum` is not yet officially documented but is supported by this linter for forward compatibility and consistency.
 
-For `int64` fields, the linter checks if the bounds exceed the JavaScript safe integer range of `-(2^53)` to `(2^53)` (specifically, `-9007199254740991` to `9007199254740991`).
+### Configuration
 
-JavaScript represents all numbers as IEEE 754 double-precision floating-point values, which can only safely represent integers in this range. Values outside this range may lose precision when processed by JavaScript clients.
+This linter is **not enabled by default** as it is primarily focused on CRD validation with kubebuilder markers. It can be enabled in your configuration.
 
-When an `int64` field has bounds that exceed this range, the linter will suggest using a string type instead to avoid precision loss.
-
-### Examples
-
-**Valid:** Numeric field with proper bounds markers
-```go
-type Example struct {
-    // +kubebuilder:validation:Minimum=0
-    // +kubebuilder:validation:Maximum=100
-    Count int32
-}
+To enable in `.golangci.yml`:
+```yaml
+linters-settings:
+  custom:
+    kubeapilinter:
+      settings:
+        linters:
+          enable:
+            - numericbounds
 ```
 
-**Valid:** Int64 field with JavaScript-safe bounds
-```go
-type Example struct {
-    // +kubebuilder:validation:Minimum=-9007199254740991
-    // +kubebuilder:validation:Maximum=9007199254740991
-    Timestamp int64
-}
-```
-
-**Invalid:** Missing bounds markers
-```go
-type Example struct {
-    Count int32 // want: should have minimum and maximum bounds validation markers
-}
-```
-
-**Invalid:** Only one bound specified
-```go
-type Example struct {
-    // +kubebuilder:validation:Minimum=0
-    Count int32 // want: has minimum but is missing maximum bounds validation marker
-}
-```
-
-**Invalid:** Int64 with bounds exceeding JavaScript safe range
-```go
-type Example struct {
-    // +kubebuilder:validation:Minimum=-10000000000000000
-    // +kubebuilder:validation:Maximum=10000000000000000
-    LargeNumber int64 // want: bounds exceed JavaScript safe integer range
-}
-```
+See the [package documentation](https://pkg.go.dev/sigs.k8s.io/kube-api-linter/pkg/analysis/numericbounds) for detailed examples and usage.
 
 ## NoBools
 

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -35,6 +35,36 @@
 | [UniqueMarkers](#uniquemarkers) | Ensures unique marker definitions | True | Native, CRD |
 
 [^1]: Some linters are applicable only to Native (in-tree, go-validated APIs) or only to CRD (Custom Resource Definitions) APIs.
+- [ArrayOfStruct](#arrayofstruct) - Ensures arrays of structs have at least one required field
+- [Conditions](#conditions) - Checks that `Conditions` fields are correctly formatted
+- [CommentStart](#commentstart) - Ensures comments start with the serialized form of the type
+- [ConflictingMarkers](#conflictingmarkers) - Detects mutually exclusive markers on the same field
+- [DefaultOrRequired](#defaultorrequired) - Ensures fields marked as required do not have default values
+- [DuplicateMarkers](#duplicatemarkers) - Checks for exact duplicates of markers
+- [DependentTags](#dependenttags) - Enforces dependencies between markers
+- [ForbiddenMarkers](#forbiddenmarkers) - Checks that no forbidden markers are present on types/fields.
+- [Integers](#integers) - Validates usage of supported integer types
+- [JSONTags](#jsontags) - Ensures proper JSON tag formatting
+- [MaxLength](#maxlength) - Checks for maximum length constraints on strings and arrays
+- [NamingConventions](#namingconventions) - Ensures field names adhere to user-defined naming conventions
+- [NumericBounds](#numericbounds) - Validates numeric fields have appropriate bounds validation markers
+- [NoBools](#nobools) - Prevents usage of boolean types
+- [NoDurations](#nodurations) - Prevents usage of duration types
+- [NoFloats](#nofloats) - Prevents usage of floating-point types
+- [Nomaps](#nomaps) - Restricts usage of map types
+- [NonPointerStructs](#nonpointerstructs) - Ensures non-pointer structs are marked correctly with required/optional markers
+- [NoNullable](#nonullable) - Prevents usage of the nullable marker
+- [Nophase](#nophase) - Prevents usage of 'Phase' fields
+- [Notimestamp](#notimestamp) - Prevents usage of 'TimeStamp' fields
+- [OptionalFields](#optionalfields) - Validates optional field conventions
+- [OptionalOrRequired](#optionalorrequired) - Ensures fields are explicitly marked as optional or required
+- [NoReferences](#noreferences) - Ensures field names use Ref/Refs instead of Reference/References
+- [PreferredMarkers](#preferredmarkers) - Ensures preferred markers are used instead of equivalent markers
+- [RequiredFields](#requiredfields) - Validates required field conventions
+- [SSATags](#ssatags) - Ensures proper Server-Side Apply (SSA) tags on array fields
+- [StatusOptional](#statusoptional) - Ensures status fields are marked as optional
+- [StatusSubresource](#statussubresource) - Validates status subresource configuration
+- [UniqueMarkers](#uniquemarkers) - Ensures unique marker definitions
 
 ## ArrayOfStruct
 
@@ -562,6 +592,68 @@ linterConfig:
         operation: Replacement
         replacement: colour
         message: prefer 'colour' over 'color' when referring to colours in field names
+```
+
+## NumericBounds
+
+The `numericbounds` linter checks that numeric fields (`int32` and `int64`) have appropriate bounds validation markers.
+
+According to Kubernetes API conventions, numeric fields should have bounds checking to prevent values that are too small, negative (when not intended), or too large.
+
+This linter ensures that:
+- `int32` and `int64` fields have both `+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum` markers
+- `int64` fields with bounds outside the JavaScript safe integer range are flagged
+
+### JavaScript Safe Integer Range
+
+For `int64` fields, the linter checks if the bounds exceed the JavaScript safe integer range of `-(2^53)` to `(2^53)` (specifically, `-9007199254740991` to `9007199254740991`).
+
+JavaScript represents all numbers as IEEE 754 double-precision floating-point values, which can only safely represent integers in this range. Values outside this range may lose precision when processed by JavaScript clients.
+
+When an `int64` field has bounds that exceed this range, the linter will suggest using a string type instead to avoid precision loss.
+
+### Examples
+
+**Valid:** Numeric field with proper bounds markers
+```go
+type Example struct {
+    // +kubebuilder:validation:Minimum=0
+    // +kubebuilder:validation:Maximum=100
+    Count int32
+}
+```
+
+**Valid:** Int64 field with JavaScript-safe bounds
+```go
+type Example struct {
+    // +kubebuilder:validation:Minimum=-9007199254740991
+    // +kubebuilder:validation:Maximum=9007199254740991
+    Timestamp int64
+}
+```
+
+**Invalid:** Missing bounds markers
+```go
+type Example struct {
+    Count int32 // want: should have minimum and maximum bounds validation markers
+}
+```
+
+**Invalid:** Only one bound specified
+```go
+type Example struct {
+    // +kubebuilder:validation:Minimum=0
+    Count int32 // want: has minimum but is missing maximum bounds validation marker
+}
+```
+
+**Invalid:** Int64 with bounds exceeding JavaScript safe range
+```go
+type Example struct {
+    // +kubebuilder:validation:Minimum=-10000000000000000
+    // +kubebuilder:validation:Maximum=10000000000000000
+    LargeNumber int64 // want: bounds exceed JavaScript safe integer range
+}
 ```
 
 ## NoBools

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -601,12 +601,12 @@ The `numericbounds` linter checks that numeric fields (`int32`, `int64`, `float3
 According to Kubernetes API conventions, numeric fields should have bounds checking to prevent values that are too small, negative (when not intended), or too large.
 
 This linter ensures that:
-- Numeric fields have both `+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum` markers
-- K8s declarative validation markers (`+k8s:minimum` and `+k8s:maximum`) are also supported  
-- Bounds values are within the type's valid range:
-  - int32: full int32 range (±2^31-1)
-  - int64: JavaScript-safe range (±2^53-1) per Kubernetes API conventions
-  - float32/float64: within their respective ranges
+- Numeric fields have both `+k8s:minimum` and `+k8s:maximum` markers
+- Kubebuilder validation markers (`+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum`) are also supported
+- Bounds values are validated:
+  - int32: within int32 range (±2^31-1)
+  - int64: within JavaScript-safe range (±2^53-1) per K8s API conventions for JSON compatibility
+  - float32/float64: marker values are valid (within type ranges)
 
 **Note:** While `+k8s:minimum` is documented in the official Kubernetes declarative validation spec, `+k8s:maximum` is not yet officially documented but is supported by this linter for forward compatibility and consistency.
 

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -602,28 +602,15 @@ According to Kubernetes API conventions, numeric fields should have bounds check
 
 This linter ensures that:
 - Numeric fields have both `+kubebuilder:validation:Minimum` and `+kubebuilder:validation:Maximum` markers
-- K8s declarative validation markers (`+k8s:minimum` and `+k8s:maximum`) are also supported
-- Bounds values are within the type's valid range (e.g., int32 bounds must fit in int32)
-- `int64` fields with bounds outside the JavaScript safe integer range (±2^53-1) are flagged
+- K8s declarative validation markers (`+k8s:minimum` and `+k8s:maximum`) are also supported  
+- Bounds values are within the type's valid range:
+  - int32: full int32 range (±2^31-1)
+  - int64: JavaScript-safe range (±2^53-1) per Kubernetes API conventions
+  - float32/float64: within their respective ranges
 
 **Note:** While `+k8s:minimum` is documented in the official Kubernetes declarative validation spec, `+k8s:maximum` is not yet officially documented but is supported by this linter for forward compatibility and consistency.
 
-### Configuration
-
-This linter is **not enabled by default** as it is primarily focused on CRD validation with kubebuilder markers. It can be enabled in your configuration.
-
-To enable in `.golangci.yml`:
-```yaml
-linters-settings:
-  custom:
-    kubeapilinter:
-      settings:
-        linters:
-          enable:
-            - numericbounds
-```
-
-See the [package documentation](https://pkg.go.dev/sigs.k8s.io/kube-api-linter/pkg/analysis/numericbounds) for detailed examples and usage.
+This linter is **not enabled by default** as it is primarily focused on CRD validation with kubebuilder markers.
 
 ## NoBools
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/tools v0.37.0
 	k8s.io/apimachinery v0.32.3
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b

--- a/pkg/analysis/numericbounds/analyzer.go
+++ b/pkg/analysis/numericbounds/analyzer.go
@@ -189,30 +189,23 @@ func checkBoundsWithinTypeRange(pass *analysis.Pass, field *ast.Field, prefix, t
 		checkBoundInRange(pass, field, prefix, maximum, int64(minSafeInt64), int64(maxSafeInt64), "maximum", "JavaScript-safe int64",
 			"Consider using a string type to avoid precision loss in JavaScript clients")
 	case "float32":
-		checkFloatBoundInRange(pass, field, prefix, minimum, minFloat32, maxFloat32, "minimum", "float32")
-		checkFloatBoundInRange(pass, field, prefix, maximum, minFloat32, maxFloat32, "maximum", "float32")
+		checkBoundInRange(pass, field, prefix, minimum, minFloat32, maxFloat32, "minimum", "float32")
+		checkBoundInRange(pass, field, prefix, maximum, minFloat32, maxFloat32, "maximum", "float32")
 	case "float64":
-		checkFloatBoundInRange(pass, field, prefix, minimum, minFloat64, maxFloat64, "minimum", "float64")
-		checkFloatBoundInRange(pass, field, prefix, maximum, minFloat64, maxFloat64, "maximum", "float64")
+		checkBoundInRange(pass, field, prefix, minimum, minFloat64, maxFloat64, "minimum", "float64")
+		checkBoundInRange(pass, field, prefix, maximum, minFloat64, maxFloat64, "maximum", "float64")
 	}
 }
 
-// checkBoundInRange checks if an integer bound value is within the valid range.
-// Uses generics to avoid type conversions.
-func checkBoundInRange[T constraints.Integer](pass *analysis.Pass, field *ast.Field, prefix string, value float64, minBound, maxBound T, boundType, typeName string, extraMsg ...string) {
+// checkBoundInRange checks if a bound value is within the valid range.
+// Uses generics to work with both integer and float types.
+func checkBoundInRange[T constraints.Integer | constraints.Float](pass *analysis.Pass, field *ast.Field, prefix string, value float64, minBound, maxBound T, boundType, typeName string, extraMsg ...string) {
 	if value < float64(minBound) || value > float64(maxBound) {
-		msg := fmt.Sprintf("%s has %s bound %%v that is outside the %s range [%%d, %%d]", prefix, boundType, typeName)
+		msg := fmt.Sprintf("%s has %s bound %%v that is outside the %s range [%%v, %%v]", prefix, boundType, typeName)
 		if len(extraMsg) > 0 {
 			msg += ". " + extraMsg[0]
 		}
 
 		pass.Reportf(field.Pos(), msg, value, minBound, maxBound)
-	}
-}
-
-// checkFloatBoundInRange checks if a float bound value is within the valid range.
-func checkFloatBoundInRange[T constraints.Float](pass *analysis.Pass, field *ast.Field, prefix string, value float64, minBound, maxBound T, boundType, typeName string) {
-	if value < float64(minBound) || value > float64(maxBound) {
-		pass.Reportf(field.Pos(), "%s has %s bound %v that is outside the valid %s range", prefix, boundType, value, typeName)
 	}
 }

--- a/pkg/analysis/numericbounds/analyzer.go
+++ b/pkg/analysis/numericbounds/analyzer.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package numericbounds
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+const name = "numericbounds"
+
+// JavaScript safe integer bounds (2^53 - 1 and -(2^53 - 1))
+const (
+	maxSafeInt = 9007199254740991  // 2^53 - 1
+	minSafeInt = -9007199254740991 // -(2^53 - 1)
+)
+
+var errMarkerMissingValue = errors.New("marker value not found")
+
+// Analyzer is the analyzer for the numericbounds package.
+// It checks that numeric fields have appropriate bounds validation markers.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "Checks that numeric fields (int32, int64) have appropriate minimum and maximum bounds validation markers",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspector.Analyzer},
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+		checkField(pass, field, markersAccess)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers) {
+	if field == nil || len(field.Names) == 0 {
+		return
+	}
+
+	// Unwrap pointers and slices to get the underlying type
+	fieldType, isSlice := unwrapType(field.Type)
+
+	// Get the underlying numeric type identifier (int32 or int64)
+	ident := getNumericTypeIdent(pass, fieldType)
+	if ident == nil {
+		return
+	}
+
+	// Only check int32 and int64 types
+	if ident.Name != "int32" && ident.Name != "int64" {
+		return
+	}
+
+	fieldName := utils.FieldName(field)
+	fieldMarkers := utils.TypeAwareMarkerCollectionForField(pass, markersAccess, field)
+
+	// Determine which markers to look for based on whether the field is a slice
+	minMarker, maxMarker := getMarkerNames(isSlice)
+
+	// Get minimum and maximum marker values
+	minimum, minErr := getMarkerNumericValue(fieldMarkers, minMarker)
+	maximum, maxErr := getMarkerNumericValue(fieldMarkers, maxMarker)
+
+	// Check if markers are missing
+	minMissing := errors.Is(minErr, errMarkerMissingValue)
+	maxMissing := errors.Is(maxErr, errMarkerMissingValue)
+
+	// Report any invalid marker values (e.g., non-numeric values)
+	if minErr != nil && !minMissing {
+		pass.Reportf(field.Pos(), "field %s has an invalid minimum marker: %v", fieldName, minErr)
+		return
+	}
+	if maxErr != nil && !maxMissing {
+		pass.Reportf(field.Pos(), "field %s has an invalid maximum marker: %v", fieldName, maxErr)
+		return
+	}
+
+	// Report if both markers are missing
+	if minMissing && maxMissing {
+		pass.Reportf(field.Pos(), "field %s of type %s should have minimum and maximum bounds validation markers", fieldName, ident.Name)
+		return
+	}
+
+	// Report if only one marker is present
+	if minMissing {
+		pass.Reportf(field.Pos(), "field %s of type %s has maximum but is missing minimum bounds validation marker", fieldName, ident.Name)
+		return
+	}
+	if maxMissing {
+		pass.Reportf(field.Pos(), "field %s of type %s has minimum but is missing maximum bounds validation marker", fieldName, ident.Name)
+		return
+	}
+
+	// For int64 fields, check if bounds are within JavaScript safe integer range
+	checkJavaScriptSafeBounds(pass, field, fieldName, ident.Name, minimum, maximum)
+}
+
+// unwrapType unwraps pointers and slices to get the underlying type.
+// Returns the unwrapped type and a boolean indicating if it's a slice.
+func unwrapType(expr ast.Expr) (ast.Expr, bool) {
+	isSlice := false
+
+	// Unwrap pointer if present (e.g., *int32)
+	if starExpr, ok := expr.(*ast.StarExpr); ok {
+		expr = starExpr.X
+	}
+
+	// Check if it's a slice and unwrap (e.g., []int32)
+	if arrayType, ok := expr.(*ast.ArrayType); ok {
+		isSlice = true
+		expr = arrayType.Elt
+
+		// Handle pointer inside slice (e.g., []*int32)
+		if starExpr, ok := expr.(*ast.StarExpr); ok {
+			expr = starExpr.X
+		}
+	}
+
+	return expr, isSlice
+}
+
+// getMarkerNames returns the appropriate minimum and maximum marker names
+// based on whether the field is a slice.
+func getMarkerNames(isSlice bool) (minMarker, maxMarker string) {
+	if isSlice {
+		return markers.KubebuilderItemsMinimumMarker, markers.KubebuilderItemsMaximumMarker
+	}
+	return markers.KubebuilderMinimumMarker, markers.KubebuilderMaximumMarker
+}
+
+// checkJavaScriptSafeBounds checks if int64 bounds are within JavaScript safe integer range.
+func checkJavaScriptSafeBounds(pass *analysis.Pass, field *ast.Field, fieldName, typeName string, minimum, maximum float64) {
+	if typeName != "int64" {
+		return
+	}
+
+	if minimum < minSafeInt || maximum > maxSafeInt {
+		pass.Reportf(field.Pos(),
+			"field %s of type int64 has bounds [%d, %d] that exceed safe integer range [%d, %d]. Consider using a string type to avoid precision loss in JavaScript clients",
+			fieldName, int64(minimum), int64(maximum), minSafeInt, maxSafeInt)
+	}
+}
+
+// getMarkerNumericValue extracts the numeric value from the first instance of the marker with the given name.
+func getMarkerNumericValue(markerSet markershelper.MarkerSet, markerName string) (float64, error) {
+	markerList := markerSet.Get(markerName)
+	if len(markerList) == 0 {
+		return 0, errMarkerMissingValue
+	}
+
+	marker := markerList[0]
+	rawValue, ok := marker.Expressions[""]
+	if !ok {
+		return 0, errMarkerMissingValue
+	}
+
+	// Parse as float64 using strconv for better error handling
+	value, err := strconv.ParseFloat(rawValue, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error converting value to number: %w", err)
+	}
+
+	return value, nil
+}
+
+// getNumericTypeIdent returns the identifier for int32 or int64 types.
+// It handles type aliases by looking up the underlying type.
+// Note: This function expects pointers and slices to already be unwrapped.
+func getNumericTypeIdent(pass *analysis.Pass, expr ast.Expr) *ast.Ident {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+
+	// Check if it's a basic int32 or int64 type
+	if ident.Name == "int32" || ident.Name == "int64" {
+		return ident
+	}
+
+	// Check if it's a type alias to int32 or int64
+	if !utils.IsBasicType(pass, ident) {
+		typeSpec, ok := utils.LookupTypeSpec(pass, ident)
+		if ok {
+			return getNumericTypeIdent(pass, typeSpec.Type)
+		}
+	}
+
+	return nil
+}

--- a/pkg/analysis/numericbounds/analyzer.go
+++ b/pkg/analysis/numericbounds/analyzer.go
@@ -71,6 +71,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
 		// Create TypeChecker with closure capturing markersAccess and qualifiedFieldName
+		// Ignore TypeChecker's prefix since we use qualifiedFieldName from inspector
 		typeChecker := utils.NewTypeChecker(func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, _ string) {
 			checkNumericType(pass, ident, node, markersAccess, qualifiedFieldName)
 		})

--- a/pkg/analysis/numericbounds/analyzer.go
+++ b/pkg/analysis/numericbounds/analyzer.go
@@ -118,7 +118,9 @@ func checkNumericTypeExpr(pass *analysis.Pass, expr ast.Expr, node ast.Node, mar
 
 	// Handle both fields and type aliases
 	var markerSet markershelper.MarkerSet
+
 	var isSlice bool
+
 	var pos ast.Node
 
 	switch n := node.(type) {

--- a/pkg/analysis/numericbounds/analyzer.go
+++ b/pkg/analysis/numericbounds/analyzer.go
@@ -190,11 +190,11 @@ func checkBoundsWithinTypeRange(pass *analysis.Pass, field *ast.Field, prefix, t
 		// Kubernetes API conventions enforce JavaScript-safe bounds for int64 (±2^53-1)
 		// to ensure compatibility with JavaScript clients
 		if minimum < float64(minSafeInt64) {
-			pass.Reportf(field.Pos(), "%s has minimum bound %v that is outside the JavaScript-safe int64 range [%d, %d]. Consider using a string type to avoid precision loss in JavaScript clients", prefix, minimum, minSafeInt64, maxSafeInt64)
+			pass.Reportf(field.Pos(), "%s has minimum bound %v that is outside the JavaScript-safe int64 range [%d, %d]. Consider using a string type to avoid precision loss in JavaScript clients", prefix, minimum, int64(minSafeInt64), int64(maxSafeInt64))
 		}
 
 		if maximum > float64(maxSafeInt64) {
-			pass.Reportf(field.Pos(), "%s has maximum bound %v that is outside the JavaScript-safe int64 range [%d, %d]. Consider using a string type to avoid precision loss in JavaScript clients", prefix, maximum, minSafeInt64, maxSafeInt64)
+			pass.Reportf(field.Pos(), "%s has maximum bound %v that is outside the JavaScript-safe int64 range [%d, %d]. Consider using a string type to avoid precision loss in JavaScript clients", prefix, maximum, int64(minSafeInt64), int64(maxSafeInt64))
 		}
 	case "float32":
 		if minimum < float64(minFloat32) || minimum > float64(maxFloat32) {

--- a/pkg/analysis/numericbounds/analyzer_test.go
+++ b/pkg/analysis/numericbounds/analyzer_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package numericbounds_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/numericbounds"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, numericbounds.Analyzer, "a")
+}

--- a/pkg/analysis/numericbounds/doc.go
+++ b/pkg/analysis/numericbounds/doc.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+numericbounds is an analyzer that checks for proper bounds validation on numeric fields.
+
+According to Kubernetes API conventions, numeric fields should have appropriate bounds
+checking to prevent values that are too small, negative (when not intended), or too large.
+
+This analyzer ensures that:
+  - int32 and int64 fields have both minimum and maximum bounds markers
+  - For slices of numeric types, the analyzer checks for items:Minimum and items:Maximum markers
+  - Type aliases to int32 or int64 are also checked
+  - Pointer types (e.g., *int32, []*int64) are unwrapped and validated
+  - int64 fields with values outside the JavaScript safe integer range (-(2^53-1) to (2^53-1))
+    are flagged, as they may cause precision loss in JavaScript clients
+
+The analyzer checks for the presence of +kubebuilder:validation:Minimum and
++kubebuilder:validation:Maximum markers on numeric fields, or the items: variants for slices.
+
+For int64 fields, if the bounds exceed the JavaScript safe integer range of
+[-9007199254740991, 9007199254740991], the analyzer suggests using a string type instead
+to avoid precision loss in JavaScript environments.
+
+Examples of valid and invalid code:
+
+Valid:
+
+	type Example struct {
+		// +kubebuilder:validation:Minimum=0
+		// +kubebuilder:validation:Maximum=100
+		Count int32
+	}
+
+Invalid:
+
+	type Example struct {
+		Count int32 // Missing minimum and maximum markers
+	}
+*/
+package numericbounds

--- a/pkg/analysis/numericbounds/initializer.go
+++ b/pkg/analysis/numericbounds/initializer.go
@@ -30,6 +30,6 @@ func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewInitializer(
 		name,
 		Analyzer,
-		false, // For now, CRD only, and so not on by default.
+		false,
 	)
 }

--- a/pkg/analysis/numericbounds/initializer.go
+++ b/pkg/analysis/numericbounds/initializer.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package numericbounds
+
+import (
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewInitializer(
+		name,
+		Analyzer,
+		true,
+	)
+}

--- a/pkg/analysis/numericbounds/initializer.go
+++ b/pkg/analysis/numericbounds/initializer.go
@@ -30,6 +30,6 @@ func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewInitializer(
 		name,
 		Analyzer,
-		true,
+		false, // For now, CRD only, and so not on by default.
 	)
 }

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -148,10 +148,10 @@ type SliceFields struct {
 }
 
 // TypeAliasFields with type aliases should be checked
-type Int32Alias int32
-type Int64Alias int64
-type Float32Alias float32
-type Float64Alias float64
+type Int32Alias int32       // want "Int32Alias is missing minimum bound validation marker" "Int32Alias is missing maximum bound validation marker"
+type Int64Alias int64       // want "Int64Alias is missing minimum bound validation marker" "Int64Alias is missing maximum bound validation marker"
+type Float32Alias float32   // want "Float32Alias is missing minimum bound validation marker" "Float32Alias is missing maximum bound validation marker"
+type Float64Alias float64   // want "Float64Alias is missing minimum bound validation marker" "Float64Alias is missing maximum bound validation marker"
 
 // Type aliases with bounds on the type itself
 // +kubebuilder:validation:Minimum=0

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -23,57 +23,57 @@ type ValidInt64WithJSSafeBounds struct {
 
 // InvalidInt32NoBounds should have bounds markers
 type InvalidInt32NoBounds struct {
-	NoBounds int32 // want "field NoBounds int32 is missing minimum bounds validation marker" "field NoBounds int32 is missing maximum bounds validation marker"
+	NoBounds int32 // want "field NoBounds is missing minimum bounds validation marker" "field NoBounds is missing maximum bounds validation marker"
 }
 
 // InvalidInt64NoBounds should have bounds markers
 type InvalidInt64NoBounds struct {
-	NoBounds int64 // want "field NoBounds int64 is missing minimum bounds validation marker" "field NoBounds int64 is missing maximum bounds validation marker"
+	NoBounds int64 // want "field NoBounds is missing minimum bounds validation marker" "field NoBounds is missing maximum bounds validation marker"
 }
 
 // InvalidInt32OnlyMin should have maximum marker
 type InvalidInt32OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int32 // want "field OnlyMin int32 is missing maximum bounds validation marker"
+	OnlyMin int32 // want "field OnlyMin is missing maximum bounds validation marker"
 }
 
 // InvalidInt32OnlyMax should have minimum marker
 type InvalidInt32OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int32 // want "field OnlyMax int32 is missing minimum bounds validation marker"
+	OnlyMax int32 // want "field OnlyMax is missing minimum bounds validation marker"
 }
 
 // InvalidInt64OnlyMin should have maximum marker
 type InvalidInt64OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int64 // want "field OnlyMin int64 is missing maximum bounds validation marker"
+	OnlyMin int64 // want "field OnlyMin is missing maximum bounds validation marker"
 }
 
 // InvalidInt64OnlyMax should have minimum marker
 type InvalidInt64OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int64 // want "field OnlyMax int64 is missing minimum bounds validation marker"
+	OnlyMax int64 // want "field OnlyMax is missing minimum bounds validation marker"
 }
 
 // InvalidInt64ExceedsJSMaxBounds has maximum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMaxBounds struct {
 	// +kubebuilder:validation:Minimum=-1000
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeMax int64 // want "field UnsafeMax int64 has bounds \\[-1000, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMax int64 // want "field UnsafeMax has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSMinBounds has minimum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMinBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=1000
-	UnsafeMin int64 // want "field UnsafeMin int64 has bounds \\[-9007199254740992, 1000\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMin int64 // want "field UnsafeMin has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSBothBounds has both bounds exceeding JavaScript safe integer range
 type InvalidInt64ExceedsJSBothBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeBoth int64 // want "field UnsafeBoth int64 has bounds \\[-9007199254740992, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeBoth int64 // want "field UnsafeBoth has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients" "field UnsafeBoth has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // IgnoredStringField should not be checked
@@ -102,12 +102,12 @@ type ValidFloat32WithBounds struct {
 
 // InvalidFloat64NoBounds should have bounds markers
 type InvalidFloat64NoBounds struct {
-	Value float64 // want "field Value float64 is missing minimum bounds validation marker" "field Value float64 is missing maximum bounds validation marker"
+	Value float64 // want "field Value is missing minimum bounds validation marker" "field Value is missing maximum bounds validation marker"
 }
 
 // InvalidFloat32NoBounds should have bounds markers
 type InvalidFloat32NoBounds struct {
-	Ratio float32 // want "field Ratio float32 is missing minimum bounds validation marker" "field Ratio float32 is missing maximum bounds validation marker"
+	Ratio float32 // want "field Ratio is missing minimum bounds validation marker" "field Ratio is missing maximum bounds validation marker"
 }
 
 // MixedFields has both valid and invalid fields
@@ -116,7 +116,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidCount int32
 
-	InvalidCount int32 // want "field InvalidCount int32 is missing minimum bounds validation marker" "field InvalidCount int32 is missing maximum bounds validation marker"
+	InvalidCount int32 // want "field InvalidCount is missing minimum bounds validation marker" "field InvalidCount is missing maximum bounds validation marker"
 
 	Name string
 
@@ -124,7 +124,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=1000
 	ValidValue int64
 
-	InvalidValue int64 // want "field InvalidValue int64 is missing minimum bounds validation marker" "field InvalidValue int64 is missing maximum bounds validation marker"
+	InvalidValue int64 // want "field InvalidValue is missing minimum bounds validation marker" "field InvalidValue is missing maximum bounds validation marker"
 }
 
 // PointerFields with pointers should also be checked
@@ -133,18 +133,18 @@ type PointerFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidPointerWithBounds *int32
 
-	InvalidPointer *int32 // want "field InvalidPointer int32 is missing minimum bounds validation marker" "field InvalidPointer int32 is missing maximum bounds validation marker"
+	InvalidPointer *int32 // want "field InvalidPointer pointer is missing minimum bounds validation marker" "field InvalidPointer pointer is missing maximum bounds validation marker"
 
-	InvalidPointer64 *int64 // want "field InvalidPointer64 int64 is missing minimum bounds validation marker" "field InvalidPointer64 int64 is missing maximum bounds validation marker"
+	InvalidPointer64 *int64 // want "field InvalidPointer64 pointer is missing minimum bounds validation marker" "field InvalidPointer64 pointer is missing maximum bounds validation marker"
 }
 
 // SliceFields with slices should check the element type
 type SliceFields struct {
 	ValidSlice []string
 
-	InvalidSlice []int32 // want "field InvalidSlice array element type of int32 is missing minimum bounds validation marker" "field InvalidSlice array element type of int32 is missing maximum bounds validation marker"
+	InvalidSlice []int32 // want "field InvalidSlice array element is missing minimum bounds validation marker" "field InvalidSlice array element is missing maximum bounds validation marker"
 
-	InvalidSlice64 []int64 // want "field InvalidSlice64 array element type of int64 is missing minimum bounds validation marker" "field InvalidSlice64 array element type of int64 is missing maximum bounds validation marker"
+	InvalidSlice64 []int64 // want "field InvalidSlice64 array element is missing minimum bounds validation marker" "field InvalidSlice64 array element is missing maximum bounds validation marker"
 
 	// +kubebuilder:validation:items:Minimum=0
 	// +kubebuilder:validation:items:Maximum=100
@@ -179,13 +179,13 @@ type TypeAliasFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidAlias Int32Alias
 
-	InvalidAlias Int32Alias // want "field InvalidAlias int32 is missing minimum bounds validation marker" "field InvalidAlias int32 is missing maximum bounds validation marker"
+	InvalidAlias Int32Alias // want "field InvalidAlias type Int32Alias is missing minimum bounds validation marker" "field InvalidAlias type Int32Alias is missing maximum bounds validation marker"
 
-	InvalidAlias64 Int64Alias // want "field InvalidAlias64 int64 is missing minimum bounds validation marker" "field InvalidAlias64 int64 is missing maximum bounds validation marker"
+	InvalidAlias64 Int64Alias // want "field InvalidAlias64 type Int64Alias is missing minimum bounds validation marker" "field InvalidAlias64 type Int64Alias is missing maximum bounds validation marker"
 
-	InvalidAliasFloat32 Float32Alias // want "field InvalidAliasFloat32 float32 is missing minimum bounds validation marker" "field InvalidAliasFloat32 float32 is missing maximum bounds validation marker"
+	InvalidAliasFloat32 Float32Alias // want "field InvalidAliasFloat32 type Float32Alias is missing minimum bounds validation marker" "field InvalidAliasFloat32 type Float32Alias is missing maximum bounds validation marker"
 
-	InvalidAliasFloat64 Float64Alias // want "field InvalidAliasFloat64 float64 is missing minimum bounds validation marker" "field InvalidAliasFloat64 float64 is missing maximum bounds validation marker"
+	InvalidAliasFloat64 Float64Alias // want "field InvalidAliasFloat64 type Float64Alias is missing minimum bounds validation marker" "field InvalidAliasFloat64 type Float64Alias is missing maximum bounds validation marker"
 
 	// Valid: bounds are on the type alias itself
 	ValidBoundedAlias BoundedInt32Alias
@@ -199,7 +199,7 @@ type TypeAliasFields struct {
 
 // PointerSliceFields with pointer slices should also be checked
 type PointerSliceFields struct {
-	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice array element type of int32 is missing minimum bounds validation marker" "field InvalidPointerSlice array element type of int32 is missing maximum bounds validation marker"
+	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice array element pointer is missing minimum bounds validation marker" "field InvalidPointerSlice array element pointer is missing maximum bounds validation marker"
 }
 
 // K8sDeclarativeValidation with k8s declarative validation markers should work
@@ -217,7 +217,7 @@ type K8sDeclarativeValidation struct {
 type InvalidInt32BoundsOutOfRange struct {
 	// +kubebuilder:validation:Minimum=-3000000000
 	// +kubebuilder:validation:Maximum=3000000000
-	OutOfRange int32 // want "field OutOfRange int32 has minimum bound -3e\\+09 that is outside the valid int32 range" "field OutOfRange int32 has maximum bound 3e\\+09 that is outside the valid int32 range"
+	OutOfRange int32 // want "field OutOfRange has minimum bound -3e\\+09 that is outside the valid int32 range" "field OutOfRange has maximum bound 3e\\+09 that is outside the valid int32 range"
 }
 
 // MixedMarkersKubebuilderAndK8s can use either kubebuilder or k8s markers

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -23,57 +23,57 @@ type ValidInt64WithJSSafeBounds struct {
 
 // InvalidInt32NoBounds should have bounds markers
 type InvalidInt32NoBounds struct {
-	NoBounds int32 // want "field NoBounds of type int32 should have minimum and maximum bounds validation markers"
+	NoBounds int32 // want "field NoBounds int32 is missing minimum bounds validation marker" "field NoBounds int32 is missing maximum bounds validation marker"
 }
 
 // InvalidInt64NoBounds should have bounds markers
 type InvalidInt64NoBounds struct {
-	NoBounds int64 // want "field NoBounds of type int64 should have minimum and maximum bounds validation markers"
+	NoBounds int64 // want "field NoBounds int64 is missing minimum bounds validation marker" "field NoBounds int64 is missing maximum bounds validation marker"
 }
 
 // InvalidInt32OnlyMin should have maximum marker
 type InvalidInt32OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int32 // want "field OnlyMin of type int32 has minimum but is missing maximum bounds validation marker"
+	OnlyMin int32 // want "field OnlyMin int32 is missing maximum bounds validation marker"
 }
 
 // InvalidInt32OnlyMax should have minimum marker
 type InvalidInt32OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int32 // want "field OnlyMax of type int32 has maximum but is missing minimum bounds validation marker"
+	OnlyMax int32 // want "field OnlyMax int32 is missing minimum bounds validation marker"
 }
 
 // InvalidInt64OnlyMin should have maximum marker
 type InvalidInt64OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int64 // want "field OnlyMin of type int64 has minimum but is missing maximum bounds validation marker"
+	OnlyMin int64 // want "field OnlyMin int64 is missing maximum bounds validation marker"
 }
 
 // InvalidInt64OnlyMax should have minimum marker
 type InvalidInt64OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int64 // want "field OnlyMax of type int64 has maximum but is missing minimum bounds validation marker"
+	OnlyMax int64 // want "field OnlyMax int64 is missing minimum bounds validation marker"
 }
 
 // InvalidInt64ExceedsJSMaxBounds has maximum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMaxBounds struct {
 	// +kubebuilder:validation:Minimum=-1000
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeMax int64 // want "field UnsafeMax of type int64 has bounds \\[-1000, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMax int64 // want "field UnsafeMax int64 has bounds \\[-1000, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSMinBounds has minimum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMinBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=1000
-	UnsafeMin int64 // want "field UnsafeMin of type int64 has bounds \\[-9007199254740992, 1000\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMin int64 // want "field UnsafeMin int64 has bounds \\[-9007199254740992, 1000\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSBothBounds has both bounds exceeding JavaScript safe integer range
 type InvalidInt64ExceedsJSBothBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeBoth int64 // want "field UnsafeBoth of type int64 has bounds \\[-9007199254740992, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeBoth int64 // want "field UnsafeBoth int64 has bounds \\[-9007199254740992, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // IgnoredStringField should not be checked
@@ -86,9 +86,28 @@ type IgnoredBoolField struct {
 	Enabled bool
 }
 
-// IgnoredFloat64Field should not be checked
-type IgnoredFloat64Field struct {
+// ValidFloat64WithBounds has proper bounds validation
+type ValidFloat64WithBounds struct {
+	// +kubebuilder:validation:Minimum=-1000.5
+	// +kubebuilder:validation:Maximum=1000.5
 	Value float64
+}
+
+// ValidFloat32WithBounds has proper bounds validation
+type ValidFloat32WithBounds struct {
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=100.0
+	Ratio float32
+}
+
+// InvalidFloat64NoBounds should have bounds markers
+type InvalidFloat64NoBounds struct {
+	Value float64 // want "field Value float64 is missing minimum bounds validation marker" "field Value float64 is missing maximum bounds validation marker"
+}
+
+// InvalidFloat32NoBounds should have bounds markers
+type InvalidFloat32NoBounds struct {
+	Ratio float32 // want "field Ratio float32 is missing minimum bounds validation marker" "field Ratio float32 is missing maximum bounds validation marker"
 }
 
 // MixedFields has both valid and invalid fields
@@ -97,7 +116,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidCount int32
 
-	InvalidCount int32 // want "field InvalidCount of type int32 should have minimum and maximum bounds validation markers"
+	InvalidCount int32 // want "field InvalidCount int32 is missing minimum bounds validation marker" "field InvalidCount int32 is missing maximum bounds validation marker"
 
 	Name string
 
@@ -105,7 +124,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=1000
 	ValidValue int64
 
-	InvalidValue int64 // want "field InvalidValue of type int64 should have minimum and maximum bounds validation markers"
+	InvalidValue int64 // want "field InvalidValue int64 is missing minimum bounds validation marker" "field InvalidValue int64 is missing maximum bounds validation marker"
 }
 
 // PointerFields with pointers should also be checked
@@ -114,18 +133,18 @@ type PointerFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidPointerWithBounds *int32
 
-	InvalidPointer *int32 // want "field InvalidPointer of type int32 should have minimum and maximum bounds validation markers"
+	InvalidPointer *int32 // want "field InvalidPointer int32 is missing minimum bounds validation marker" "field InvalidPointer int32 is missing maximum bounds validation marker"
 
-	InvalidPointer64 *int64 // want "field InvalidPointer64 of type int64 should have minimum and maximum bounds validation markers"
+	InvalidPointer64 *int64 // want "field InvalidPointer64 int64 is missing minimum bounds validation marker" "field InvalidPointer64 int64 is missing maximum bounds validation marker"
 }
 
 // SliceFields with slices should check the element type
 type SliceFields struct {
 	ValidSlice []string
 
-	InvalidSlice []int32 // want "field InvalidSlice of type int32 should have minimum and maximum bounds validation markers"
+	InvalidSlice []int32 // want "field InvalidSlice array element type of int32 is missing minimum bounds validation marker" "field InvalidSlice array element type of int32 is missing maximum bounds validation marker"
 
-	InvalidSlice64 []int64 // want "field InvalidSlice64 of type int64 should have minimum and maximum bounds validation markers"
+	InvalidSlice64 []int64 // want "field InvalidSlice64 array element type of int64 is missing minimum bounds validation marker" "field InvalidSlice64 array element type of int64 is missing maximum bounds validation marker"
 
 	// +kubebuilder:validation:items:Minimum=0
 	// +kubebuilder:validation:items:Maximum=100
@@ -135,18 +154,75 @@ type SliceFields struct {
 // TypeAliasFields with type aliases should be checked
 type Int32Alias int32
 type Int64Alias int64
+type Float32Alias float32
+type Float64Alias float64
+
+// Type aliases with bounds on the type itself
+// +kubebuilder:validation:Minimum=0
+// +kubebuilder:validation:Maximum=255
+type BoundedInt32Alias int32
+
+// +kubebuilder:validation:Minimum=-1000
+// +kubebuilder:validation:Maximum=1000
+type BoundedInt64Alias int64
+
+// +kubebuilder:validation:Minimum=0.0
+// +kubebuilder:validation:Maximum=1.0
+type BoundedFloat32Alias float32
+
+// +kubebuilder:validation:Minimum=-100.5
+// +kubebuilder:validation:Maximum=100.5
+type BoundedFloat64Alias float64
 
 type TypeAliasFields struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	ValidAlias Int32Alias
 
-	InvalidAlias Int32Alias // want "field InvalidAlias of type int32 should have minimum and maximum bounds validation markers"
+	InvalidAlias Int32Alias // want "field InvalidAlias int32 is missing minimum bounds validation marker" "field InvalidAlias int32 is missing maximum bounds validation marker"
 
-	InvalidAlias64 Int64Alias // want "field InvalidAlias64 of type int64 should have minimum and maximum bounds validation markers"
+	InvalidAlias64 Int64Alias // want "field InvalidAlias64 int64 is missing minimum bounds validation marker" "field InvalidAlias64 int64 is missing maximum bounds validation marker"
+
+	InvalidAliasFloat32 Float32Alias // want "field InvalidAliasFloat32 float32 is missing minimum bounds validation marker" "field InvalidAliasFloat32 float32 is missing maximum bounds validation marker"
+
+	InvalidAliasFloat64 Float64Alias // want "field InvalidAliasFloat64 float64 is missing minimum bounds validation marker" "field InvalidAliasFloat64 float64 is missing maximum bounds validation marker"
+
+	// Valid: bounds are on the type alias itself
+	ValidBoundedAlias BoundedInt32Alias
+
+	ValidBoundedAlias64 BoundedInt64Alias
+
+	ValidBoundedFloat32 BoundedFloat32Alias
+
+	ValidBoundedFloat64 BoundedFloat64Alias
 }
 
 // PointerSliceFields with pointer slices should also be checked
 type PointerSliceFields struct {
-	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice of type int32 should have minimum and maximum bounds validation markers"
+	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice array element type of int32 is missing minimum bounds validation marker" "field InvalidPointerSlice array element type of int32 is missing maximum bounds validation marker"
+}
+
+// K8sDeclarativeValidation with k8s declarative validation markers should work
+type K8sDeclarativeValidation struct {
+	// +k8s:minimum=0
+	// +k8s:maximum=100
+	ValidWithK8sMarkers int32
+
+	// +k8s:minimum=-1000
+	// +k8s:maximum=1000
+	ValidInt64WithK8s int64
+}
+
+// InvalidInt32BoundsOutOfRange has int32 bounds outside the valid int32 range
+type InvalidInt32BoundsOutOfRange struct {
+	// +kubebuilder:validation:Minimum=-3000000000
+	// +kubebuilder:validation:Maximum=3000000000
+	OutOfRange int32 // want "field OutOfRange int32 has minimum bound -3e\\+09 that is outside the valid int32 range" "field OutOfRange int32 has maximum bound 3e\\+09 that is outside the valid int32 range"
+}
+
+// MixedMarkersKubebuilderAndK8s can use either kubebuilder or k8s markers
+type MixedMarkersKubebuilderAndK8s struct {
+	// +kubebuilder:validation:Minimum=0
+	// +k8s:maximum=100
+	MixedMarkers int32
 }

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -1,0 +1,152 @@
+package a
+
+// ValidInt32WithBounds has proper bounds validation
+type ValidInt32WithBounds struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	Count int32
+}
+
+// ValidInt64WithBounds has proper bounds validation
+type ValidInt64WithBounds struct {
+	// +kubebuilder:validation:Minimum=-1000
+	// +kubebuilder:validation:Maximum=1000
+	Value int64
+}
+
+// ValidInt64WithJSSafeBounds has bounds within JavaScript safe integer range
+type ValidInt64WithJSSafeBounds struct {
+	// +kubebuilder:validation:Minimum=-9007199254740991
+	// +kubebuilder:validation:Maximum=9007199254740991
+	SafeValue int64
+}
+
+// InvalidInt32NoBounds should have bounds markers
+type InvalidInt32NoBounds struct {
+	NoBounds int32 // want "field NoBounds of type int32 should have minimum and maximum bounds validation markers"
+}
+
+// InvalidInt64NoBounds should have bounds markers
+type InvalidInt64NoBounds struct {
+	NoBounds int64 // want "field NoBounds of type int64 should have minimum and maximum bounds validation markers"
+}
+
+// InvalidInt32OnlyMin should have maximum marker
+type InvalidInt32OnlyMin struct {
+	// +kubebuilder:validation:Minimum=0
+	OnlyMin int32 // want "field OnlyMin of type int32 has minimum but is missing maximum bounds validation marker"
+}
+
+// InvalidInt32OnlyMax should have minimum marker
+type InvalidInt32OnlyMax struct {
+	// +kubebuilder:validation:Maximum=100
+	OnlyMax int32 // want "field OnlyMax of type int32 has maximum but is missing minimum bounds validation marker"
+}
+
+// InvalidInt64OnlyMin should have maximum marker
+type InvalidInt64OnlyMin struct {
+	// +kubebuilder:validation:Minimum=0
+	OnlyMin int64 // want "field OnlyMin of type int64 has minimum but is missing maximum bounds validation marker"
+}
+
+// InvalidInt64OnlyMax should have minimum marker
+type InvalidInt64OnlyMax struct {
+	// +kubebuilder:validation:Maximum=100
+	OnlyMax int64 // want "field OnlyMax of type int64 has maximum but is missing minimum bounds validation marker"
+}
+
+// InvalidInt64ExceedsJSMaxBounds has maximum that exceeds JavaScript safe integer range
+type InvalidInt64ExceedsJSMaxBounds struct {
+	// +kubebuilder:validation:Minimum=-1000
+	// +kubebuilder:validation:Maximum=9007199254740992
+	UnsafeMax int64 // want "field UnsafeMax of type int64 has bounds \\[-1000, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+}
+
+// InvalidInt64ExceedsJSMinBounds has minimum that exceeds JavaScript safe integer range
+type InvalidInt64ExceedsJSMinBounds struct {
+	// +kubebuilder:validation:Minimum=-9007199254740992
+	// +kubebuilder:validation:Maximum=1000
+	UnsafeMin int64 // want "field UnsafeMin of type int64 has bounds \\[-9007199254740992, 1000\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+}
+
+// InvalidInt64ExceedsJSBothBounds has both bounds exceeding JavaScript safe integer range
+type InvalidInt64ExceedsJSBothBounds struct {
+	// +kubebuilder:validation:Minimum=-9007199254740992
+	// +kubebuilder:validation:Maximum=9007199254740992
+	UnsafeBoth int64 // want "field UnsafeBoth of type int64 has bounds \\[-9007199254740992, 9007199254740992\\] that exceed safe integer range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+}
+
+// IgnoredStringField should not be checked
+type IgnoredStringField struct {
+	Name string
+}
+
+// IgnoredBoolField should not be checked
+type IgnoredBoolField struct {
+	Enabled bool
+}
+
+// IgnoredFloat64Field should not be checked
+type IgnoredFloat64Field struct {
+	Value float64
+}
+
+// MixedFields has both valid and invalid fields
+type MixedFields struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	ValidCount int32
+
+	InvalidCount int32 // want "field InvalidCount of type int32 should have minimum and maximum bounds validation markers"
+
+	Name string
+
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000
+	ValidValue int64
+
+	InvalidValue int64 // want "field InvalidValue of type int64 should have minimum and maximum bounds validation markers"
+}
+
+// PointerFields with pointers should also be checked
+type PointerFields struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	ValidPointerWithBounds *int32
+
+	InvalidPointer *int32 // want "field InvalidPointer of type int32 should have minimum and maximum bounds validation markers"
+
+	InvalidPointer64 *int64 // want "field InvalidPointer64 of type int64 should have minimum and maximum bounds validation markers"
+}
+
+// SliceFields with slices should check the element type
+type SliceFields struct {
+	ValidSlice []string
+
+	InvalidSlice []int32 // want "field InvalidSlice of type int32 should have minimum and maximum bounds validation markers"
+
+	InvalidSlice64 []int64 // want "field InvalidSlice64 of type int64 should have minimum and maximum bounds validation markers"
+
+	// +kubebuilder:validation:items:Minimum=0
+	// +kubebuilder:validation:items:Maximum=100
+	ValidSliceWithBounds []int32
+}
+
+// TypeAliasFields with type aliases should be checked
+type Int32Alias int32
+type Int64Alias int64
+
+type TypeAliasFields struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	ValidAlias Int32Alias
+
+	InvalidAlias Int32Alias // want "field InvalidAlias of type int32 should have minimum and maximum bounds validation markers"
+
+	InvalidAlias64 Int64Alias // want "field InvalidAlias64 of type int64 should have minimum and maximum bounds validation markers"
+}
+
+// PointerSliceFields with pointer slices should also be checked
+type PointerSliceFields struct {
+	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice of type int32 should have minimum and maximum bounds validation markers"
+}

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -1,79 +1,79 @@
 package a
 
-// ValidInt32WithBounds has proper bounds validation
-type ValidInt32WithBounds struct {
+// ValidInt32WithBound has proper bounds validation
+type ValidInt32WithBound struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	Count int32
 }
 
-// ValidInt64WithBounds has proper bounds validation
-type ValidInt64WithBounds struct {
+// ValidInt64WithBound has proper bounds validation
+type ValidInt64WithBound struct {
 	// +kubebuilder:validation:Minimum=-1000
 	// +kubebuilder:validation:Maximum=1000
 	Value int64
 }
 
-// ValidInt64WithJSSafeBounds has bounds within JavaScript safe integer range
-type ValidInt64WithJSSafeBounds struct {
+// ValidInt64WithJSSafeBound has bounds within JavaScript safe integer range
+type ValidInt64WithJSSafeBound struct {
 	// +kubebuilder:validation:Minimum=-9007199254740991
 	// +kubebuilder:validation:Maximum=9007199254740991
 	SafeValue int64
 }
 
-// InvalidInt32NoBounds should have bounds markers
-type InvalidInt32NoBounds struct {
-	NoBounds int32 // want "field NoBounds is missing minimum bounds validation marker" "field NoBounds is missing maximum bounds validation marker"
+// InvalidInt32NoBound should have bounds markers
+type InvalidInt32NoBound struct {
+	NoBound int32 // want "InvalidInt32NoBound.NoBound is missing minimum bound validation marker" "InvalidInt32NoBound.NoBound is missing maximum bound validation marker"
 }
 
-// InvalidInt64NoBounds should have bounds markers
-type InvalidInt64NoBounds struct {
-	NoBounds int64 // want "field NoBounds is missing minimum bounds validation marker" "field NoBounds is missing maximum bounds validation marker"
+// InvalidInt64NoBound should have bounds markers
+type InvalidInt64NoBound struct {
+	NoBound int64 // want "InvalidInt64NoBound.NoBound is missing minimum bound validation marker" "InvalidInt64NoBound.NoBound is missing maximum bound validation marker"
 }
 
 // InvalidInt32OnlyMin should have maximum marker
 type InvalidInt32OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int32 // want "field OnlyMin is missing maximum bounds validation marker"
+	OnlyMin int32 // want "InvalidInt32OnlyMin.OnlyMin is missing maximum bound validation marker"
 }
 
 // InvalidInt32OnlyMax should have minimum marker
 type InvalidInt32OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int32 // want "field OnlyMax is missing minimum bounds validation marker"
+	OnlyMax int32 // want "InvalidInt32OnlyMax.OnlyMax is missing minimum bound validation marker"
 }
 
 // InvalidInt64OnlyMin should have maximum marker
 type InvalidInt64OnlyMin struct {
 	// +kubebuilder:validation:Minimum=0
-	OnlyMin int64 // want "field OnlyMin is missing maximum bounds validation marker"
+	OnlyMin int64 // want "InvalidInt64OnlyMin.OnlyMin is missing maximum bound validation marker"
 }
 
 // InvalidInt64OnlyMax should have minimum marker
 type InvalidInt64OnlyMax struct {
 	// +kubebuilder:validation:Maximum=100
-	OnlyMax int64 // want "field OnlyMax is missing minimum bounds validation marker"
+	OnlyMax int64 // want "InvalidInt64OnlyMax.OnlyMax is missing minimum bound validation marker"
 }
 
 // InvalidInt64ExceedsJSMaxBounds has maximum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMaxBounds struct {
 	// +kubebuilder:validation:Minimum=-1000
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeMax int64 // want "field UnsafeMax has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMax int64 // want "InvalidInt64ExceedsJSMaxBounds.UnsafeMax has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSMinBounds has minimum that exceeds JavaScript safe integer range
 type InvalidInt64ExceedsJSMinBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=1000
-	UnsafeMin int64 // want "field UnsafeMin has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeMin int64 // want "InvalidInt64ExceedsJSMinBounds.UnsafeMin has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // InvalidInt64ExceedsJSBothBounds has both bounds exceeding JavaScript safe integer range
 type InvalidInt64ExceedsJSBothBounds struct {
 	// +kubebuilder:validation:Minimum=-9007199254740992
 	// +kubebuilder:validation:Maximum=9007199254740992
-	UnsafeBoth int64 // want "field UnsafeBoth has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients" "field UnsafeBoth has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
+	UnsafeBoth int64 // want "InvalidInt64ExceedsJSBothBounds.UnsafeBoth has minimum bound -9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients" "InvalidInt64ExceedsJSBothBounds.UnsafeBoth has maximum bound 9\\.007199254740992e\\+15 that is outside the JavaScript-safe int64 range \\[-9007199254740991, 9007199254740991\\]\\. Consider using a string type to avoid precision loss in JavaScript clients"
 }
 
 // IgnoredStringField should not be checked
@@ -102,12 +102,12 @@ type ValidFloat32WithBounds struct {
 
 // InvalidFloat64NoBounds should have bounds markers
 type InvalidFloat64NoBounds struct {
-	Value float64 // want "field Value is missing minimum bounds validation marker" "field Value is missing maximum bounds validation marker"
+	Value float64 // want "InvalidFloat64NoBounds.Value is missing minimum bound validation marker" "InvalidFloat64NoBounds.Value is missing maximum bound validation marker"
 }
 
 // InvalidFloat32NoBounds should have bounds markers
 type InvalidFloat32NoBounds struct {
-	Ratio float32 // want "field Ratio is missing minimum bounds validation marker" "field Ratio is missing maximum bounds validation marker"
+	Ratio float32 // want "InvalidFloat32NoBounds.Ratio is missing minimum bound validation marker" "InvalidFloat32NoBounds.Ratio is missing maximum bound validation marker"
 }
 
 // MixedFields has both valid and invalid fields
@@ -116,7 +116,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidCount int32
 
-	InvalidCount int32 // want "field InvalidCount is missing minimum bounds validation marker" "field InvalidCount is missing maximum bounds validation marker"
+	InvalidCount int32 // want "MixedFields.InvalidCount is missing minimum bound validation marker" "MixedFields.InvalidCount is missing maximum bound validation marker"
 
 	Name string
 
@@ -124,7 +124,7 @@ type MixedFields struct {
 	// +kubebuilder:validation:Maximum=1000
 	ValidValue int64
 
-	InvalidValue int64 // want "field InvalidValue is missing minimum bounds validation marker" "field InvalidValue is missing maximum bounds validation marker"
+	InvalidValue int64 // want "MixedFields.InvalidValue is missing minimum bound validation marker" "MixedFields.InvalidValue is missing maximum bound validation marker"
 }
 
 // PointerFields with pointers should also be checked
@@ -133,18 +133,18 @@ type PointerFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidPointerWithBounds *int32
 
-	InvalidPointer *int32 // want "field InvalidPointer pointer is missing minimum bounds validation marker" "field InvalidPointer pointer is missing maximum bounds validation marker"
+	InvalidPointer *int32 // want "PointerFields.InvalidPointer is missing minimum bound validation marker" "PointerFields.InvalidPointer is missing maximum bound validation marker"
 
-	InvalidPointer64 *int64 // want "field InvalidPointer64 pointer is missing minimum bounds validation marker" "field InvalidPointer64 pointer is missing maximum bounds validation marker"
+	InvalidPointer64 *int64 // want "PointerFields.InvalidPointer64 is missing minimum bound validation marker" "PointerFields.InvalidPointer64 is missing maximum bound validation marker"
 }
 
 // SliceFields with slices should check the element type
 type SliceFields struct {
 	ValidSlice []string
 
-	InvalidSlice []int32 // want "field InvalidSlice array element is missing minimum bounds validation marker" "field InvalidSlice array element is missing maximum bounds validation marker"
+	InvalidSlice []int32 // want "SliceFields.InvalidSlice is missing minimum bound validation marker" "SliceFields.InvalidSlice is missing maximum bound validation marker"
 
-	InvalidSlice64 []int64 // want "field InvalidSlice64 array element is missing minimum bounds validation marker" "field InvalidSlice64 array element is missing maximum bounds validation marker"
+	InvalidSlice64 []int64 // want "SliceFields.InvalidSlice64 is missing minimum bound validation marker" "SliceFields.InvalidSlice64 is missing maximum bound validation marker"
 
 	// +kubebuilder:validation:items:Minimum=0
 	// +kubebuilder:validation:items:Maximum=100
@@ -179,13 +179,13 @@ type TypeAliasFields struct {
 	// +kubebuilder:validation:Maximum=100
 	ValidAlias Int32Alias
 
-	InvalidAlias Int32Alias // want "field InvalidAlias type Int32Alias is missing minimum bounds validation marker" "field InvalidAlias type Int32Alias is missing maximum bounds validation marker"
+	InvalidAlias Int32Alias // want "TypeAliasFields.InvalidAlias is missing minimum bound validation marker" "TypeAliasFields.InvalidAlias is missing maximum bound validation marker"
 
-	InvalidAlias64 Int64Alias // want "field InvalidAlias64 type Int64Alias is missing minimum bounds validation marker" "field InvalidAlias64 type Int64Alias is missing maximum bounds validation marker"
+	InvalidAlias64 Int64Alias // want "TypeAliasFields.InvalidAlias64 is missing minimum bound validation marker" "TypeAliasFields.InvalidAlias64 is missing maximum bound validation marker"
 
-	InvalidAliasFloat32 Float32Alias // want "field InvalidAliasFloat32 type Float32Alias is missing minimum bounds validation marker" "field InvalidAliasFloat32 type Float32Alias is missing maximum bounds validation marker"
+	InvalidAliasFloat32 Float32Alias // want "TypeAliasFields.InvalidAliasFloat32 is missing minimum bound validation marker" "TypeAliasFields.InvalidAliasFloat32 is missing maximum bound validation marker"
 
-	InvalidAliasFloat64 Float64Alias // want "field InvalidAliasFloat64 type Float64Alias is missing minimum bounds validation marker" "field InvalidAliasFloat64 type Float64Alias is missing maximum bounds validation marker"
+	InvalidAliasFloat64 Float64Alias // want "TypeAliasFields.InvalidAliasFloat64 is missing minimum bound validation marker" "TypeAliasFields.InvalidAliasFloat64 is missing maximum bound validation marker"
 
 	// Valid: bounds are on the type alias itself
 	ValidBoundedAlias BoundedInt32Alias
@@ -199,10 +199,10 @@ type TypeAliasFields struct {
 
 // PointerSliceFields with pointer slices should also be checked
 type PointerSliceFields struct {
-	InvalidPointerSlice []*int32 // want "field InvalidPointerSlice array element pointer is missing minimum bounds validation marker" "field InvalidPointerSlice array element pointer is missing maximum bounds validation marker"
+	InvalidPointerSlice []*int32 // want "PointerSliceFields.InvalidPointerSlice is missing minimum bound validation marker" "PointerSliceFields.InvalidPointerSlice is missing maximum bound validation marker"
 }
 
-// K8sDeclarativeValidation with k8s declarative validation markers should work
+// K8sDeclarativeValidation with k8s declarative validation markers
 type K8sDeclarativeValidation struct {
 	// +k8s:minimum=0
 	// +k8s:maximum=100
@@ -217,7 +217,7 @@ type K8sDeclarativeValidation struct {
 type InvalidInt32BoundsOutOfRange struct {
 	// +kubebuilder:validation:Minimum=-3000000000
 	// +kubebuilder:validation:Maximum=3000000000
-	OutOfRange int32 // want "field OutOfRange has minimum bound -3e\\+09 that is outside the valid int32 range" "field OutOfRange has maximum bound 3e\\+09 that is outside the valid int32 range"
+	OutOfRange int32 // want "InvalidInt32BoundsOutOfRange.OutOfRange has minimum bound -3e\\+09 that is outside the int32 range \\[-2147483648, 2147483647\\]" "InvalidInt32BoundsOutOfRange.OutOfRange has maximum bound 3e\\+09 that is outside the int32 range \\[-2147483648, 2147483647\\]"
 }
 
 // MixedMarkersKubebuilderAndK8s can use either kubebuilder or k8s markers
@@ -225,4 +225,18 @@ type MixedMarkersKubebuilderAndK8s struct {
 	// +kubebuilder:validation:Minimum=0
 	// +k8s:maximum=100
 	MixedMarkers int32
+}
+
+// InvalidMarkerNonNumericMin has a non-numeric minimum value
+type InvalidMarkerNonNumericMin struct {
+	// +kubebuilder:validation:Minimum=invalid
+	// +kubebuilder:validation:Maximum=100
+	BadMin int32 // want "InvalidMarkerNonNumericMin.BadMin has an invalid minimum marker"
+}
+
+// InvalidMarkerNonNumericMax has a non-numeric maximum value
+type InvalidMarkerNonNumericMax struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=notanumber
+	BadMax int64 // want "InvalidMarkerNonNumericMax.BadMax has an invalid maximum marker"
 }

--- a/pkg/analysis/numericbounds/testdata/src/a/a.go
+++ b/pkg/analysis/numericbounds/testdata/src/a/a.go
@@ -145,10 +145,6 @@ type SliceFields struct {
 	InvalidSlice []int32 // want "SliceFields.InvalidSlice is missing minimum bound validation marker" "SliceFields.InvalidSlice is missing maximum bound validation marker"
 
 	InvalidSlice64 []int64 // want "SliceFields.InvalidSlice64 is missing minimum bound validation marker" "SliceFields.InvalidSlice64 is missing maximum bound validation marker"
-
-	// +kubebuilder:validation:items:Minimum=0
-	// +kubebuilder:validation:items:Maximum=100
-	ValidSliceWithBounds []int32
 }
 
 // TypeAliasFields with type aliases should be checked

--- a/pkg/analysis/utils/type_check.go
+++ b/pkg/analysis/utils/type_check.go
@@ -31,14 +31,16 @@ type TypeChecker interface {
 }
 
 // NewTypeChecker returns a new TypeChecker with the provided checkFunc.
-func NewTypeChecker(checkFunc func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, qualifiedFieldName string)) TypeChecker {
+func NewTypeChecker(isTypeFunc func(pass *analysis.Pass, ident ast.Expr) bool, checkFunc func(pass *analysis.Pass, expr ast.Expr, node ast.Node, prefix string)) TypeChecker {
 	return &typeChecker{
-		checkFunc: checkFunc,
+		isTypeFunc: isTypeFunc,
+		checkFunc:  checkFunc,
 	}
 }
 
 type typeChecker struct {
-	checkFunc func(pass *analysis.Pass, ident *ast.Ident, node ast.Node, qualifiedFieldName string)
+	isTypeFunc func(pass *analysis.Pass, expr ast.Expr) bool
+	checkFunc  func(pass *analysis.Pass, expr ast.Expr, node ast.Node, prefix string)
 }
 
 // CheckNode checks the provided node for built-in types.
@@ -84,6 +86,11 @@ func (t *typeChecker) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, no
 }
 
 func (t *typeChecker) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, prefix string) {
+	if t.isTypeFunc(pass, typeExpr) {
+		t.checkFunc(pass, typeExpr, node, prefix)
+		return
+	}
+
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
 		t.checkIdent(pass, typ, node, prefix)
@@ -102,12 +109,6 @@ func (t *typeChecker) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node
 // checkIdent calls the checkFunc with the ident, when we have hit a built-in type.
 // If the ident is not a built in, we look at the underlying type until we hit a built-in type.
 func (t *typeChecker) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, prefix string) {
-	if IsBasicType(pass, ident) {
-		// We've hit a built-in type, no need to check further.
-		t.checkFunc(pass, ident, node, prefix)
-		return
-	}
-
 	tSpec, ok := LookupTypeSpec(pass, ident)
 	if !ok {
 		return

--- a/pkg/analysis/utils/utils.go
+++ b/pkg/analysis/utils/utils.go
@@ -462,7 +462,7 @@ func isTypeBasic(t types.Type) bool {
 // It returns a nil value when the marker is not present, and an error
 // when the marker is present, but malformed.
 func GetMinProperties(markerSet markershelper.MarkerSet) (*int, error) {
-	minProperties, err := getMarkerNumericValueByName[int](markerSet, markers.KubebuilderMinPropertiesMarker)
+	minProperties, err := GetMarkerNumericValueByName[int](markerSet, markers.KubebuilderMinPropertiesMarker)
 	if err != nil && !errors.Is(err, errMarkerMissingValue) {
 		return nil, fmt.Errorf("invalid format for minimum properties marker: %w", err)
 	}

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -47,6 +47,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nophase"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/noreferences"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/numericbounds"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalfields"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/preferredmarkers"


### PR DESCRIPTION
## Numericbounds Linter

Adds a new analyzer that ensures `int32, int64, float32, float64` fields have both minimum and maximum bounds validation markers, following Kubernetes API conventions.

**What it checks**

- Both `Minimum` and `Maximum` markers are present on numeric fields
- Uses `items:Minimum` and `items:Maximum` for slice elements
- Unwraps pointers and slices


Fixes #18 