### PR TITLE
Better handling of pointers in zero value struct checks

### DIFF
--- a/pkg/analysis/utils/testdata/src/c/structs.go
+++ b/pkg/analysis/utils/testdata/src/c/structs.go
@@ -8,6 +8,24 @@ type ZeroValueTestStructs struct {
 	StructWithOmitZeroFieldsAndMinProperties StructWithOmitZeroFieldsAndMinProperties `json:"structWithOmitZeroFieldsAndMinProperties,omitempty"` // want "zero value is not valid" "validation is complete"
 
 	StructWithOmitZeroAndRequiredFieldsAndMinProperties StructWithOmitZeroAndRequiredFieldsAndMinProperties `json:"structWithOmitZeroAndRequiredFieldsAndMinProperties,omitempty"` // want "zero value is valid" "validation is complete"
+
+	// RecursiveStructs demonstrates that the zero value checker stops when it finds recursive structs
+
+	RecursiveStruct RecursiveStructA `json:"recursiveStruct` // want "zero value is valid" "validation is complete"
+
+	RecursiveStructWithOmitEmpty RecursiveStructA `json:"recursiveStructWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
+
+	RecursiveStructPointer *RecursiveStructA `json:"recursiveStructPointer` // want "zero value is valid" "validation is complete"
+
+	RecursiveStructPointerWithOmitEmpty *RecursiveStructA `json:"recursiveStructPointerWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
+
+	SelfRecursiveStruct SelfRecursiveStruct `json:"selfRecursiveStruct` // want "zero value is valid" "validation is complete"
+
+	SelfRecursiveStructWithOmitEmpty SelfRecursiveStruct `json:"selfRecursiveStructWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
+
+	SelfRecursiveStructPointer *SelfRecursiveStruct `json:"selfRecursiveStructPointer` // want "zero value is valid" "validation is complete"
+
+	SelfRecursiveStructPointerWithOmitEmpty *SelfRecursiveStruct `json:"selfRecursiveStructPointerWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
 }
 
 // StructWithOmittedRequiredField
@@ -57,4 +75,31 @@ type StructWithOmitZeroAndRequiredFieldsAndMinProperties struct {
 
 	// +required
 	RequiredStructWithAllOptionalFields StructWithAllOptionalFields `json:"requiredStructWithAllOptionalFields"` // want "zero value is valid" "validation is not complete"
+}
+
+// RecursiveStructA is paired with RecursiveStructB to demonstrate a recursive relationship for zero value checking.
+type RecursiveStructA struct {
+	// +optional
+	String string `json:"string,omitempty"` // want "zero value is valid" "validation is not complete"
+
+	RecursiveStructB *RecursiveStructB `json:"recursiveStructB,omitempty` // want "zero value is valid" "validation is complete"
+}
+
+// RecursiveStructB is paired with RecursiveStructA to demonstrate a recursive relationship for zero value checking.
+type RecursiveStructB struct {
+	// +optional
+	String string `json:"string,omitempty"` // want "zero value is valid" "validation is not complete"
+
+	RecursiveStructA *RecursiveStructA `json:"recursiveStructB` // want "zero value is valid" "validation is complete"
+
+	RecursiveStructAWithOmitEmpty *RecursiveStructA `json:"recursiveStructAWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
+}
+
+type SelfRecursiveStruct struct {
+	// +optional
+	String string `json:"string,omitempty"` // want "zero value is valid" "validation is not complete"
+
+	SelfRecursiveStruct *SelfRecursiveStruct `json:"selfRecursiveStruct` // want "zero value is valid" "validation is complete"
+
+	SelfRecursiveStructWithOmitEmpty *SelfRecursiveStruct `json:"selfRecursiveStructWithOmitEmpty,omitempty"` // want "zero value is valid" "validation is complete"
 }

--- a/pkg/analysis/utils/utils.go
+++ b/pkg/analysis/utils/utils.go
@@ -66,6 +66,12 @@ func IsStarExpr(expr ast.Expr) (bool, ast.Expr) {
 	return false, expr
 }
 
+// IsPointer checks if the expression is a pointer.
+func IsPointer(expr ast.Expr) bool {
+	_, ok := expr.(*ast.StarExpr)
+	return ok
+}
+
 // IsPointerType checks if the expression is a pointer type.
 // This is for types that are always implemented as pointers and therefore should
 // not be the underlying type of a star expr.


### PR DESCRIPTION
Fixes #185 (When initially adding the recursive structs I saw the same stack overflows in tests)

A struct that is recursive must be a pointer to a struct, else Go complains of invalid recursion.

When checking pointers to things as a field in a struct to determine if the zero value is valid or not, there are two cases.

One is that the field marshals to `null`. In this case, this is silently dropped by the API server unless the field has `+nullable`, in which case it is accepted.

Or, with omitempty, the field is omitted form the serialization, which means that the validness of the field being zero is based on if the field is optional or if it is required, which we already have checks for.

This PR updates the field detection logic for structs to handle these cases better.