### PR TITLE
Skip statussubresource linting for Kubernetes List types

### DIFF
--- a/pkg/analysis/helpers/inspector/inspector.go
+++ b/pkg/analysis/helpers/inspector/inspector.go
@@ -117,7 +117,7 @@ func (i *inspector) shouldProcessField(stack []ast.Node, skipListTypes bool) boo
 		return false
 	}
 
-	if skipListTypes && isItemsType(structType) {
+	if skipListTypes && utils.IsKubernetesListType(structType, "") {
 		// Skip list types if requested.
 		return false
 	}
@@ -166,34 +166,6 @@ func (i *inspector) InspectTypeSpec(inspectTypeSpec func(typeSpec *ast.TypeSpec,
 
 		inspectTypeSpec(typeSpec, i.markers)
 	})
-}
-
-func isItemsType(structType *ast.StructType) bool {
-	// An items type is a struct with TypeMeta, ListMeta and Items fields.
-	if len(structType.Fields.List) != 3 {
-		return false
-	}
-
-	// Check if the first field is TypeMeta.
-	// This should be a selector (e.g. metav1.TypeMeta)
-	// Check the TypeMeta part as the package name may vary.
-	if typeMeta, ok := structType.Fields.List[0].Type.(*ast.SelectorExpr); !ok || typeMeta.Sel.Name != "TypeMeta" {
-		return false
-	}
-
-	// Check if the second field is ListMeta.
-	if listMeta, ok := structType.Fields.List[1].Type.(*ast.SelectorExpr); !ok || listMeta.Sel.Name != "ListMeta" {
-		return false
-	}
-
-	// Check if the third field is Items.
-	// It should be an array, and be called Items.
-	itemsField := structType.Fields.List[2]
-	if _, ok := itemsField.Type.(*ast.ArrayType); !ok || len(itemsField.Names) == 0 || itemsField.Names[0].Name != "Items" {
-		return false
-	}
-
-	return true
 }
 
 func isSchemalessType(markerSet markers.MarkerSet) bool {

--- a/pkg/analysis/statussubresource/testdata/src/a/a.go
+++ b/pkg/analysis/statussubresource/testdata/src/a/a.go
@@ -52,9 +52,124 @@ type FooBarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 type FooBarBaz struct { // want "root object type \"FooBarBaz\" is marked to enable the status subresource with marker \"kubebuilder:subresource:status\" but has no status field"
-    Spec FooBarBazSpec `json:"spec"`
+	Spec FooBarBazSpec `json:"spec"`
 }
 
 type FooBarBazSpec struct {
-    Name string `json:"name"`
+	Name string `json:"name"`
+}
+
+// Test that List types are skipped (issue #53)
+// This is a Kubernetes List type with TypeMeta, ListMeta, and Items
+// Even with space between marker and type definition, it should be skipped
+
+// +kubebuilder:object:root=true
+type ClusterList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    []Cluster `json:"items"`
+}
+
+type TypeMeta struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+}
+
+type ListMeta struct {
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
+type Cluster struct {
+	Name string `json:"name"`
+}
+
+// Test List type with qualified types (metav1.TypeMeta, metav1.ListMeta)
+// +kubebuilder:object:root=true
+type PodList struct {
+	metav1TypeMeta `json:",inline"`
+	metav1ListMeta `json:"metadata,omitempty"`
+	Items          []Pod `json:"items"`
+}
+
+type metav1TypeMeta struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+}
+
+type metav1ListMeta struct {
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
+type Pod struct {
+	Name string `json:"name"`
+}
+
+// Test that non-List types are not skipped even if they have 3 fields
+// This should trigger the linter because it has a status field but no marker
+// +kubebuilder:object:root=true
+type NotAList struct { // want "root object type \"NotAList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	Spec   NotAListSpec   `json:"spec"`
+	Status NotAListStatus `json:"status"`
+	Extra  string         `json:"extra"`
+}
+
+type NotAListSpec struct {
+	Name string `json:"name"`
+}
+
+type NotAListStatus struct {
+	Ready bool `json:"ready"`
+}
+
+// Test that types ending with "List" but not matching the pattern are not skipped
+// This has 4 fields instead of 3, so it should not be treated as a List type
+// +kubebuilder:object:root=true
+type BadList struct { // want "root object type \"BadList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    []string      `json:"items"`
+	Status   BadListStatus `json:"status"`
+}
+
+type BadListStatus struct {
+	Count int `json:"count"`
+}
+
+// Test that types ending with "List" but missing Items field are not skipped
+// +kubebuilder:object:root=true
+type IncompleteList struct { // want "root object type \"IncompleteList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Status   IncompleteListStatus `json:"status"`
+}
+
+type IncompleteListStatus struct {
+	Ready bool `json:"ready"`
+}
+
+// Test that types ending with "List" but with non-slice Items field are not skipped
+// Items must be a slice type to be considered a valid List type
+// +kubebuilder:object:root=true
+type NonSliceItemsList struct { // want "root object type \"NonSliceItemsList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    string         `json:"items"`
+	Status   NonSliceStatus `json:"status"`
+}
+
+type NonSliceStatus struct {
+	Count int `json:"count"`
+}
+
+// Test that List types with fields in non-standard order are still recognized
+// Fields can be in any order as long as they have TypeMeta, ListMeta, and Items
+// +kubebuilder:object:root=true
+type ReorderedFieldsList struct {
+	Items    []ReorderedItem `json:"items"`
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+}
+
+type ReorderedItem struct {
+	Name string `json:"name"`
 }

--- a/pkg/analysis/statussubresource/testdata/src/a/a.go.golden
+++ b/pkg/analysis/statussubresource/testdata/src/a/a.go.golden
@@ -53,9 +53,128 @@ type FooBarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 type FooBarBaz struct { // want "root object type \"FooBarBaz\" is marked to enable the status subresource with marker \"kubebuilder:subresource:status\" but has no status field"
-    Spec FooBarBazSpec `json:"spec"`
+	Spec FooBarBazSpec `json:"spec"`
 }
 
 type FooBarBazSpec struct {
-    Name string `json:"name"`
+	Name string `json:"name"`
+}
+
+// Test that List types are skipped (issue #53)
+// This is a Kubernetes List type with TypeMeta, ListMeta, and Items
+// Even with space between marker and type definition, it should be skipped
+
+// +kubebuilder:object:root=true
+type ClusterList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    []Cluster `json:"items"`
+}
+
+type TypeMeta struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+}
+
+type ListMeta struct {
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
+type Cluster struct {
+	Name string `json:"name"`
+}
+
+// Test List type with qualified types (metav1.TypeMeta, metav1.ListMeta)
+// +kubebuilder:object:root=true
+type PodList struct {
+	metav1TypeMeta `json:",inline"`
+	metav1ListMeta `json:"metadata,omitempty"`
+	Items          []Pod `json:"items"`
+}
+
+type metav1TypeMeta struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+}
+
+type metav1ListMeta struct {
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
+type Pod struct {
+	Name string `json:"name"`
+}
+
+// Test that non-List types are not skipped even if they have 3 fields
+// This should trigger the linter because it has a status field but no marker
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type NotAList struct { // want "root object type \"NotAList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	Spec   NotAListSpec   `json:"spec"`
+	Status NotAListStatus `json:"status"`
+	Extra  string         `json:"extra"`
+}
+
+type NotAListSpec struct {
+	Name string `json:"name"`
+}
+
+type NotAListStatus struct {
+	Ready bool `json:"ready"`
+}
+
+// Test that types ending with "List" but not matching the pattern are not skipped
+// This has 4 fields instead of 3, so it should not be treated as a List type
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type BadList struct { // want "root object type \"BadList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    []string      `json:"items"`
+	Status   BadListStatus `json:"status"`
+}
+
+type BadListStatus struct {
+	Count int `json:"count"`
+}
+
+// Test that types ending with "List" but missing Items field are not skipped
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type IncompleteList struct { // want "root object type \"IncompleteList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Status   IncompleteListStatus `json:"status"`
+}
+
+type IncompleteListStatus struct {
+	Ready bool `json:"ready"`
+}
+
+// Test that types ending with "List" but with non-slice Items field are not skipped
+// Items must be a slice type to be considered a valid List type
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type NonSliceItemsList struct { // want "root object type \"NonSliceItemsList\" has a status field but does not have the marker \"kubebuilder:subresource:status\" to enable the status subresource"
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    string         `json:"items"`
+	Status   NonSliceStatus `json:"status"`
+}
+
+type NonSliceStatus struct {
+	Count int `json:"count"`
+}
+
+// Test that List types with fields in non-standard order are still recognized
+// Fields can be in any order as long as they have TypeMeta, ListMeta, and Items
+// +kubebuilder:object:root=true
+type ReorderedFieldsList struct {
+	Items    []ReorderedItem `json:"items"`
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+}
+
+type ReorderedItem struct {
+	Name string `json:"name"`
 }


### PR DESCRIPTION
The `statussubresource` linter was incorrectly flagging Kubernetes List types that don't have a status field. List types follow a different pattern (TypeMeta, ListMeta, Items) and don't use the status subresource.

Fixes #53
