### PR TITLE
Fix zero value detection for custom types with validation markers

### DIFF
--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go
@@ -1,5 +1,19 @@
 package a
 
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=23
+type BootstrapTokenString string
+
+// BootstrapTokenStruct is a struct with Type=string marker (issue #138).
+// This struct has custom JSON marshalling that serializes it as a string, not an object.
+// +kubebuilder:validation:Type=string
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=23
+type BootstrapTokenStruct struct {
+	ID     string `json:"-"`
+	Secret string `json:"-"`
+}
+
 type TestStrings struct {
 	String string `json:"string"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
@@ -56,4 +70,22 @@ type TestStrings struct {
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`
+
+	// Test for issue #138: custom string type with validation markers on the type definition
+	Token BootstrapTokenString `json:"token"` // want "field TestStrings.Token should have the omitempty tag."
+
+	TokenWithOmitEmpty BootstrapTokenString `json:"tokenWithOmitEmpty,omitempty"`
+
+	TokenPtr *BootstrapTokenString `json:"tokenPtr"` // want "field TestStrings.TokenPtr should have the omitempty tag." "field TestStrings.TokenPtr does not allow the zero value. The field does not need to be a pointer."
+
+	TokenPtrWithOmitEmpty *BootstrapTokenString `json:"tokenPtrWithOmitEmpty,omitempty"` // want "field TestStrings.TokenPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// Test for issue #138: struct with Type=string marker
+	TokenStruct BootstrapTokenStruct `json:"tokenStruct"` // want "field TestStrings.TokenStruct should have the omitempty tag."
+
+	TokenStructWithOmitEmpty BootstrapTokenStruct `json:"tokenStructWithOmitEmpty,omitempty"`
+
+	TokenStructPtr *BootstrapTokenStruct `json:"tokenStructPtr"` // want "field TestStrings.TokenStructPtr should have the omitempty tag." "field TestStrings.TokenStructPtr does not allow the zero value. The field does not need to be a pointer."
+
+	TokenStructPtrWithOmitEmpty *BootstrapTokenStruct `json:"tokenStructPtrWithOmitEmpty,omitempty"` // want "field TestStrings.TokenStructPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go.golden
@@ -1,5 +1,19 @@
 package a
 
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=23
+type BootstrapTokenString string
+
+// BootstrapTokenStruct is a struct with Type=string marker (issue #138).
+// This struct has custom JSON marshalling that serializes it as a string, not an object.
+// +kubebuilder:validation:Type=string
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=23
+type BootstrapTokenStruct struct {
+	ID     string `json:"-"`
+	Secret string `json:"-"`
+}
+
 type TestStrings struct {
 	String *string `json:"string,omitempty"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
@@ -56,4 +70,22 @@ type TestStrings struct {
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`
+
+	// Test for issue #138: custom string type with validation markers on the type definition
+	Token BootstrapTokenString `json:"token,omitempty"` // want "field TestStrings.Token should have the omitempty tag."
+
+	TokenWithOmitEmpty BootstrapTokenString `json:"tokenWithOmitEmpty,omitempty"`
+
+	TokenPtr BootstrapTokenString `json:"tokenPtr,omitempty"` // want "field TestStrings.TokenPtr should have the omitempty tag." "field TestStrings.TokenPtr does not allow the zero value. The field does not need to be a pointer."
+
+	TokenPtrWithOmitEmpty BootstrapTokenString `json:"tokenPtrWithOmitEmpty,omitempty"` // want "field TestStrings.TokenPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// Test for issue #138: struct with Type=string marker
+	TokenStruct BootstrapTokenStruct `json:"tokenStruct,omitempty"` // want "field TestStrings.TokenStruct should have the omitempty tag."
+
+	TokenStructWithOmitEmpty BootstrapTokenStruct `json:"tokenStructWithOmitEmpty,omitempty"`
+
+	TokenStructPtr BootstrapTokenStruct `json:"tokenStructPtr,omitempty"` // want "field TestStrings.TokenStructPtr should have the omitempty tag." "field TestStrings.TokenStructPtr does not allow the zero value. The field does not need to be a pointer."
+
+	TokenStructPtrWithOmitEmpty BootstrapTokenStruct `json:"tokenStructPtrWithOmitEmpty,omitempty"` // want "field TestStrings.TokenStructPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -73,12 +73,41 @@ func getUnderlyingType(expr ast.Expr) ast.Expr {
 	return expr
 }
 
+// GetTypeMarkerValue returns the value of the kubebuilder Type marker for a field.
+// Returns empty string if no Type marker is present.
+// The Type marker indicates how the field serializes (e.g., "string", "number", "object").
+func GetTypeMarkerValue(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers) string {
+	fieldMarkers := TypeAwareMarkerCollectionForField(pass, markersAccess, field)
+	typeMarkers := fieldMarkers.Get(markers.KubebuilderTypeMarker)
+
+	for _, typeMarker := range typeMarkers {
+		// The value might be "string" (with quotes) or string (without quotes)
+		typeValue := strings.Trim(typeMarker.Payload.Value, `"`)
+		if typeValue != "" {
+			return typeValue
+		}
+	}
+
+	return ""
+}
+
 // isStructZeroValueValid checks if the zero value of a struct is valid.
 // It checks if all non-omitted fields within the struct accept their zero values.
 // It also checks if the struct has a minProperties marker, and if so, whether the number of non-omitted fields is greater than or equal to the minProperties value.
+// Special case: If the struct has Type=string marker with string validation markers (MinLength/MaxLength),
+// treat it as a string for validation purposes (e.g., for structs with custom marshalling).
 func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *ast.StructType, markersAccess markershelper.Markers, considerOmitzero bool, qualifiedFieldName string) (bool, bool) {
 	if structType == nil {
 		return false, false
+	}
+
+	// Check if this struct should be validated as a string (Type=string marker).
+	// This handles structs with custom marshalling that serialize as strings.
+	if GetTypeMarkerValue(pass, field, markersAccess) == "string" {
+		// Use string validation logic instead of struct validation logic.
+		// This ensures that string-specific validation markers (MinLength, MaxLength, Pattern)
+		// are properly evaluated for structs that marshal as strings.
+		return isStringZeroValueValid(pass, field, markersAccess)
 	}
 
 	jsonTagInfo, ok := pass.ResultOf[extractjsontags.Analyzer].(extractjsontags.StructFieldTags)


### PR DESCRIPTION
Fixes issue #138 where the linter was not detecting invalid zero values for structs with Type=string markers and string validation constraints.

The problem occurred because structs with custom marshalling (indicated by the Type=string marker) were being validated as regular structs instead of as strings, causing MinLength/MaxLength markers to be ignored.