### PR TITLE
Added enums linter

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -343,19 +343,6 @@ This provides better API evolution, self-documentation, and validation compared 
 
 By default, `enums` is not enabled.
 
-### Configuration
-
-```yaml
-linterConfig:
-  enums:
-    allowlist:
-      - kubectl
-      - docker
-      - helm
-```
-
-The `allowlist` field contains enum values that should be exempt from PascalCase validation, such as command-line executable names.
-
 ## ForbiddenMarkers
 
 The `forbiddenmarkers` linter ensures that types and fields do not contain any markers that are forbidden.

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -337,11 +337,36 @@ If there are duplicates across fields and their underlying type, the marker on t
 
 ## Enums
 
-The `enums` linter enforces that enumerated fields use type aliases with the `+enum` marker and that enum values follow PascalCase naming conventions.
+The `enums` linter enforces that string type aliases used for enumerated values have proper enum markers.
 
-This provides better API evolution, self-documentation, and validation compared to plain strings.
+**Enum Marker Types:**
+- **Plain marker** (`+enum`): Primary Kubernetes idiom; auto-discovers constants and validates PascalCase.
+- **Declarative Validation Marker** (`+k8s:enum`): Used in Kubernetes core API types; auto-discovers constants.
+- **CRD Validation Marker** (`+kubebuilder:validation:Enum=Value1;Value2`): Used for CRD validation. Requires explicit values (no auto-discovery); marker values are validated for PascalCase.
 
-By default, `enums` is not enabled.
+**Enum Marker Modes:**
+- **Auto-discovery** (`+enum` or `+k8s:enum`): Validates that constants follow PascalCase.
+- **Explicit values** (`+kubebuilder:validation:Enum=Value1;Value2`): Validates the values listed in the marker for PascalCase; constants are not auto-discovered.
+
+**PascalCase allows:** "Pending", "PhaseRunning", "HTTP", "IPv4" (acronyms and digits).  
+**PascalCase rejects:** "pending", "phase_pending", "Phase-Failed".
+
+**Note:** The linter only flags string type aliases that have associated constants (indicating enum usage), avoiding false positives for generic string types.
+
+By default, `enums` is enabled.
+
+### Configuration
+
+```yaml
+linterConfig:
+  enums:
+    # Values exempt from PascalCase validation
+    allowlist:
+      - kubectl
+      - docker
+    # Require type aliases (RequireTypeAlias, default) or allow plain strings (AllowPlainString)
+    kubebuilderEnumPolicy: RequireTypeAlias
+```
 
 ## ForbiddenMarkers
 

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -35,6 +35,35 @@
 | [UniqueMarkers](#uniquemarkers) | Ensures unique marker definitions | True | Native, CRD |
 
 [^1]: Some linters are applicable only to Native (in-tree, go-validated APIs) or only to CRD (Custom Resource Definitions) APIs.
+- [ArrayOfStruct](#arrayofstruct) - Ensures arrays of structs have at least one required field
+- [Conditions](#conditions) - Checks that `Conditions` fields are correctly formatted
+- [CommentStart](#commentstart) - Ensures comments start with the serialized form of the type
+- [ConflictingMarkers](#conflictingmarkers) - Detects mutually exclusive markers on the same field
+- [DefaultOrRequired](#defaultorrequired) - Ensures fields marked as required do not have default values
+- [DuplicateMarkers](#duplicatemarkers) - Checks for exact duplicates of markers
+- [Enums](#enums) - Enforces proper usage of enumerated fields with type aliases and +enum marker
+- [DependentTags](#dependenttags) - Enforces dependencies between markers
+- [ForbiddenMarkers](#forbiddenmarkers) - Checks that no forbidden markers are present on types/fields.
+- [Integers](#integers) - Validates usage of supported integer types
+- [JSONTags](#jsontags) - Ensures proper JSON tag formatting
+- [MaxLength](#maxlength) - Checks for maximum length constraints on strings and arrays
+- [NamingConventions](#namingconventions) - Ensures field names adhere to user-defined naming conventions
+- [NoBools](#nobools) - Prevents usage of boolean types
+- [NoDurations](#nodurations) - Prevents usage of duration types
+- [NoFloats](#nofloats) - Prevents usage of floating-point types
+- [Nomaps](#nomaps) - Restricts usage of map types
+- [NoNullable](#nonullable) - Prevents usage of the nullable marker
+- [Nophase](#nophase) - Prevents usage of 'Phase' fields
+- [Notimestamp](#notimestamp) - Prevents usage of 'TimeStamp' fields
+- [OptionalFields](#optionalfields) - Validates optional field conventions
+- [OptionalOrRequired](#optionalorrequired) - Ensures fields are explicitly marked as optional or required
+- [NoReferences](#noreferences) - Ensures field names use Ref/Refs instead of Reference/References
+- [PreferredMarkers](#preferredmarkers) - Ensures preferred markers are used instead of equivalent markers
+- [RequiredFields](#requiredfields) - Validates required field conventions
+- [SSATags](#ssatags) - Ensures proper Server-Side Apply (SSA) tags on array fields
+- [StatusOptional](#statusoptional) - Ensures status fields are marked as optional
+- [StatusSubresource](#statussubresource) - Validates status subresource configuration
+- [UniqueMarkers](#uniquemarkers) - Ensures unique marker definitions
 
 ## ArrayOfStruct
 
@@ -305,6 +334,27 @@ will not.
 
 The `duplicatemarkers` linter can automatically fix all markers that are exact match to another markers.
 If there are duplicates across fields and their underlying type, the marker on the type will be preferred and the marker on the field will be removed.
+
+## Enums
+
+The `enums` linter enforces that enumerated fields use type aliases with the `+enum` marker and that enum values follow PascalCase naming conventions.
+
+This provides better API evolution, self-documentation, and validation compared to plain strings.
+
+By default, `enums` is not enabled.
+
+### Configuration
+
+```yaml
+linterConfig:
+  enums:
+    allowlist:
+      - kubectl
+      - docker
+      - helm
+```
+
+The `allowlist` field contains enum values that should be exempt from PascalCase validation, such as command-line executable names.
 
 ## ForbiddenMarkers
 

--- a/pkg/analysis/enums/analyzer.go
+++ b/pkg/analysis/enums/analyzer.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package enums
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+	"unicode"
+
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+const (
+	name = "enums"
+)
+
+type analyzer struct {
+	config *Config
+}
+
+// newAnalyzer creates a new analysis.Analyzer for the enums linter based on the provided config.
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	a := &analyzer{
+		config: cfg,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Enforces that enumerated fields use type aliases with +enum marker and have PascalCase values",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	// Check struct fields for proper enum usage
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+		a.checkField(pass, field, markersAccess)
+	})
+
+	// Check type declarations for +enum markers
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
+		a.checkTypeSpec(pass, typeSpec, markersAccess)
+	})
+
+	// Check const values for PascalCase
+	a.checkConstValues(pass, inspect)
+
+	return nil, nil //nolint:nilnil
+}
+
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers) {
+	fieldName := utils.FieldName(field)
+	if fieldName == "" {
+		return
+	}
+	// Get the underlying type, unwrapping pointers and arrays
+	fieldType, isArray := unwrapTypeWithArrayTracking(field.Type)
+	ident, ok := fieldType.(*ast.Ident)
+	if !ok {
+		return
+	}
+
+	// Build appropriate prefix for error messages
+	prefix := fmt.Sprintf("field %s", fieldName)
+	if isArray {
+		prefix = fmt.Sprintf("field %s array element", fieldName)
+	}
+
+	// Check if it's a basic string type
+	if ident.Name == "string" && utils.IsBasicType(pass, ident) {
+		// Check if the field has an enum marker directly
+		fieldMarkers := markersAccess.FieldMarkers(field)
+		if !hasEnumMarker(fieldMarkers) {
+			pass.Reportf(field.Pos(),
+				"%s uses plain string without +enum marker. Enumerated fields should use a type alias with +enum marker",
+				prefix)
+		}
+		return
+	}
+	// If it's a type alias, check that the alias has an enum marker
+	if !utils.IsBasicType(pass, ident) {
+		typeSpec, ok := utils.LookupTypeSpec(pass, ident)
+		if !ok {
+			return
+		}
+		// Check if the underlying type is string
+		if !isStringTypeAlias(pass, typeSpec) {
+			return
+		}
+		// Check if the type has an enum marker
+		typeMarkers := markersAccess.TypeMarkers(typeSpec)
+		if !hasEnumMarker(typeMarkers) {
+			pass.Reportf(field.Pos(),
+				"%s uses type %s which appears to be an enum but is missing +enum marker (kubebuilder:validation:Enum)",
+				prefix, typeSpec.Name.Name)
+		}
+	}
+}
+
+func (a *analyzer) checkTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
+	if typeSpec.Name == nil {
+		return
+	}
+	typeMarkers := markersAccess.TypeMarkers(typeSpec)
+	if !hasEnumMarker(typeMarkers) {
+		return
+	}
+
+	// Has +enum marker, verify it's a string type
+	if !isStringTypeAlias(pass, typeSpec) {
+		pass.Reportf(typeSpec.Pos(),
+			"type %s has +enum marker but underlying type is not string",
+			typeSpec.Name.Name)
+	}
+}
+
+func (a *analyzer) checkConstValues(pass *analysis.Pass, inspect inspector.Inspector) {
+	// We need to check const declarations, but the inspector helper doesn't
+	// have a method for this, so we'll iterate through files manually
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok.String() != "const" {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				a.checkConstSpec(pass, valueSpec)
+			}
+		}
+	}
+}
+
+func (a *analyzer) checkConstSpec(pass *analysis.Pass, valueSpec *ast.ValueSpec) {
+	for i, name := range valueSpec.Names {
+		if name == nil {
+			continue
+		}
+		// Get the type of the constant
+		obj := pass.TypesInfo.ObjectOf(name)
+		if obj == nil {
+			continue
+		}
+		constObj, ok := obj.(*types.Const)
+		if !ok {
+			continue
+		}
+		// Check if the type is a named type (potential enum)
+		namedType, ok := constObj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		// Check if the type is in the current package
+		if namedType.Obj().Pkg() == nil || namedType.Obj().Pkg() != pass.Pkg {
+			continue
+		}
+		// Find the type spec for this named type
+		typeSpec := findTypeSpecByName(pass, namedType.Obj().Name())
+		if typeSpec == nil {
+			continue
+		}
+		// Check if this type has an enum marker
+		if !hasEnumMarkerOnTypeSpec(pass, typeSpec) {
+			continue
+		}
+		// This is an enum constant, validate the value
+		if i >= len(valueSpec.Values) {
+			continue
+		}
+		value := valueSpec.Values[i]
+		basicLit, ok := value.(*ast.BasicLit)
+		if !ok {
+			continue
+		}
+		// Extract the string value (remove quotes)
+		strValue := strings.Trim(basicLit.Value, `"`)
+		// Check if it's in the allowlist
+		if a.isInAllowlist(strValue) {
+			continue
+		}
+		// Validate PascalCase
+		if !isPascalCase(strValue) {
+			pass.Reportf(basicLit.Pos(),
+				"enum value %q should be PascalCase (e.g., \"PhasePending\", \"StateRunning\")",
+				strValue)
+		}
+	}
+}
+
+// unwrapType removes pointer and array wrappers to get the underlying type
+func unwrapType(expr ast.Expr) ast.Expr {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		return unwrapType(t.X)
+	case *ast.ArrayType:
+		return unwrapType(t.Elt)
+	default:
+		return expr
+	}
+}
+
+// unwrapTypeWithArrayTracking removes pointer and array wrappers to get the underlying type
+// and tracks whether an array was encountered during unwrapping.
+func unwrapTypeWithArrayTracking(expr ast.Expr) (ast.Expr, bool) {
+	isArray := false
+	for {
+		switch t := expr.(type) {
+		case *ast.StarExpr:
+			expr = t.X
+		case *ast.ArrayType:
+			expr = t.Elt
+			isArray = true
+		default:
+			return expr, isArray
+		}
+	}
+}
+
+// isStringTypeAlias checks if a type spec is an alias for string
+func isStringTypeAlias(pass *analysis.Pass, typeSpec *ast.TypeSpec) bool {
+	underlyingType := unwrapType(typeSpec.Type)
+	ident, ok := underlyingType.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "string" && utils.IsBasicType(pass, ident)
+}
+
+// hasEnumMarker checks if a marker set contains an enum marker
+func hasEnumMarker(markerSet markershelper.MarkerSet) bool {
+	return markerSet.Has(markers.KubebuilderEnumMarker) || markerSet.Has(markers.K8sEnumMarker)
+}
+
+// hasEnumMarkerOnTypeSpec checks if a type spec has an enum marker by checking its doc comments
+func hasEnumMarkerOnTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec) bool {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				if spec == typeSpec {
+					if genDecl.Doc != nil {
+						for _, comment := range genDecl.Doc.List {
+							if strings.Contains(comment.Text, markers.KubebuilderEnumMarker) ||
+								strings.Contains(comment.Text, markers.K8sEnumMarker) {
+								return true
+							}
+						}
+					}
+					return false
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isInAllowlist checks if a value is in the configured allowlist
+func (a *analyzer) isInAllowlist(value string) bool {
+	if a.config == nil {
+		return false
+	}
+	for _, allowed := range a.config.Allowlist {
+		if value == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// findTypeSpecByName searches through the AST files to find a TypeSpec by name
+func findTypeSpecByName(pass *analysis.Pass, typeName string) *ast.TypeSpec {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if typeSpec.Name != nil && typeSpec.Name.Name == typeName {
+					return typeSpec
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// isPascalCase validates that a string follows PascalCase convention
+// PascalCase: FirstLetterUpperCase, no underscores, no hyphens
+func isPascalCase(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// First character must be uppercase
+	if !unicode.IsUpper(rune(s[0])) {
+		return false
+	}
+	// Check for invalid characters (underscores, hyphens)
+	for _, r := range s {
+		if r == '_' || r == '-' {
+			return false
+		}
+		// Only allow letters and digits
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	// Should not be all uppercase (that's SCREAMING_SNAKE_CASE or similar)
+	allUpper := true
+	for _, r := range s[1:] {
+		if unicode.IsLower(r) {
+			allUpper = false
+			break
+		}
+	}
+	if allUpper && len(s) > 1 {
+		return false
+	}
+	return true
+}

--- a/pkg/analysis/enums/analyzer.go
+++ b/pkg/analysis/enums/analyzer.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
+	"regexp"
 	"slices"
 	"strings"
-	"unicode"
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
@@ -34,6 +34,15 @@ import (
 
 const name = "enums"
 
+func init() {
+	// Register enum markers so they can be parsed
+	markershelper.DefaultRegistry().Register(
+		markers.EnumMarker,
+		markers.KubebuilderEnumMarker,
+		markers.K8sEnumMarker,
+	)
+}
+
 type analyzer struct {
 	config *Config
 }
@@ -43,9 +52,9 @@ func newAnalyzer(cfg *Config) *analysis.Analyzer {
 
 	return &analysis.Analyzer{
 		Name:     name,
-		Doc:      "Enforces that enumerated fields use type aliases with +enum marker and have PascalCase values",
+		Doc:      "Enforces that string type aliases with constants have enum markers (+enum, +k8s:enum, or +kubebuilder:validation:Enum=...) and that enum values follow PascalCase conventions",
 		Run:      a.run,
-		Requires: []*analysis.Analyzer{inspector.Analyzer},
+		Requires: []*analysis.Analyzer{inspector.Analyzer, markershelper.Analyzer},
 	}
 }
 
@@ -55,52 +64,56 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
+	markersAccess, ok := pass.ResultOf[markershelper.Analyzer].(markershelper.Markers)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
 	// Check struct fields for proper enum usage
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, _ string) {
-		a.checkField(pass, field, markersAccess)
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markers markershelper.Markers, qualifiedFieldName string) {
+		a.checkField(pass, field, markers, qualifiedFieldName)
 	})
 
-	// Check type declarations for +enum markers
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
-		a.checkTypeSpec(pass, typeSpec, markersAccess)
+	// Check type declarations for enum markers
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markers markershelper.Markers) {
+		a.checkTypeSpec(pass, typeSpec, markers)
 	})
-	a.checkConstValues(pass)
+
+	a.checkConstValues(pass, markersAccess)
 
 	return nil, nil //nolint:nilnil
 }
 
-func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers) {
-	fieldName := utils.FieldName(field)
-	if fieldName == "" {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+	if qualifiedFieldName == "" {
 		return
 	}
 
-	// Get the underlying type, unwrapping pointers and arrays
 	fieldType, isArray := unwrapTypeWithArrayTracking(field.Type)
-
 	ident, ok := fieldType.(*ast.Ident)
 
 	if !ok {
 		return
 	}
 
-	prefix := buildFieldPrefix(fieldName, isArray)
+	prefix := buildFieldPrefix(qualifiedFieldName, isArray)
 
-	// Check if it's a plain string (basic type) vs. a type alias
-	if ident.Name == "string" && utils.IsBasicType(pass, ident) {
-		a.checkPlainStringField(pass, field, markersAccess, prefix)
+	// Plain string type (ident.Name is always "string" for built-in; IsBasicType would be redundant here)
+	if ident.Name == "string" {
+		if a.config != nil && a.config.KubebuilderEnumPolicy == KubebuilderEnumPolicyRequireTypeAlias {
+			a.checkPlainStringField(pass, field, markersAccess, prefix)
+		}
 
 		return
 	}
 
-	// Check if it's a type alias that might be an enum
 	a.checkTypeAliasField(pass, field, ident, markersAccess, prefix)
 }
 
 func (a *analyzer) checkPlainStringField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, prefix string) {
 	if !hasEnumMarker(markersAccess.FieldMarkers(field)) {
 		pass.Reportf(field.Pos(),
-			"%s uses plain string without +enum marker. Enumerated fields should use a type alias with +enum marker",
+			"%s uses plain string type. Consider using a type alias with an enum marker (+enum, +k8s:enum, or +kubebuilder:validation:Enum=...)",
 			prefix)
 	}
 }
@@ -111,14 +124,17 @@ func (a *analyzer) checkTypeAliasField(pass *analysis.Pass, field *ast.Field, id
 	}
 
 	typeSpec, ok := utils.LookupTypeSpec(pass, ident)
-
 	if !ok || !isStringTypeAlias(pass, typeSpec) {
 		return
 	}
-
+	// Only check if this type has constants (indicating enum usage)
+	if !typeHasConstants(pass, typeSpec.Name.Name) {
+		return
+	}
+	// Check for enum markers (+enum, +k8s:enum, or +kubebuilder:validation:Enum)
 	if !hasEnumMarker(markersAccess.TypeMarkers(typeSpec)) {
 		pass.Reportf(field.Pos(),
-			"%s uses type %s which appears to be an enum but is missing +enum marker (kubebuilder:validation:Enum)",
+			"%s uses type %s which appears to be an enum but is missing an enum marker (+enum, +k8s:enum, or +kubebuilder:validation:Enum=...)",
 			prefix, typeSpec.Name.Name)
 	}
 }
@@ -136,12 +152,34 @@ func (a *analyzer) checkTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec, ma
 
 	if !isStringTypeAlias(pass, typeSpec) {
 		pass.Reportf(typeSpec.Pos(),
-			"type %s has +enum marker but underlying type is not string",
+			"type %s has enum marker but underlying type is not string",
 			typeSpec.Name.Name)
+
+		return
+	}
+
+	// Validate explicit values in +kubebuilder:validation:Enum=value1;value2
+	for _, m := range typeMarkers.Get(markers.KubebuilderEnumMarker) {
+		if m.Payload.Value == "" {
+			continue
+		}
+
+		for _, val := range strings.Split(m.Payload.Value, ";") {
+			val = strings.TrimSpace(val)
+			if val == "" {
+				continue
+			}
+
+			if !a.isInAllowlist(val) && !isPascalCase(val) {
+				pass.Reportf(typeSpec.Pos(),
+					"enum value %q in marker should be PascalCase (e.g., \"PhasePending\", \"StateRunning\")",
+					val)
+			}
+		}
 	}
 }
 
-func (a *analyzer) checkConstValues(pass *analysis.Pass) {
+func (a *analyzer) checkConstValues(pass *analysis.Pass, markersAccess markershelper.Markers) {
 	for _, file := range pass.Files {
 		for _, decl := range file.Decls {
 			genDecl, ok := decl.(*ast.GenDecl)
@@ -151,25 +189,25 @@ func (a *analyzer) checkConstValues(pass *analysis.Pass) {
 
 			for _, spec := range genDecl.Specs {
 				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
-					a.checkConstSpec(pass, valueSpec)
+					a.checkConstSpec(pass, valueSpec, markersAccess)
 				}
 			}
 		}
 	}
 }
 
-func (a *analyzer) checkConstSpec(pass *analysis.Pass, valueSpec *ast.ValueSpec) {
+func (a *analyzer) checkConstSpec(pass *analysis.Pass, valueSpec *ast.ValueSpec, markersAccess markershelper.Markers) {
 	for i, name := range valueSpec.Names {
-		a.validateEnumConstant(pass, name, valueSpec, i)
+		a.validateEnumConstant(pass, name, valueSpec, i, markersAccess)
 	}
 }
 
-func (a *analyzer) validateEnumConstant(pass *analysis.Pass, name *ast.Ident, valueSpec *ast.ValueSpec, index int) {
+func (a *analyzer) validateEnumConstant(pass *analysis.Pass, name *ast.Ident, valueSpec *ast.ValueSpec, index int, markersAccess markershelper.Markers) {
 	if name == nil || index >= len(valueSpec.Values) {
 		return
 	}
 
-	typeSpec := a.getEnumTypeSpec(pass, name)
+	typeSpec := a.getEnumTypeSpec(pass, name, markersAccess)
 	if typeSpec == nil {
 		return
 	}
@@ -189,20 +227,20 @@ func (a *analyzer) validateEnumConstant(pass *analysis.Pass, name *ast.Ident, va
 	}
 }
 
-func (a *analyzer) getEnumTypeSpec(pass *analysis.Pass, name *ast.Ident) *ast.TypeSpec {
+func (a *analyzer) getEnumTypeSpec(pass *analysis.Pass, name *ast.Ident, markersAccess markershelper.Markers) *ast.TypeSpec {
 	constObj, ok := pass.TypesInfo.ObjectOf(name).(*types.Const)
 	if !ok {
 		return nil
 	}
 
 	namedType, ok := constObj.Type().(*types.Named)
+
 	if !ok || namedType.Obj().Pkg() == nil || namedType.Obj().Pkg() != pass.Pkg {
 		return nil
 	}
 
 	typeSpec := findTypeSpecByName(pass, namedType.Obj().Name())
-
-	if typeSpec == nil || !hasEnumMarkerOnTypeSpec(pass, typeSpec) {
+	if typeSpec == nil || !usesAutoDiscovery(markersAccess, typeSpec) {
 		return nil
 	}
 
@@ -261,61 +299,41 @@ func unwrapTypeWithArrayTracking(expr ast.Expr) (ast.Expr, bool) {
 // isStringTypeAlias checks if a type spec is a string type alias.
 func isStringTypeAlias(pass *analysis.Pass, typeSpec *ast.TypeSpec) bool {
 	underlyingType := unwrapType(typeSpec.Type)
-
 	ident, ok := underlyingType.(*ast.Ident)
 
 	if !ok {
 		return false
 	}
 
+	// Both checks are needed: name check is fast, IsBasicType handles edge cases
+	// where 'string' might be redefined (rare but possible)
 	return ident.Name == "string" && utils.IsBasicType(pass, ident)
 }
 
-// hasEnumMarker checks if a marker set contains enum markers.
+// hasEnumMarker checks if a marker set contains enum markers
+// (+enum, +kubebuilder:validation:Enum, or +k8s:enum).
 func hasEnumMarker(markerSet markershelper.MarkerSet) bool {
-	return markerSet.Has(markers.KubebuilderEnumMarker) || markerSet.Has(markers.K8sEnumMarker)
+	return markerSet.Has(markers.EnumMarker) ||
+		markerSet.Has(markers.KubebuilderEnumMarker) ||
+		markerSet.Has(markers.K8sEnumMarker)
 }
 
-// hasEnumMarkerOnTypeSpec checks if a type spec has enum markers in its documentation.
-func hasEnumMarkerOnTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec) bool {
-	for _, file := range pass.Files {
-		if genDecl := findGenDeclForSpec(file, typeSpec); genDecl != nil {
-			return hasEnumMarkerInDoc(genDecl.Doc)
-		}
+// usesAutoDiscovery checks if a type's constants should be validated for PascalCase.
+// Returns true for +enum, +k8s:enum, and +kubebuilder:validation:Enum (we validate both
+// marker values and constant values for PascalCase when the type has constants).
+func usesAutoDiscovery(markersAccess markershelper.Markers, typeSpec *ast.TypeSpec) bool {
+	typeMarkers := markersAccess.TypeMarkers(typeSpec)
+
+	if typeMarkers.Has(markers.EnumMarker) {
+		return true
 	}
 
-	return false
-}
-
-// findGenDeclForSpec finds the GenDecl that contains a given TypeSpec.
-func findGenDeclForSpec(file *ast.File, typeSpec *ast.TypeSpec) *ast.GenDecl {
-	for _, decl := range file.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-
-		for _, spec := range genDecl.Specs {
-			if spec == typeSpec {
-				return genDecl
-			}
-		}
+	if typeMarkers.Has(markers.K8sEnumMarker) {
+		return true
 	}
 
-	return nil
-}
-
-// hasEnumMarkerInDoc checks if a comment group contains enum markers.
-func hasEnumMarkerInDoc(doc *ast.CommentGroup) bool {
-	if doc == nil {
-		return false
-	}
-
-	for _, comment := range doc.List {
-		text := comment.Text
-		if strings.Contains(text, markers.KubebuilderEnumMarker) || strings.Contains(text, markers.K8sEnumMarker) {
-			return true
-		}
+	if typeMarkers.Has(markers.KubebuilderEnumMarker) {
+		return true
 	}
 
 	return false
@@ -346,31 +364,38 @@ func findTypeSpecByName(pass *analysis.Pass, typeName string) *ast.TypeSpec {
 	return nil
 }
 
+// typeHasConstants checks if any constants are defined for the given type name.
+func typeHasConstants(pass *analysis.Pass, typeName string) bool {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+
+			if !ok || genDecl.Tok.String() != "const" {
+				continue
+			}
+
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok || valueSpec.Type == nil {
+					continue
+				}
+				// Check if the const has this type
+				if ident, ok := valueSpec.Type.(*ast.Ident); ok && ident.Name == typeName {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// pascalCaseRegex matches PascalCase: starts with uppercase, then letters, digits, or "+".
+// Allows: PascalCase (Running), all-uppercase acronyms (HTTP, API), single letters (A), signal names (SIGRTMIN+1).
+// Rejects: lowercase start (running), snake_case (phase_pending), kebab-case (phase-pending).
+var pascalCaseRegex = regexp.MustCompile(`^[A-Z][A-Za-z0-9+]*$`)
+
 // isPascalCase checks if a string follows PascalCase naming convention.
 func isPascalCase(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-
-	if !unicode.IsUpper(rune(s[0])) {
-		return false
-	}
-
-	hasLower := false
-
-	for _, r := range s {
-		if r == '_' || r == '-' {
-			return false
-		}
-
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			return false
-		}
-
-		if unicode.IsLower(r) {
-			hasLower = true
-		}
-	}
-
-	return len(s) == 1 || hasLower
+	return len(s) > 0 && pascalCaseRegex.MatchString(s)
 }

--- a/pkg/analysis/enums/analyzer_test.go
+++ b/pkg/analysis/enums/analyzer_test.go
@@ -28,6 +28,7 @@ func TestAnalyzer(t *testing.T) {
 	// Test without allowlist
 	config := &enums.Config{}
 	analyzer, err := enums.Initializer().Init(config)
+
 	if err != nil {
 		t.Fatalf("initializing enums linter: %v", err)
 	}

--- a/pkg/analysis/enums/analyzer_test.go
+++ b/pkg/analysis/enums/analyzer_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package enums_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/enums"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	// Test without allowlist
+	config := &enums.Config{}
+	analyzer, err := enums.Initializer().Init(config)
+	if err != nil {
+		t.Fatalf("initializing enums linter: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "a")
+}
+
+func TestAnalyzerWithAllowlist(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	// Test with allowlist
+	config := &enums.Config{
+		Allowlist: []string{"kubectl", "docker", "helm"},
+	}
+
+	analyzer, err := enums.Initializer().Init(config)
+	if err != nil {
+		t.Fatalf("initializing enums linter: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "b")
+}

--- a/pkg/analysis/enums/analyzer_test.go
+++ b/pkg/analysis/enums/analyzer_test.go
@@ -25,8 +25,10 @@ import (
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
 
-	// Test without allowlist
-	config := &enums.Config{}
+	// Test with default config (plain strings allowed)
+	config := &enums.Config{
+		KubebuilderEnumPolicy: enums.KubebuilderEnumPolicyAllowPlainString,
+	}
 	analyzer, err := enums.Initializer().Init(config)
 
 	if err != nil {

--- a/pkg/analysis/enums/config.go
+++ b/pkg/analysis/enums/config.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package enums
+
+// Config is the configuration for the enums linter.
+type Config struct {
+	// Allowlist contains values that are exempt from PascalCase validation.
+	// This is useful for command-line executable names like "kubectl", "docker", etc.
+	Allowlist []string `yaml:"allowlist" json:"allowlist"`
+}

--- a/pkg/analysis/enums/config.go
+++ b/pkg/analysis/enums/config.go
@@ -15,9 +15,24 @@ limitations under the License.
 */
 package enums
 
+// KubebuilderEnumPolicy controls whether plain string fields with enum markers are allowed.
+type KubebuilderEnumPolicy string
+
+const (
+	// KubebuilderEnumPolicyRequireTypeAlias enforces that string fields representing enums
+	// must use type aliases instead of plain string types.
+	KubebuilderEnumPolicyRequireTypeAlias KubebuilderEnumPolicy = "RequireTypeAlias"
+	// KubebuilderEnumPolicyAllowPlainString allows plain string types for enum-validated fields.
+	KubebuilderEnumPolicyAllowPlainString KubebuilderEnumPolicy = "AllowPlainString"
+)
+
 // Config is the configuration for the enums linter.
 type Config struct {
 	// Allowlist contains values that are exempt from PascalCase validation.
 	// This is useful for command-line executable names like "kubectl", "docker", etc.
 	Allowlist []string `yaml:"allowlist" json:"allowlist"`
+
+	// KubebuilderEnumPolicy controls whether string fields with enum validation must use type aliases.
+	// RequireTypeAlias (default): enforce type aliases; AllowPlainString: allow plain strings.
+	KubebuilderEnumPolicy KubebuilderEnumPolicy `yaml:"kubebuilderEnumPolicy" json:"kubebuilderEnumPolicy"`
 }

--- a/pkg/analysis/enums/doc.go
+++ b/pkg/analysis/enums/doc.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+enums is an analyzer that enforces proper usage of enumerated fields in Kubernetes APIs.
+
+Enumerated fields provide better API evolution and self-documentation compared to plain strings.
+By using type aliases with explicit enum markers, the API schema can include valid values and
+provide better validation at the schema level.
+
+# Rules
+
+The linter checks for three main patterns:
+1. Fields must use type aliases, not plain strings: String fields that represent enums should
+use a type alias with an +enum marker rather than a raw string type.
+2. Type aliases must have +enum marker: Type aliases used for enumerated values must be
+annotated with either // +kubebuilder:validation:Enum or // +k8s:enum.
+3. Enum values must be PascalCase: Constant values for enums should follow PascalCase naming
+(e.g., "PhasePending", "StateRunning") rather than lowercase, snake_case, or SCREAMING_SNAKE_CASE.
+
+# Examples
+
+Good:
+
+	// +kubebuilder:validation:Enum
+	type Phase string
+	const (
+		PhasePending   Phase = "Pending"
+		PhaseRunning   Phase = "Running"
+		PhaseSucceeded Phase = "Succeeded"
+	)
+	type MySpec struct {
+		Phase Phase
+	}
+
+Bad:
+
+	// Missing +enum marker
+	type Phase string
+	type MySpec struct {
+		// Plain string without type alias
+		Phase string
+	}
+	// Values not PascalCase
+	const (
+		phase_pending Phase = "pending"      // Should be "Pending"
+		PHASE_RUNNING Phase = "RUNNING"      // Should be "Running"
+	)
+
+# Configuration
+
+The linter supports an allowlist for enum values that should be exempt from PascalCase
+validation, such as command-line executable names:
+
+	linterConfig:
+	  enums:
+	    allowlist:
+	      - kubectl
+	      - docker
+	      - helm
+
+# Rationale
+
+Using type aliases for enums instead of raw strings provides several benefits:
+- API schemas can explicitly list valid enum values
+- Better validation at both the schema and runtime level
+- Improved documentation and API evolution
+- Stronger type safety in generated clients
+- Clearer intent for API consumers
+
+The PascalCase convention for enum values aligns with Kubernetes API conventions and
+improves readability and consistency across the ecosystem.
+
+Note: This linter is disabled by default as enum usage is recommended but not strictly
+required for all Kubernetes APIs. Enable it in your configuration to enforce these conventions.
+*/
+package enums

--- a/pkg/analysis/enums/doc.go
+++ b/pkg/analysis/enums/doc.go
@@ -23,24 +23,68 @@ provide better validation at the schema level.
 
 # Rules
 
-The linter checks for three main patterns:
-1. Fields must use type aliases, not plain strings: String fields that represent enums should
-use a type alias with an +enum marker rather than a raw string type.
-2. Type aliases must have +enum marker: Type aliases used for enumerated values must be
-annotated with either // +kubebuilder:validation:Enum or // +k8s:enum.
-3. Enum values must be PascalCase: Constant values for enums should follow PascalCase naming
-(e.g., "PhasePending", "StateRunning") rather than lowercase, snake_case, or SCREAMING_SNAKE_CASE.
+1. String type aliases that have associated constants must be annotated with an enum marker:
+  - +enum (plain marker, recommended primary idiom)
+  - +k8s:enum for declarative validation (used in Kubernetes core API types)
+  - +kubebuilder:validation:Enum=Value1;Value2 for CRD validation (used in projects with CustomResourceDefinitions)
+
+2. Enum constant values must follow PascalCase when using auto-discovery mode.
+Valid: "Pending", "Running", "HTTP", "HTTPS" (acronyms allowed).
+Invalid: "pending", "phase_pending", "Phase-Failed" (snake_case/kebab-case).
+
+3. (Optional) When KubebuilderEnumPolicy is RequireTypeAlias: String fields without enum markers
+should use type aliases instead of plain string types.
+
+The linter only flags type aliases that have constants defined, avoiding false positives
+for generic string wrapper types.
+
+# Enum Marker Types
+
+The linter recognizes three enum markers:
+
++enum (Primary Kubernetes idiom):
+- Plain marker, the canonical/recommended approach
+- Auto-discovers constants and validates them as PascalCase
+
++k8s:enum (Declarative validation for core APIs):
+- Used in Kubernetes core API types (in-tree APIs)
+- Auto-discovers constants and validates them as PascalCase
+
++kubebuilder:validation:Enum (CRD OpenAPI schema validation):
+- Used in projects with CustomResourceDefinitions
+- Processed by controller-gen to generate OpenAPI schema validation
+- REQUIRES explicit values: +kubebuilder:validation:Enum=Value1;Value2;Value3
+- Does NOT auto-discover constants
+- The explicit values in the marker are validated as PascalCase
+
+Examples:
+
+Auto-discovery (validates constants):
+
+	// +enum                    ← Primary Kubernetes idiom (recommended)
+	// +k8s:enum                ← Alternative for core APIs
+	type Phase string
+	const (
+		PhasePending Phase = "Pending"  ← These must be PascalCase
+	)
+
+Explicit values (validates marker values, not constants):
+
+	// +kubebuilder:validation:Enum=Pending;Running;Failed  ← For CRD schema validation
+	type Phase string
+	const (
+		helper Phase = "helper"  ← Constants not checked; marker values are validated
+	)
 
 # Examples
 
 Good:
 
-	// +kubebuilder:validation:Enum
+	// +enum  (or // +kubebuilder:validation:Enum for CRDs, // +k8s:enum for core APIs)
 	type Phase string
 	const (
-		PhasePending   Phase = "Pending"
-		PhaseRunning   Phase = "Running"
-		PhaseSucceeded Phase = "Succeeded"
+		PhasePending Phase = "Pending"
+		PhaseRunning Phase = "Running"
 	)
 	type MySpec struct {
 		Phase Phase
@@ -48,33 +92,33 @@ Good:
 
 Bad:
 
-	// Missing +enum marker
+	// String type alias with constants but missing enum marker
 	type Phase string
-	type MySpec struct {
-		// Plain string without type alias
-		Phase string
-	}
-	// Values not PascalCase
 	const (
 		phase_pending Phase = "pending"      // Should be "Pending"
-		PHASE_RUNNING Phase = "RUNNING"      // Should be "Running"
+		phase_running Phase = "phase_running" // Should be "PhaseRunning"
+		Phase_Failed  Phase = "Phase-Failed"  // Should be "PhaseFailed"
 	)
+
+Note: Acronyms (HTTP, HTTPS, API) are allowed. The linter only flags type aliases with
+constants, not all string types.
 
 # Configuration
 
-The linter supports an allowlist for enum values that should be exempt from PascalCase
-validation, such as command-line executable names:
+Configuration options:
 
 	linterConfig:
 	  enums:
+	    # Values exempt from PascalCase validation
 	    allowlist:
 	      - kubectl
 	      - docker
-	      - helm
+	    # Require type aliases (RequireTypeAlias, default) or allow plain strings (AllowPlainString)
+	    kubebuilderEnumPolicy: RequireTypeAlias
 
 # Rationale
 
-Using type aliases for enums instead of raw strings provides several benefits:
+Using type aliases with enum markers instead of raw strings provides several benefits:
 - API schemas can explicitly list valid enum values
 - Better validation at both the schema and runtime level
 - Improved documentation and API evolution
@@ -84,7 +128,11 @@ Using type aliases for enums instead of raw strings provides several benefits:
 The PascalCase convention for enum values aligns with Kubernetes API conventions and
 improves readability and consistency across the ecosystem.
 
-Note: This linter is disabled by default as enum usage is recommended but not strictly
-required for all Kubernetes APIs. Enable it in your configuration to enforce these conventions.
+The distinction between CRD validation markers and declarative validation markers allows
+the linter to work correctly in both CRD-based projects (using controller-gen) and
+Kubernetes core API development (using declarative validation).
+
+Note: This linter is enabled by default to ensure string types with constants follow enum
+conventions. It only flags types that have associated constants, minimizing false positives.
 */
 package enums

--- a/pkg/analysis/enums/initializer.go
+++ b/pkg/analysis/enums/initializer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package enums
+
+import (
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewConfigurableInitializer(
+		name,
+		initAnalyzer,
+		// The enums linter is opt-in as enum usage is not strictly
+		// required for all Kubernetes APIs, though it is recommended.
+		false,
+		validateConfig,
+	)
+}
+
+func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	return newAnalyzer(cfg), nil
+}
+
+// validateConfig implements validation of the enums linter config.
+func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
+	// Config is optional, allowlist can be empty
+	return field.ErrorList{}
+}

--- a/pkg/analysis/enums/initializer.go
+++ b/pkg/analysis/enums/initializer.go
@@ -43,6 +43,7 @@ func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
 	if cfg == nil {
 		cfg = &Config{}
 	}
+
 	return newAnalyzer(cfg), nil
 }
 

--- a/pkg/analysis/enums/initializer.go
+++ b/pkg/analysis/enums/initializer.go
@@ -32,9 +32,8 @@ func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewConfigurableInitializer(
 		name,
 		initAnalyzer,
-		// The enums linter is opt-in as enum usage is not strictly
-		// required for all Kubernetes APIs, though it is recommended.
-		false,
+		// Enabled by default: validates string type aliases with constants have enum markers
+		true,
 		validateConfig,
 	)
 }
@@ -44,11 +43,30 @@ func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
 		cfg = &Config{}
 	}
 
+	if cfg.KubebuilderEnumPolicy == "" {
+		cfg.KubebuilderEnumPolicy = KubebuilderEnumPolicyRequireTypeAlias
+	}
+
 	return newAnalyzer(cfg), nil
 }
 
 // validateConfig implements validation of the enums linter config.
 func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
-	// Config is optional, allowlist can be empty
-	return field.ErrorList{}
+	var errs field.ErrorList
+	if cfg == nil {
+		return errs
+	}
+
+	allowlistPath := fldPath.Child("allowlist")
+	seen := make(map[string]bool, len(cfg.Allowlist))
+
+	for i, v := range cfg.Allowlist {
+		if seen[v] {
+			errs = append(errs, field.Duplicate(allowlistPath.Index(i), v))
+		}
+
+		seen[v] = true
+	}
+
+	return errs
 }

--- a/pkg/analysis/enums/testdata/src/a/a.go
+++ b/pkg/analysis/enums/testdata/src/a/a.go
@@ -1,0 +1,122 @@
+package a
+
+// Valid enum type with proper marker
+// +kubebuilder:validation:Enum
+type Phase string
+
+const (
+	PhasePending   Phase = "Pending"   // Valid PascalCase
+	PhaseRunning   Phase = "Running"   // Valid PascalCase
+	PhaseSucceeded Phase = "Succeeded" // Valid PascalCase
+	PhaseFailed    Phase = "Failed"    // Valid PascalCase
+)
+
+// Alternative marker format
+// +k8s:enum
+type State string
+
+const (
+	StateActive   State = "Active"   // Valid PascalCase
+	StateInactive State = "Inactive" // Valid PascalCase
+)
+
+// Invalid: Missing +enum marker
+// This type doesn't have +enum marker, so it will be flagged when used in fields
+type Status string
+
+const (
+	StatusReady    Status = "Ready"
+	StatusNotReady Status = "NotReady"
+)
+
+// Invalid: Type with +enum but not string
+// +kubebuilder:validation:Enum
+type InvalidEnumType int // want "type InvalidEnumType has \\+enum marker but underlying type is not string"
+
+// Invalid enum values (not PascalCase)
+// +kubebuilder:validation:Enum
+type BadPhase string
+
+const (
+	phase_pending   BadPhase = "pending"      // want "enum value \"pending\" should be PascalCase"
+	PHASE_RUNNING   BadPhase = "RUNNING"      // want "enum value \"RUNNING\" should be PascalCase"
+	phase_succeeded BadPhase = "succeeded"    // want "enum value \"succeeded\" should be PascalCase"
+	Phase_Failed    BadPhase = "Phase-Failed" // want "enum value \"Phase-Failed\" should be PascalCase"
+)
+
+// Test struct with fields
+type MySpec struct {
+	// Valid: uses type alias with +enum
+	Phase Phase
+
+	// Valid: uses type alias with +enum
+	State State
+
+	// Invalid: plain string without +enum
+	PlainString string // want "field PlainString uses plain string without \\+enum marker"
+
+	// Invalid: type alias without +enum marker
+	Status Status // want "field Status uses type Status which appears to be an enum but is missing \\+enum marker"
+
+	// Valid: pointer to enum type
+	PhasePtr *Phase
+
+	// Valid: slice of enum type
+	Phases []Phase
+
+	// Invalid: plain string slice
+	PlainStrings []string // want "field PlainStrings array element uses plain string without \\+enum marker"
+}
+
+// Test pointer fields
+type PointerSpec struct {
+	PhasePtr    *Phase
+	StatusPtr   *Status // want "field StatusPtr uses type Status which appears to be an enum but is missing \\+enum marker"
+	PlainStrPtr *string // want "field PlainStrPtr uses plain string without \\+enum marker"
+}
+
+// Test array fields
+type ArraySpec struct {
+	Phases        []Phase
+	Statuses      []Status // want "field Statuses array element uses type Status which appears to be an enum but is missing \\+enum marker"
+	PlainStrArray []string // want "field PlainStrArray array element uses plain string without \\+enum marker"
+}
+
+// Embedded field test
+type EmbeddedSpec struct {
+	MySpec
+	Phase Phase
+}
+
+// Edge case: Field with +enum marker directly on the field (should be allowed as exception)
+type DirectMarkerSpec struct {
+	// +kubebuilder:validation:Enum
+	DirectEnum string // Valid: has +enum marker directly on field
+}
+
+// Edge case: Enum values with numbers (should be valid PascalCase)
+// +kubebuilder:validation:Enum
+type Priority string
+
+const (
+	Priority1 Priority = "Priority1" // Valid: PascalCase with number
+	Priority2 Priority = "Priority2" // Valid: PascalCase with number
+)
+
+// Edge case: Single letter uppercase (edge case for all-caps check)
+// +kubebuilder:validation:Enum
+type Level string
+
+const (
+	LevelA Level = "A" // Valid: single uppercase letter
+	LevelB Level = "B" // Valid: single uppercase letter
+)
+
+// Edge case: Map with enum types (maps are allowed, not enforced to use enum types)
+type MapSpec struct {
+	// Valid: map with enum value type
+	PhaseMap map[string]Phase
+
+	// Valid: map with plain string value (maps are not enforced to use enums)
+	PlainMap map[string]string
+}

--- a/pkg/analysis/enums/testdata/src/a/a.go
+++ b/pkg/analysis/enums/testdata/src/a/a.go
@@ -1,7 +1,7 @@
 package a
 
-// Valid enum type with proper marker
-// +kubebuilder:validation:Enum
+// Valid: +kubebuilder:validation:Enum with explicit values (does NOT auto-discover constants)
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
 type Phase string
 
 const (
@@ -11,7 +11,7 @@ const (
 	PhaseFailed    Phase = "Failed"    // Valid PascalCase
 )
 
-// Alternative marker format
+// Valid: +k8s:enum always auto-discovers constants
 // +k8s:enum
 type State string
 
@@ -20,8 +20,17 @@ const (
 	StateInactive State = "Inactive" // Valid PascalCase
 )
 
-// Invalid: Missing +enum marker
-// This type doesn't have +enum marker, so it will be flagged when used in fields
+// +kubebuilder:validation:Enum with explicit values; non-PascalCase values in marker are flagged
+// +kubebuilder:validation:Enum=Pending;helper
+type ExplicitPhase string // want "enum value \"helper\" in marker should be PascalCase \\(e.g., \"PhasePending\", \"StateRunning\"\\)"
+
+// Constants for ExplicitPhase; "helper" in the marker is flagged at type line; constant value also validated
+const (
+	ExplicitPending ExplicitPhase = "Pending"
+	explicit_helper ExplicitPhase = "helper" // want "enum value \"helper\" should be PascalCase \\(e.g., \"PhasePending\", \"StateRunning\"\\)"
+)
+
+// Invalid: Type alias without enum marker (will be flagged when used in fields)
 type Status string
 
 const (
@@ -29,34 +38,42 @@ const (
 	StatusNotReady Status = "NotReady"
 )
 
-// Invalid: Type with +enum but not string
+// Invalid: Type with kubebuilder:validation:Enum marker but underlying type is not string
 // +kubebuilder:validation:Enum
-type InvalidEnumType int // want "type InvalidEnumType has \\+enum marker but underlying type is not string"
+type InvalidEnumType int // want "type InvalidEnumType has enum marker but underlying type is not string"
 
-// Invalid enum values (not PascalCase)
-// +kubebuilder:validation:Enum
+// Invalid enum values (not PascalCase) - using auto-discovery (+enum)
+// +enum
 type BadPhase string
 
 const (
-	phase_pending   BadPhase = "pending"      // want "enum value \"pending\" should be PascalCase"
-	PHASE_RUNNING   BadPhase = "RUNNING"      // want "enum value \"RUNNING\" should be PascalCase"
-	phase_succeeded BadPhase = "succeeded"    // want "enum value \"succeeded\" should be PascalCase"
-	Phase_Failed    BadPhase = "Phase-Failed" // want "enum value \"Phase-Failed\" should be PascalCase"
+	phase_pending BadPhase = "pending"      // want "enum value \"pending\" should be PascalCase"
+	phase_failed  BadPhase = "Phase-Failed" // want "enum value \"Phase-Failed\" should be PascalCase"
+)
+
+// Valid: Acronyms and all-caps are allowed
+// +kubebuilder:validation:Enum
+type Protocol string
+
+const (
+	ProtocolHTTP  Protocol = "HTTP"  // Valid: acronym
+	ProtocolHTTPS Protocol = "HTTPS" // Valid: acronym
+	ProtocolTCP   Protocol = "TCP"   // Valid: acronym
 )
 
 // Test struct with fields
 type MySpec struct {
-	// Valid: uses type alias with +enum
+	// Valid: uses type alias with enum marker
 	Phase Phase
 
-	// Valid: uses type alias with +enum
+	// Valid: uses type alias with enum marker
 	State State
 
-	// Invalid: plain string without +enum
-	PlainString string // want "field PlainString uses plain string without \\+enum marker"
+	// Valid: plain string (not required to be enum unless kubebuilderEnumPolicy is RequireTypeAlias)
+	PlainString string
 
-	// Invalid: type alias without +enum marker
-	Status Status // want "field Status uses type Status which appears to be an enum but is missing \\+enum marker"
+	// Invalid: type alias without enum marker
+	Status Status // want "field MySpec.Status uses type Status which appears to be an enum but is missing an enum marker \\(\\+enum, \\+k8s:enum, or \\+kubebuilder:validation:Enum=...\\)"
 
 	// Valid: pointer to enum type
 	PhasePtr *Phase
@@ -64,22 +81,23 @@ type MySpec struct {
 	// Valid: slice of enum type
 	Phases []Phase
 
-	// Invalid: plain string slice
-	PlainStrings []string // want "field PlainStrings array element uses plain string without \\+enum marker"
+	// Valid: plain string slice (not required to be enum)
+	PlainStrings []string
+
+	// Valid: explicit enum type
+	Explicit ExplicitPhase
 }
 
 // Test pointer fields
 type PointerSpec struct {
-	PhasePtr    *Phase
-	StatusPtr   *Status // want "field StatusPtr uses type Status which appears to be an enum but is missing \\+enum marker"
-	PlainStrPtr *string // want "field PlainStrPtr uses plain string without \\+enum marker"
+	PhasePtr  *Phase
+	StatusPtr *Status // want "field PointerSpec.StatusPtr uses type Status which appears to be an enum but is missing an enum marker \\(\\+enum, \\+k8s:enum, or \\+kubebuilder:validation:Enum=...\\)"
 }
 
 // Test array fields
 type ArraySpec struct {
-	Phases        []Phase
-	Statuses      []Status // want "field Statuses array element uses type Status which appears to be an enum but is missing \\+enum marker"
-	PlainStrArray []string // want "field PlainStrArray array element uses plain string without \\+enum marker"
+	Phases   []Phase
+	Statuses []Status // want "field ArraySpec.Statuses array element uses type Status which appears to be an enum but is missing an enum marker \\(\\+enum, \\+k8s:enum, or \\+kubebuilder:validation:Enum=...\\)"
 }
 
 // Embedded field test
@@ -88,14 +106,14 @@ type EmbeddedSpec struct {
 	Phase Phase
 }
 
-// Edge case: Field with +enum marker directly on the field (should be allowed as exception)
+// Edge case: Field with enum marker directly on the field (allowed as exception)
 type DirectMarkerSpec struct {
 	// +kubebuilder:validation:Enum
-	DirectEnum string // Valid: has +enum marker directly on field
+	DirectEnum string // Valid: has enum marker directly on field
 }
 
 // Edge case: Enum values with numbers (should be valid PascalCase)
-// +kubebuilder:validation:Enum
+// +kubebuilder:validation:Enum=Priority1;Priority2
 type Priority string
 
 const (
@@ -103,13 +121,14 @@ const (
 	Priority2 Priority = "Priority2" // Valid: PascalCase with number
 )
 
-// Edge case: Single letter uppercase (edge case for all-caps check)
-// +kubebuilder:validation:Enum
+// Valid: Single letter and all-caps values
+// +kubebuilder:validation:Enum=A;B;API
 type Level string
 
 const (
-	LevelA Level = "A" // Valid: single uppercase letter
-	LevelB Level = "B" // Valid: single uppercase letter
+	LevelA   Level = "A"   // Valid: single letter
+	LevelB   Level = "B"   // Valid: single letter
+	LevelAPI Level = "API" // Valid: acronym
 )
 
 // Edge case: Map with enum types (maps are allowed, not enforced to use enum types)

--- a/pkg/analysis/enums/testdata/src/b/b.go
+++ b/pkg/analysis/enums/testdata/src/b/b.go
@@ -1,0 +1,29 @@
+package b
+
+// Test with allowlist configuration
+
+// Valid enum type with proper marker
+// +kubebuilder:validation:Enum
+type ExecutableName string
+
+const (
+	ExecKubectl ExecutableName = "kubectl" // Valid: in allowlist
+	ExecDocker  ExecutableName = "docker"  // Valid: in allowlist
+	ExecHelm    ExecutableName = "helm"    // Valid: in allowlist
+	ExecUnknown ExecutableName = "unknown" // want "enum value \"unknown\" should be PascalCase"
+)
+
+// Regular enum with PascalCase (should still work)
+// +kubebuilder:validation:Enum
+type Status string
+
+const (
+	StatusReady    Status = "Ready"    // Valid PascalCase
+	StatusNotReady Status = "NotReady" // Valid PascalCase
+)
+
+// Test struct
+type MyConfig struct {
+	Executable ExecutableName
+	Status     Status
+}

--- a/pkg/analysis/enums/testdata/src/b/b.go
+++ b/pkg/analysis/enums/testdata/src/b/b.go
@@ -2,8 +2,8 @@ package b
 
 // Test with allowlist configuration
 
-// Valid enum type with proper marker
-// +kubebuilder:validation:Enum
+// Valid enum type with proper marker (+enum so constants are validated for PascalCase)
+// +enum
 type ExecutableName string
 
 const (
@@ -13,8 +13,8 @@ const (
 	ExecUnknown ExecutableName = "unknown" // want "enum value \"unknown\" should be PascalCase"
 )
 
-// Regular enum with PascalCase (should still work)
-// +kubebuilder:validation:Enum
+// Regular enum with PascalCase
+// +enum
 type Status string
 
 const (

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -27,6 +27,9 @@ const (
 
 	// DefaultMarker is the marker that specifies the default value of a field or type.
 	DefaultMarker = "default"
+
+	// EnumMarker is the marker that indicates that a field has an enum.
+	EnumMarker = "enum"
 )
 
 const (

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -32,6 +32,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/defaults"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/dependenttags"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/duplicatemarkers"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/enums"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/forbiddenmarkers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/integers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/jsontags"

--- a/tests/integration/testdata/all_ok/config.yaml
+++ b/tests/integration/testdata/all_ok/config.yaml
@@ -1,3 +1,5 @@
 linters:
-  enabled:
-  - "*"
+            enable: []
+          lintersConfig:
+            enums:
+              kubebuilderEnumPolicy: AllowPlainString

--- a/tests/integration/testdata/default_configurations/affinity.go
+++ b/tests/integration/testdata/default_configurations/affinity.go
@@ -215,7 +215,7 @@ type Taint struct {
 
 }
 
-// +enum
+// +kubebuilder:validation:Enum
 type TaintEffect string
 
 const (
@@ -269,7 +269,7 @@ type Toleration struct {
 }
 
 // A toleration operator is the set of operators that can be used in a toleration.
-// +enum
+// +kubebuilder:validation:Enum
 type TolerationOperator string
 
 const (
@@ -322,7 +322,7 @@ type NodeSelectorRequirement struct {
 
 // A node selector operator is the set of operators that can be used in
 // a node selector requirement.
-// +enum
+// +kubebuilder:validation:Enum
 type NodeSelectorOperator string
 
 const (
@@ -454,7 +454,7 @@ type TopologySpreadConstraint struct {
 	MatchLabelKeys []string `json:"matchLabelKeys,omitempty" protobuf:"bytes,8,opt,name=matchLabelKeys"`
 }
 
-// +enum
+// +kubebuilder:validation:Enum
 type UnsatisfiableConstraintAction string
 
 const (
@@ -467,7 +467,7 @@ const (
 )
 
 // NodeInclusionPolicy defines the type of node inclusion policy
-// +enum
+// +kubebuilder:validation:Enum
 type NodeInclusionPolicy string
 
 const (
@@ -478,7 +478,7 @@ const (
 )
 
 // PreemptionPolicy describes a policy for if/when to preempt a pod.
-// +enum
+// +kubebuilder:validation:Enum
 type PreemptionPolicy string
 
 const (

--- a/tests/integration/testdata/default_configurations/config.yaml
+++ b/tests/integration/testdata/default_configurations/config.yaml
@@ -1,4 +1,26 @@
 linters:
-  enabled: [] # This will mean only the default enabled linters are enabled.
-  disabled: [] # This will mean only the default disabled linters are disabled.
-linterSettings: {} # This will mean only the default linter settings are used.
+            enable: []
+          lintersConfig:
+            enums:
+              kubebuilderEnumPolicy: AllowPlainString
+              allowlist:
+                - ""
+                - '""'
+                - linux
+                - windows
+                - SIGRTMAX
+                - "HugePages-"
+                - "SIGRTMAX-1"
+                - "SIGRTMAX-2"
+                - "SIGRTMAX-3"
+                - "SIGRTMAX-4"
+                - "SIGRTMAX-5"
+                - "SIGRTMAX-6"
+                - "SIGRTMAX-7"
+                - "SIGRTMAX-8"
+                - "SIGRTMAX-9"
+                - "SIGRTMAX-10"
+                - "SIGRTMAX-11"
+                - "SIGRTMAX-12"
+                - "SIGRTMAX-13"
+                - "SIGRTMAX-14"

--- a/tests/integration/testdata/default_configurations/container.go
+++ b/tests/integration/testdata/default_configurations/container.go
@@ -209,7 +209,7 @@ type Container struct {
 }
 
 // Protocol defines network protocols supported for things like container ports.
-// +enum
+// +kubebuilder:validation:Enum
 type Protocol string
 
 const (
@@ -453,6 +453,7 @@ type ResourceClaim struct {
 }
 
 // ResourceResizeRestartPolicy specifies how to handle container resource resize.
+// +kubebuilder:validation:Enum=NotRequired;RestartContainer
 type ResourceResizeRestartPolicy string
 
 // These are the valid resource resize restart policy values:
@@ -484,6 +485,7 @@ type ContainerResizePolicy struct {
 
 // ContainerRestartPolicy is the restart policy for a single container.
 // The only allowed values are "Always", "Never", and "OnFailure".
+// +kubebuilder:validation:Enum=Always;Never;OnFailure
 type ContainerRestartPolicy string
 
 const (
@@ -498,7 +500,7 @@ type ContainerRestartRule struct {
 	// are satisfied. The only possible value is "Restart" to restart the
 	// container.
 	// +required
-	Action ContainerRestartRuleAction `json:"action,omitempty" proto:"bytes,1,opt,name=action" protobuf:"bytes,1,opt,name=action,casttype=ContainerRestartRuleAction"` // want "requiredfields: field ContainerRestartRule.Action has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Action ContainerRestartRuleAction `json:"action,omitempty" proto:"bytes,1,opt,name=action" protobuf:"bytes,1,opt,name=action,casttype=ContainerRestartRuleAction"`
 
 	// Represents the exit codes to check on container exits. // want "commentstart: godoc for field ContainerRestartRule.ExitCodes should start with 'exitCodes ...'"
 	// +optional
@@ -508,6 +510,7 @@ type ContainerRestartRule struct {
 
 // ContainerRestartRuleAction describes the action to take when the
 // container exits.
+// +kubebuilder:validation:Enum=Restart
 type ContainerRestartRuleAction string
 
 // The only valid action is Restart.
@@ -525,7 +528,7 @@ type ContainerRestartRuleOnExitCodes struct {
 	// - NotIn: the requirement is satisfied if the container exit code is
 	//   not in the set of specified values.
 	// +required
-	Operator ContainerRestartRuleOnExitCodesOperator `json:"operator,omitempty" proto:"bytes,1,opt,name=operator" protobuf:"bytes,1,opt,name=operator,casttype=ContainerRestartRuleOnExitCodesOperator"` // want "requiredfields: field ContainerRestartRuleOnExitCodes.Operator has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Operator ContainerRestartRuleOnExitCodesOperator `json:"operator,omitempty" proto:"bytes,1,opt,name=operator" protobuf:"bytes,1,opt,name=operator,casttype=ContainerRestartRuleOnExitCodesOperator"`
 
 	// Specifies the set of values to check for container exit codes. // want "commentstart: godoc for field ContainerRestartRuleOnExitCodes.Values should start with 'values ...'"
 	// At most 255 elements are allowed.
@@ -536,6 +539,7 @@ type ContainerRestartRuleOnExitCodes struct {
 
 // ContainerRestartRuleOnExitCodesOperator describes the operator
 // to take for the exit codes.
+// +kubebuilder:validation:Enum
 type ContainerRestartRuleOnExitCodesOperator string
 
 const (
@@ -634,7 +638,7 @@ type HTTPHeader struct {
 }
 
 // URIScheme identifies the scheme used for connection to a host for Get actions
-// +enum
+// +kubebuilder:validation:Enum
 type URIScheme string
 
 const (
@@ -689,7 +693,7 @@ type SleepAction struct {
 }
 
 // Signal defines the stop signal of containers
-// +enum
+// +kubebuilder:validation:Enum=SIGABRT;SIGALRM;SIGBUS;SIGCHLD;SIGCLD;SIGCONT;SIGFPE;SIGHUP;SIGILL;SIGINT;SIGIO;SIGIOT;SIGKILL;SIGPIPE;SIGPOLL;SIGPROF;SIGPWR;SIGQUIT;SIGSEGV;SIGSTKFLT;SIGSTOP;SIGSYS;SIGTERM;SIGTRAP;SIGTSTP;SIGTTIN;SIGTTOU;SIGURG;SIGUSR1;SIGUSR2;SIGVTALRM;SIGWINCH;SIGXCPU;SIGXFSZ;SIGRTMIN;SIGRTMIN+1;SIGRTMIN+2;SIGRTMIN+3;SIGRTMIN+4;SIGRTMIN+5;SIGRTMIN+6;SIGRTMIN+7;SIGRTMIN+8;SIGRTMIN+9;SIGRTMIN+10;SIGRTMIN+11;SIGRTMIN+12;SIGRTMIN+13;SIGRTMIN+14;SIGRTMIN+15;SIGRTMAX-14;SIGRTMAX-13;SIGRTMAX-12;SIGRTMAX-11;SIGRTMAX-10;SIGRTMAX-9;SIGRTMAX-8;SIGRTMAX-7;SIGRTMAX-6;SIGRTMAX-5;SIGRTMAX-4;SIGRTMAX-3;SIGRTMAX-2;SIGRTMAX-1;SIGRTMAX
 type Signal string
 
 const (
@@ -808,7 +812,7 @@ type LifecycleHandler struct {
 }
 
 // TerminationMessagePolicy describes how termination messages are retrieved from a container.
-// +enum
+// +kubebuilder:validation:Enum
 type TerminationMessagePolicy string
 
 const (
@@ -822,7 +826,7 @@ const (
 )
 
 // PullPolicy describes a policy for if/when to pull a container image
-// +enum
+// +kubebuilder:validation:Enum
 type PullPolicy string
 
 const (
@@ -918,7 +922,7 @@ type SecurityContext struct {
 	AppArmorProfile *AppArmorProfile `json:"appArmorProfile,omitempty" protobuf:"bytes,12,opt,name=appArmorProfile"`
 }
 
-// +enum
+// +kubebuilder:validation:Enum
 type ProcMountType string
 
 const (
@@ -1012,7 +1016,7 @@ type SeccompProfile struct {
 }
 
 // SeccompProfileType defines the supported seccomp profile types.
-// +enum
+// +kubebuilder:validation:Enum
 type SeccompProfileType string
 
 const (
@@ -1044,7 +1048,7 @@ type AppArmorProfile struct {
 	LocalhostProfile *string `json:"localhostProfile,omitempty" protobuf:"bytes,2,opt,name=localhostProfile"`
 }
 
-// +enum
+// +kubebuilder:validation:Enum
 type AppArmorProfileType string
 
 const (
@@ -1072,7 +1076,7 @@ type HostAlias struct {
 // Only one of the following restart policies may be specified.
 // If none of the following policies is specified, the default one
 // is RestartPolicyAlways.
-// +enum
+// +kubebuilder:validation:Enum
 type RestartPolicy string
 
 const (
@@ -1082,7 +1086,7 @@ const (
 )
 
 // DNSPolicy defines how a pod's DNS will be configured.
-// +enum
+// +kubebuilder:validation:Enum
 type DNSPolicy string
 
 const (

--- a/tests/integration/testdata/default_configurations/pod.go
+++ b/tests/integration/testdata/default_configurations/pod.go
@@ -388,6 +388,7 @@ type PodReadinessGate struct {
 }
 
 // PodConditionType is a valid value for PodCondition.Type
+// +kubebuilder:validation:Enum=ContainersReady;Initialized;Ready;PodScheduled;DisruptionTarget;PodReadyToStartContainers;PodResizePending;PodResizeInProgress
 type PodConditionType string
 
 // These are built-in conditions of pod. An application may use a custom condition not listed here.
@@ -420,6 +421,7 @@ const (
 	PodResizeInProgress PodConditionType = "PodResizeInProgress"
 )
 
+// +kubebuilder:validation:Enum=linux;windows
 // OSName is the set of OS'es that can be used in OS.
 type OSName string
 

--- a/tests/integration/testdata/default_configurations/security_context.go
+++ b/tests/integration/testdata/default_configurations/security_context.go
@@ -128,7 +128,7 @@ type PodSecurityContext struct {
 
 // SupplementalGroupsPolicy defines how supplemental groups
 // of the first container processes are calculated.
-// +enum
+// +kubebuilder:validation:Enum=Merge;Strict
 type SupplementalGroupsPolicy string
 
 const (
@@ -153,7 +153,7 @@ type Sysctl struct {
 
 // PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume
 // when volume is mounted.
-// +enum
+// +kubebuilder:validation:Enum=OnRootMismatch;Always
 type PodFSGroupChangePolicy string
 
 const (
@@ -168,6 +168,7 @@ const (
 	FSGroupChangeAlways PodFSGroupChangePolicy = "Always"
 )
 
+// +kubebuilder:validation:Enum
 // PodSELinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
 type PodSELinuxChangePolicy string
 

--- a/tests/integration/testdata/default_configurations/volume.go
+++ b/tests/integration/testdata/default_configurations/volume.go
@@ -50,7 +50,7 @@ type VolumeMount struct {
 }
 
 // MountPropagationMode describes mount propagation.
-// +enum
+// +kubebuilder:validation:Enum=None;HostToContainer;Bidirectional
 type MountPropagationMode string
 
 const (
@@ -75,6 +75,7 @@ const (
 	MountPropagationBidirectional MountPropagationMode = "Bidirectional"
 )
 
+// +kubebuilder:validation:Enum
 // RecursiveReadOnlyMode describes recursive-readonly mode.
 type RecursiveReadOnlyMode string
 
@@ -460,7 +461,7 @@ type HostPathVolumeSource struct {
 	Type *HostPathType `json:"type,omitempty" protobuf:"bytes,2,opt,name=type"`
 }
 
-// +enum
+// +kubebuilder:validation:Enum="";DirectoryOrCreate;Directory;FileOrCreate;File;Socket;CharDevice;BlockDevice
 type HostPathType string
 
 const (
@@ -762,6 +763,7 @@ type FlockerVolumeSource struct {
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.
+// +kubebuilder:validation:Enum=Memory;HugePages;HugePages-<size>
 type StorageMedium string
 
 const (
@@ -1194,10 +1196,10 @@ type PhotonPersistentDiskVolumeSource struct {
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalorrequired: field PhotonPersistentDiskVolumeSource.FSType must be marked as optional or required"
 }
 
-// +enum
+// +kubebuilder:validation:Enum=None;ReadOnly;ReadWrite
 type AzureDataDiskCachingMode string
 
-// +enum
+// +kubebuilder:validation:Enum=Shared;Dedicated;Managed
 type AzureDataDiskKind string
 
 const (
@@ -1872,7 +1874,7 @@ type PersistentVolumeClaimSpec struct {
 	VolumeAttributesClassName *string `json:"volumeAttributesClassName,omitempty" protobuf:"bytes,9,opt,name=volumeAttributesClassName"`
 }
 
-// +enum
+// +kubebuilder:validation:Enum
 type PersistentVolumeAccessMode string
 
 const (
@@ -1888,7 +1890,7 @@ const (
 )
 
 // PersistentVolumeMode describes how a volume is intended to be consumed, either Block or Filesystem.
-// +enum
+// +kubebuilder:validation:Enum=Block;Filesystem
 type PersistentVolumeMode string
 
 const (


### PR DESCRIPTION
### Description
This PR introduces a new `enums linter` to enforce best practices for enumerated fields in Kubernetes APIs.

The new linter, `enums`, achieves the following:

- Documents Enum Fields: Enforces use of type aliases with `+enum` markers instead of plain strings. Ensures enum values are explicitly documented in OpenAPI schemas with clear justifications for their purpose.
- Prevents Regressions: Validates that enum fields match documented patterns. Prevents undocumented or accidental changes to enum naming conventions and type definitions.
- Improves API Quality: Enforces PascalCase naming for enum values (e.g., "PhasePending"). Ensures thoughtful consideration for enum field design, improving schema validation and generated client type safety.
- The linter is disabled by default and supports an allowlist for special cases like command-line tool names.

Fixes #17 