### PR TITLE
Print qualified field name in error messages for optional and required field linters

### DIFF
--- a/pkg/analysis/optionalfields/analyzer.go
+++ b/pkg/analysis/optionalfields/analyzer.go
@@ -93,14 +93,14 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, _ string) {
-		a.checkField(pass, field, markersAccess, jsonTagInfo)
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
+		a.checkField(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo, qualifiedFieldName string) {
 	if field == nil || len(field.Names) == 0 {
 		return
 	}
@@ -116,7 +116,7 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAcce
 		return
 	}
 
-	a.serializationCheck.Check(pass, field, markersAccess, jsonTags)
+	a.serializationCheck.Check(pass, field, markersAccess, jsonTags, qualifiedFieldName)
 }
 
 func defaultConfig(cfg *OptionalFieldsConfig) {

--- a/pkg/analysis/optionalfields/testdata/src/a/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go
@@ -19,36 +19,36 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String should be a pointer."
+	String string `json:"string,omitempty"` // want "field A.String should be a pointer."
 
 	// NonOmittedString is a string field without omitempty
 	// +optional
-	NonOmittedString string `json:"nonOmittedString"` // want "field NonOmittedString should be a pointer." "field NonOmittedString should have the omitempty tag."
+	NonOmittedString string `json:"nonOmittedString"` // want "field A.NonOmittedString should be a pointer." "field A.NonOmittedString should have the omitempty tag."
 
 	// int is an int field.
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int int `json:"int,omitempty"` // want "field A.Int should be a pointer."
 
 	// nonOmittedInt is an int field without omitempty
 	// +optional
-	NonOmittedInt int `json:"nonOmittedInt"` // want "field NonOmittedInt should be a pointer." "field NonOmittedInt should have the omitempty tag."
+	NonOmittedInt int `json:"nonOmittedInt"` // want "field A.NonOmittedInt should be a pointer." "field A.NonOmittedInt should have the omitempty tag."
 
 	// struct is a struct field.
 	// +optional
-	Struct B `json:"struct,omitempty"` // want "field Struct should be a pointer."
+	Struct B `json:"struct,omitempty"` // want "field A.Struct should be a pointer."
 
 	// nonOmittedStruct is a struct field without omitempty.
 	// +optional
-	NonOmittedStruct B `json:"nonOmittedStruct"` // want "field NonOmittedStruct should be a pointer." "field NonOmittedStruct should have the omitempty tag."
+	NonOmittedStruct B `json:"nonOmittedStruct"` // want "field A.NonOmittedStruct should be a pointer." "field A.NonOmittedStruct should have the omitempty tag."
 
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties should be a pointer."
+	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties should be a pointer."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct should be a pointer."
+	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct should be a pointer."
 
 	// slice is a slice field.
 	// +optional
@@ -60,15 +60,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -93,16 +93,16 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAliasWithEnum is a string alias field with enum validation.
 	// With the "Always" pointer preference, optional fields should be pointers regardless of zero value validity.
 	// +optional
-	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field StringAliasWithEnum should be a pointer."
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field A.StringAliasWithEnum should be a pointer."
 
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This is correctly a pointer since the zero value is not valid.
@@ -111,7 +111,7 @@ type A struct {
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 }
 
 type B struct {

--- a/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
@@ -19,36 +19,36 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String should be a pointer."
+	String *string `json:"string,omitempty"` // want "field A.String should be a pointer."
 
 	// NonOmittedString is a string field without omitempty
 	// +optional
-	NonOmittedString *string `json:"nonOmittedString,omitempty"` // want "field NonOmittedString should be a pointer." "field NonOmittedString should have the omitempty tag."
+	NonOmittedString *string `json:"nonOmittedString,omitempty"` // want "field A.NonOmittedString should be a pointer." "field A.NonOmittedString should have the omitempty tag."
 
 	// int is an int field.
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int *int `json:"int,omitempty"` // want "field A.Int should be a pointer."
 
 	// nonOmittedInt is an int field without omitempty
 	// +optional
-	NonOmittedInt *int `json:"nonOmittedInt,omitempty"` // want "field NonOmittedInt should be a pointer." "field NonOmittedInt should have the omitempty tag."
+	NonOmittedInt *int `json:"nonOmittedInt,omitempty"` // want "field A.NonOmittedInt should be a pointer." "field A.NonOmittedInt should have the omitempty tag."
 
 	// struct is a struct field.
 	// +optional
-	Struct *B `json:"struct,omitempty"` // want "field Struct should be a pointer."
+	Struct *B `json:"struct,omitempty"` // want "field A.Struct should be a pointer."
 
     // nonOmittedStruct is a struct field without omitempty.
 	// +optional
-	NonOmittedStruct *B `json:"nonOmittedStruct,omitempty"` // want "field NonOmittedStruct should be a pointer." "field NonOmittedStruct should have the omitempty tag."
+	NonOmittedStruct *B `json:"nonOmittedStruct,omitempty"` // want "field A.NonOmittedStruct should be a pointer." "field A.NonOmittedStruct should have the omitempty tag."
 
     // structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties should be a pointer."
+	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties should be a pointer."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct should be a pointer."
+	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct should be a pointer."
 
 	// slice is a slice field.
 	// +optional
@@ -60,15 +60,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
     // PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -93,16 +93,16 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAliasWithEnum is a string alias field with enum validation.
 	// With the "Always" pointer preference, optional fields should be pointers regardless of zero value validity.
 	// +optional
-	StringAliasWithEnum *StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field StringAliasWithEnum should be a pointer."
+	StringAliasWithEnum *StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field A.StringAliasWithEnum should be a pointer."
 
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This is correctly a pointer since the zero value is not valid.
@@ -111,7 +111,7 @@ type A struct {
 	
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 }
 
 type B struct {

--- a/pkg/analysis/optionalfields/testdata/src/b/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/b/a.go
@@ -12,7 +12,7 @@ type A struct {
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -26,7 +26,7 @@ type A struct {
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -36,7 +36,7 @@ type A struct {
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -60,7 +60,7 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -70,11 +70,11 @@ type A struct {
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// int is an int field.
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -84,7 +84,7 @@ type A struct {
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithNegativeMaximumValue with negative maximum value is an int field.
 	// +kubebuilder:validation:Maximum=-1
@@ -94,32 +94,32 @@ type A struct {
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithRange is an int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithMinValue1 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=1.0
@@ -129,7 +129,7 @@ type A struct {
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithNegativeMaximumValue with negative maximum value is a float field.
 	// +kubebuilder:validation:Maximum=-1.0
@@ -139,49 +139,49 @@ type A struct {
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithRange is a float field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsFromAnotherFile is a struct field.
 	// +optional
-	StructWithRequiredFieldsFromAnotherFile StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFieldsFromAnotherFile StructWithRequiredField `json:"structWithRequiredFieldsFromAnotherFile,omitempty"` // want "field A.StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -197,7 +197,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolPointer is a pointer boolean field.
 	// +optional
@@ -213,15 +213,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -241,27 +241,27 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAlias is a string alias field.
 	// +optional
-	StringAlias StringAlias `json:"stringAlias,omitempty"` // want "field StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringAlias StringAlias `json:"stringAlias,omitempty"` // want "field A.StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// IntAlias is an int alias field.
 	// +optional
-	IntAlias IntAlias `json:"intAlias,omitempty"` // want "field IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntAlias IntAlias `json:"intAlias,omitempty"` // want "field A.IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// FloatAlias is a float alias field.
 	// +optional
-	FloatAlias FloatAlias `json:"floatAlias,omitempty"` // want "field FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatAlias FloatAlias `json:"floatAlias,omitempty"` // want "field A.FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// BoolAlias is a bool alias field.
 	// +optional
-	BoolAlias BoolAlias `json:"boolAlias,omitempty"` // want "field BoolAlias has a valid zero value \\(false\\) and should be a pointer."
+	BoolAlias BoolAlias `json:"boolAlias,omitempty"` // want "field A.BoolAlias has a valid zero value \\(false\\) and should be a pointer."
 
 	// SliceAlias is a slice alias field.
 	// +optional
@@ -279,11 +279,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -291,19 +291,19 @@ type A struct {
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
+	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field A.StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZero should have the omitempty tag"
+	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field A.StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZero should have the omitempty tag"
 
 	// structWithValidOmitZeroWithoutPointer is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZeroWithoutPointer D `json:"structWithValidOmitZeroWithoutPointer,omitempty,omitzero"` // want "field StructWithValidOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithValidOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
+	StructWithValidOmitZeroWithoutPointer D `json:"structWithValidOmitZeroWithoutPointer,omitempty,omitzero"` // want "field A.StructWithValidOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithValidOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
 
 	// structWithOnlyOmitZeroWithoutPointer is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZeroWithoutPointer D `json:"structWithOnlyOmitZeroWithoutPointer,omitzero"` // want "field StructWithOnlyOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZeroWithoutPointer should have the omitempty tag" "field StructWithOnlyOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
+	StructWithOnlyOmitZeroWithoutPointer D `json:"structWithOnlyOmitZeroWithoutPointer,omitzero"` // want "field A.StructWithOnlyOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZeroWithoutPointer should have the omitempty tag" "field A.StructWithOnlyOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
 }
 
 type B struct {
@@ -323,7 +323,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1

--- a/pkg/analysis/optionalfields/testdata/src/b/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/b/a.go.golden
@@ -12,7 +12,7 @@ type A struct {
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -26,7 +26,7 @@ type A struct {
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -36,7 +36,7 @@ type A struct {
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -60,7 +60,7 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -70,11 +70,11 @@ type A struct {
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// int is an int field.
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -84,7 +84,7 @@ type A struct {
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithNegativeMaximumValue with negative maximum value is an int field.
 	// +kubebuilder:validation:Maximum=-1
@@ -94,32 +94,32 @@ type A struct {
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithRange is an int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange *int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange *int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float *float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float *float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithMinValue1 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=1.0
@@ -129,7 +129,7 @@ type A struct {
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithNegativeMaximumValue with negative maximum value is a float field.
 	// +kubebuilder:validation:Maximum=-1.0
@@ -139,49 +139,49 @@ type A struct {
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithRange is a float field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsFromAnotherFile is a struct field.
 	// +optional
-	StructWithRequiredFieldsFromAnotherFile *StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFieldsFromAnotherFile *StructWithRequiredField `json:"structWithRequiredFieldsFromAnotherFile,omitempty"` // want "field A.StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -197,7 +197,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool *bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolPointer is a pointer boolean field.
 	// +optional
@@ -213,15 +213,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -241,27 +241,27 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAlias is a string alias field.
 	// +optional
-	StringAlias *StringAlias `json:"stringAlias,omitempty"` // want "field StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringAlias *StringAlias `json:"stringAlias,omitempty"` // want "field A.StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// IntAlias is an int alias field.
 	// +optional
-	IntAlias *IntAlias `json:"intAlias,omitempty"` // want "field IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntAlias *IntAlias `json:"intAlias,omitempty"` // want "field A.IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// FloatAlias is a float alias field.
 	// +optional
-	FloatAlias *FloatAlias `json:"floatAlias,omitempty"` // want "field FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatAlias *FloatAlias `json:"floatAlias,omitempty"` // want "field A.FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// BoolAlias is a bool alias field.
 	// +optional
-	BoolAlias *BoolAlias `json:"boolAlias,omitempty"` // want "field BoolAlias has a valid zero value \\(false\\) and should be a pointer."
+	BoolAlias *BoolAlias `json:"boolAlias,omitempty"` // want "field A.BoolAlias has a valid zero value \\(false\\) and should be a pointer."
 
 	// SliceAlias is a slice alias field.
 	// +optional
@@ -279,11 +279,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -291,19 +291,19 @@ type A struct {
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty"` // want "field StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
+	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty"` // want "field A.StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitempty"` // want "field StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZero should have the omitempty tag"
+	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitempty"` // want "field A.StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZero should have the omitempty tag"
 
 	// structWithValidOmitZeroWithoutPointer is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZeroWithoutPointer *D `json:"structWithValidOmitZeroWithoutPointer,omitempty"` // want "field StructWithValidOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithValidOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
+	StructWithValidOmitZeroWithoutPointer *D `json:"structWithValidOmitZeroWithoutPointer,omitempty"` // want "field A.StructWithValidOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithValidOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
 
 	// structWithOnlyOmitZeroWithoutPointer is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZeroWithoutPointer *D `json:"structWithOnlyOmitZeroWithoutPointer,omitempty"` // want "field StructWithOnlyOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZeroWithoutPointer should have the omitempty tag" "field StructWithOnlyOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
+	StructWithOnlyOmitZeroWithoutPointer *D `json:"structWithOnlyOmitZeroWithoutPointer,omitempty"` // want "field A.StructWithOnlyOmitZeroWithoutPointer has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZeroWithoutPointer should have the omitempty tag" "field A.StructWithOnlyOmitZeroWithoutPointer has a valid zero value \\(\\{\\}\\) and should be a pointer"
 }
 
 type B struct {
@@ -323,7 +323,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go
@@ -11,17 +11,17 @@ type A struct {
 
 	// pointerStringWithoutOmitEmpty is a pointer string field without omitempty/
 	// +optional
-	PointerStringWithoutOmitEmpty *string `json:"pointerStringWithoutOmitEmpty"` // want "field PointerStringWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStringWithoutOmitEmpty *string `json:"pointerStringWithoutOmitEmpty"` // want "field A.PointerStringWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength1WithoutOmitEmpty with minimum length is a pointer string field without omitempty.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1WithoutOmitEmpty *string `json:"pointerStringWithMinLength1WithoutOmitEmpty"` // want "field PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerStringWithMinLength1WithoutOmitEmpty *string `json:"pointerStringWithMinLength1WithoutOmitEmpty"` // want "field A.PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -31,7 +31,7 @@ type A struct {
 	// pointerStringWithMinLength0WithoutOmitempty with minimum length is a pointer string field without omitempty.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	PointerStringWithMinLength0WithoutOmitempty *string `json:"pointerStringWithMinLength0WithoutOmitempty"` // want "field PointerStringWithMinLength0WithoutOmitempty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength0WithoutOmitempty *string `json:"pointerStringWithMinLength0WithoutOmitempty"` // want "field A.PointerStringWithMinLength0WithoutOmitempty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerInt is a pointer int field.
 	// +optional
@@ -39,17 +39,17 @@ type A struct {
 
 	// pointerIntWithoutOmitEmpty is a pointer int field with omitempty.
 	// +optional
-	PointerIntWithoutOmitEmpty *int `json:"pointerIntWithoutOmitEmpty"` // want "field PointerIntWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithoutOmitEmpty *int `json:"pointerIntWithoutOmitEmpty"` // want "field A.PointerIntWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue1WithoutOmitEmpty with minimum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1WithoutOmitEmpty *int `json:"pointerIntWithMinValue1WithoutOmitEmpty"` // want "field PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerIntWithMinValue1WithoutOmitEmpty *int `json:"pointerIntWithMinValue1WithoutOmitEmpty"` // want "field A.PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -59,17 +59,17 @@ type A struct {
 	// pointerIntWithMinValue0WithoutOmitEmpty with minimum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	PointerIntWithMinValue0WithoutOmitEmpty *int `json:"pointerIntWithMinValue0WithoutOmitEmpty"` // want "field PointerIntWithMinValue0WithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue0WithoutOmitEmpty *int `json:"pointerIntWithMinValue0WithoutOmitEmpty"` // want "field A.PointerIntWithMinValue0WithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValueWithoutOmitEmpty *int `json:"pointerIntWithNegativeMaximumValueWithoutOmitEmpty"` // want "field PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerIntWithNegativeMaximumValueWithoutOmitEmpty *int `json:"pointerIntWithNegativeMaximumValueWithoutOmitEmpty"` // want "field A.PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -84,7 +84,7 @@ type A struct {
 	// pointerIntWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	PointerIntWithPositiveMaximumValueWithoutOmitEmpty *int `json:"pointerIntWithPositiveMaximumValueWithoutOmitEmpty"` // want "field PointerIntWithPositiveMaximumValueWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithPositiveMaximumValueWithoutOmitEmpty *int `json:"pointerIntWithPositiveMaximumValueWithoutOmitEmpty"` // want "field A.PointerIntWithPositiveMaximumValueWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithRange is a pointer int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
@@ -96,7 +96,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	PointerIntWithRangeWithoutOmitEmpty *int `json:"pointerIntWithRangeWithoutOmitEmpty"` // want "field PointerIntWithRangeWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithRangeWithoutOmitEmpty *int `json:"pointerIntWithRangeWithoutOmitEmpty"` // want "field A.PointerIntWithRangeWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStruct is a pointer struct field.
 	// +optional
@@ -104,11 +104,11 @@ type A struct {
 
 	// pointerStructWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithoutOmitEmpty *B `json:"pointerStructWithoutOmitEmpty"` // want "field PointerStructWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStructWithoutOmitEmpty *B `json:"pointerStructWithoutOmitEmpty"` // want "field A.PointerStructWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithoutOmitEmpty is a string field without omitempty.
 	// +optional
@@ -122,12 +122,12 @@ type A struct {
 	// stringWithMinLength1WithoutOmitEmpty with minimum length is a string field without omitempty.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	StringWithMinLength1WithoutOmitEmpty string `json:"stringWithMinLength1WithoutOmitEmpty"` // want "field StringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StringWithMinLength1WithoutOmitEmpty string `json:"stringWithMinLength1WithoutOmitEmpty"` // want "field A.StringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// EnumString is a string field with an enum.
 	// +kubebuilder:validation:Enum=foo;bar;baz
@@ -137,7 +137,7 @@ type A struct {
 	// EnumStringWithEmptyValue is a string field with an enum, also allowing the empty string.
 	// +kubebuilder:validation:Enum=foo;bar;baz;""
 	// +optional
-	EnumStringWithEmptyValue string `json:"enumStringWithEmptyValue,omitempty"` // want "field EnumStringWithEmptyValue has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumStringWithEmptyValue string `json:"enumStringWithEmptyValue,omitempty"` // want "field A.EnumStringWithEmptyValue has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// stringWithMinLength0WithoutOmitEmpty with minimum length is a string field without omitempty.
 	// +kubebuilder:validation:MinLength=0
@@ -146,7 +146,7 @@ type A struct {
 
 	// int is an int field.
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -156,12 +156,12 @@ type A struct {
 	// intWithMinValue1WithoutOmitEmpty with minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	IntWithMinValue1WithoutOmitEmpty int `json:"intWithMinValue1WithoutOmitEmpty"` // want "field IntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	IntWithMinValue1WithoutOmitEmpty int `json:"intWithMinValue1WithoutOmitEmpty"` // want "field A.IntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithMinValue0WithoutOmitEmpty with minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=0
@@ -176,12 +176,12 @@ type A struct {
 	// intWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is an int field without omitempty.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	IntWithNegativeMaximumValueWithoutOmitEmpty int `json:"intWithNegativeMaximumValueWithoutOmitEmpty"` // want "field IntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	IntWithNegativeMaximumValueWithoutOmitEmpty int `json:"intWithNegativeMaximumValueWithoutOmitEmpty"` // want "field A.IntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithNegativeMinimumValueWithoutOmitEmpty with negative minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=-1
@@ -191,7 +191,7 @@ type A struct {
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want  "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want  "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is an int field without omitempty.
 	// +kubebuilder:validation:Maximum=1
@@ -202,7 +202,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithRangeWithoutOmitEmpty is an int field with a range of values including 0 without omitempty.
 	// +kubebuilder:validation:Minimum=-10
@@ -213,16 +213,16 @@ type A struct {
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithoutOmitEmpty is a float field without omitempty.
 	// +optional
@@ -236,12 +236,12 @@ type A struct {
 	// floatWithMinValue1WithoutOmitEmpty with minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=1.0
 	// +optional
-	FloatWithMinValue1WithoutOmitEmpty float64 `json:"floatWithMinValue1WithoutOmitEmpty"` // want "field FloatWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	FloatWithMinValue1WithoutOmitEmpty float64 `json:"floatWithMinValue1WithoutOmitEmpty"` // want "field A.FloatWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithMinValue0WithoutOmitEmpty with minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=0.0
@@ -256,12 +256,12 @@ type A struct {
 	// floatWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is a float field without omitempty.
 	// +kubebuilder:validation:Maximum=-1.0
 	// +optional
-	FloatWithNegativeMaximumValueWithoutOmitEmpty float64 `json:"floatWithNegativeMaximumValueWithoutOmitEmpty"` // want "field FloatWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	FloatWithNegativeMaximumValueWithoutOmitEmpty float64 `json:"floatWithNegativeMaximumValueWithoutOmitEmpty"` // want "field A.FloatWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithNegativeMinimumValueWithoutOmitEmpty with negative minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=-1.0
@@ -271,7 +271,7 @@ type A struct {
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is a float field without omitempty.
 	// +kubebuilder:validation:Maximum=1.0
@@ -282,7 +282,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithRangeWithoutOmitEmpty is a float field with a range of values including 0 without omitempty.
 	// +kubebuilder:validation:Minimum=-10.0
@@ -293,16 +293,16 @@ type A struct {
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithOptionalFieldsWithoutOmitEmpty is a struct field without omitempty.
 	// +optional
@@ -311,24 +311,24 @@ type A struct {
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesWithoutOmitEmpty is a struct field with a minimum number of properties without omitempty.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinPropertiesWithoutOmitEmpty B `json:"structWithMinPropertiesWithoutOmitEmpty"` // want "field StructWithMinPropertiesWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field StructWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithMinPropertiesWithoutOmitEmpty B `json:"structWithMinPropertiesWithoutOmitEmpty"` // want "field A.StructWithMinPropertiesWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field A.StructWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesOnStructWithoutOmitEmpty is a struct field with a minimum number of properties on the struct without omitempty.
 	// +optional
-	StructWithMinPropertiesOnStructWithoutOmitEmpty D `json:"structWithMinPropertiesOnStructWithoutOmitEmpty"` // want "field StructWithMinPropertiesOnStructWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field StructWithMinPropertiesOnStructWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithMinPropertiesOnStructWithoutOmitEmpty D `json:"structWithMinPropertiesOnStructWithoutOmitEmpty"` // want "field A.StructWithMinPropertiesOnStructWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field A.StructWithMinPropertiesOnStructWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsWithoutOmitEmpty is a struct field without omitempty.
 	// +optional
@@ -336,15 +336,15 @@ type A struct {
 
 	// structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty is a struct field with required fields but where the zero values are not valid.
 	// +optional
-	StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty C `json:"structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty"` // want "field StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer." "field StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty C `json:"structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty"` // want "field A.StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer." "field A.StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithNonZeroByteArray is a struct field with a non-zero byte array.
 	// +optional
-	StructWithNonZeroByteArray F `json:"structWithNonZeroByteArray"` // want "field StructWithNonZeroByteArray has a valid zero value \\(\\{\"nonZeroByteArray\": \\[\\]\\}\\) and should be a pointer." "field StructWithNonZeroByteArray does not allow the zero value. It must have the omitempty tag."
+	StructWithNonZeroByteArray F `json:"structWithNonZeroByteArray"` // want "field A.StructWithNonZeroByteArray has a valid zero value \\(\\{\"nonZeroByteArray\": \\[\\]\\}\\) and should be a pointer." "field A.StructWithNonZeroByteArray does not allow the zero value. It must have the omitempty tag."
 
 	// structWithInvalidEmptyEnum is a struct field with an invalid empty enum.
 	// +optional
-	StructWithInvalidEmptyEnum G `json:"structWithInvalidEmptyEnum"` // want "field StructWithInvalidEmptyEnum has a valid zero value \\(\\{\"enumWithoutOmitEmpty\": \"\"\\}\\) and should be a pointer." "field StructWithInvalidEmptyEnum does not allow the zero value. It must have the omitempty tag."
+	StructWithInvalidEmptyEnum G `json:"structWithInvalidEmptyEnum"` // want "field A.StructWithInvalidEmptyEnum has a valid zero value \\(\\{\"enumWithoutOmitEmpty\": \"\"\\}\\) and should be a pointer." "field A.StructWithInvalidEmptyEnum does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -352,7 +352,7 @@ type A struct {
 
 	// pointerStructWithOptionalFieldsWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithOptionalFieldsWithoutOmitEmpty *B `json:"pointerStructWithOptionalFieldsWithoutOmitEmpty"` // want "field PointerStructWithOptionalFieldsWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStructWithOptionalFieldsWithoutOmitEmpty *B `json:"pointerStructWithOptionalFieldsWithoutOmitEmpty"` // want "field A.PointerStructWithOptionalFieldsWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStructWithRequiredFields is a pointer struct field.
 	// +optional
@@ -360,7 +360,7 @@ type A struct {
 
 	// pointerStructWithRequiredFieldsWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithRequiredFieldsWithoutOmitEmpty *C `json:"pointerStructWithRequiredFieldsWithoutOmitEmpty"` // want "field PointerStructWithRequiredFieldsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerStructWithRequiredFieldsWithoutOmitEmpty *C `json:"pointerStructWithRequiredFieldsWithoutOmitEmpty"` // want "field A.PointerStructWithRequiredFieldsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStructWithRequiredFromAnotherFile is a pointer struct field.
 	// +optional
@@ -368,7 +368,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolWithoutOmitEmpty is a boolean field without omitempty.
 	// +optional
@@ -380,7 +380,7 @@ type A struct {
 
 	// boolPointerWithoutOmitEmpty is a pointer boolean field without omitempty.
 	// +optional
-	BoolPointerWithoutOmitEmpty *bool `json:"boolPointerWithoutOmitEmpty"` // want "field BoolPointerWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	BoolPointerWithoutOmitEmpty *bool `json:"boolPointerWithoutOmitEmpty"` // want "field A.BoolPointerWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// slice is a slice field.
 	// +optional
@@ -394,7 +394,7 @@ type A struct {
 	// sliceWithMinItemsWithoutOmitEmpty is a slice field with a minimum number of items without omitempty.
 	// +kubebuilder:validation:MinItems=1
 	// +optional
-	SliceWithMinItemsWithoutOmitEmpty []string `json:"sliceWithMinItemsWithoutOmitEmpty"` // want "field SliceWithMinItemsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	SliceWithMinItemsWithoutOmitEmpty []string `json:"sliceWithMinItemsWithoutOmitEmpty"` // want "field A.SliceWithMinItemsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// map is a map field.
 	// +optional
@@ -408,19 +408,19 @@ type A struct {
 	// mapWithMinPropertiesWithoutOmitEmpty is a map field with a minimum number of properties without omitempty.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	MapWithMinPropertiesWithoutOmitEmpty map[string]string `json:"mapWithMinPropertiesWithoutOmitEmpty"` // want "field MapWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	MapWithMinPropertiesWithoutOmitEmpty map[string]string `json:"mapWithMinPropertiesWithoutOmitEmpty"` // want "field A.MapWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAliasWithEnum is a string alias field with enum validation.
 	// The zero value ("") is not in the enum, so this should NOT be a pointer.
@@ -430,11 +430,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field A.StringAliasWithEnumNoOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -442,11 +442,11 @@ type A struct {
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitzero,omitempty"` // want "field StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
+	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitzero,omitempty"` // want "field A.StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZero does not allow the zero value. It must have the omitempty tag."
+	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field A.StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZero does not allow the zero value. It must have the omitempty tag."
 }
 
 type B struct {
@@ -467,7 +467,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -542,7 +542,7 @@ type F struct {
 	// nonZeroByteArray is a byte array field that does not allow the zero value.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	NonZeroByteArray []byte `json:"nonZeroByteArray"` // want "field NonZeroByteArray does not allow the zero value. It must have the omitempty tag."
+	NonZeroByteArray []byte `json:"nonZeroByteArray"` // want "field F.NonZeroByteArray does not allow the zero value. It must have the omitempty tag."
 }
 
 type G struct {
@@ -550,7 +550,7 @@ type G struct {
 	// It does need to allow the zero value, else the parent zero value is not valid.
 	// +optional
 	// +kubebuilder:validation:Enum=foo;bar
-	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty"` // want "field EnumWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty"` // want "field G.EnumWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 }
 
 // StringAliasWithEnum is a string alias with enum validation.

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
@@ -11,17 +11,17 @@ type A struct {
 
 	// pointerStringWithoutOmitEmpty is a pointer string field without omitempty/
 	// +optional
-	PointerStringWithoutOmitEmpty string `json:"pointerStringWithoutOmitEmpty"` // want "field PointerStringWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStringWithoutOmitEmpty string `json:"pointerStringWithoutOmitEmpty"` // want "field A.PointerStringWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength1WithoutOmitEmpty with minimum length is a pointer string field without omitempty.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1WithoutOmitEmpty string `json:"pointerStringWithMinLength1WithoutOmitEmpty,omitempty"` // want "field PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerStringWithMinLength1WithoutOmitEmpty string `json:"pointerStringWithMinLength1WithoutOmitEmpty,omitempty"` // want "field A.PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerStringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -31,7 +31,7 @@ type A struct {
 	// pointerStringWithMinLength0WithoutOmitempty with minimum length is a pointer string field without omitempty.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	PointerStringWithMinLength0WithoutOmitempty string `json:"pointerStringWithMinLength0WithoutOmitempty"` // want "field PointerStringWithMinLength0WithoutOmitempty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength0WithoutOmitempty string `json:"pointerStringWithMinLength0WithoutOmitempty"` // want "field A.PointerStringWithMinLength0WithoutOmitempty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerInt is a pointer int field.
 	// +optional
@@ -39,17 +39,17 @@ type A struct {
 
 	// pointerIntWithoutOmitEmpty is a pointer int field with omitempty.
 	// +optional
-	PointerIntWithoutOmitEmpty int `json:"pointerIntWithoutOmitEmpty"` // want "field PointerIntWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithoutOmitEmpty int `json:"pointerIntWithoutOmitEmpty"` // want "field A.PointerIntWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue1WithoutOmitEmpty with minimum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1WithoutOmitEmpty int `json:"pointerIntWithMinValue1WithoutOmitEmpty,omitempty"` // want "field PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerIntWithMinValue1WithoutOmitEmpty int `json:"pointerIntWithMinValue1WithoutOmitEmpty,omitempty"` // want "field A.PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerIntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -59,17 +59,17 @@ type A struct {
 	// pointerIntWithMinValue0WithoutOmitEmpty with minimum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	PointerIntWithMinValue0WithoutOmitEmpty int `json:"pointerIntWithMinValue0WithoutOmitEmpty"` // want "field PointerIntWithMinValue0WithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue0WithoutOmitEmpty int `json:"pointerIntWithMinValue0WithoutOmitEmpty"` // want "field A.PointerIntWithMinValue0WithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValueWithoutOmitEmpty int `json:"pointerIntWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerIntWithNegativeMaximumValueWithoutOmitEmpty int `json:"pointerIntWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field A.PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. The field does not need to be a pointer." "field A.PointerIntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -84,7 +84,7 @@ type A struct {
 	// pointerIntWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is a pointer int field without omitempty.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	PointerIntWithPositiveMaximumValueWithoutOmitEmpty int `json:"pointerIntWithPositiveMaximumValueWithoutOmitEmpty"` // want "field PointerIntWithPositiveMaximumValueWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithPositiveMaximumValueWithoutOmitEmpty int `json:"pointerIntWithPositiveMaximumValueWithoutOmitEmpty"` // want "field A.PointerIntWithPositiveMaximumValueWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithRange is a pointer int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
@@ -96,7 +96,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	PointerIntWithRangeWithoutOmitEmpty int `json:"pointerIntWithRangeWithoutOmitEmpty"` // want "field PointerIntWithRangeWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerIntWithRangeWithoutOmitEmpty int `json:"pointerIntWithRangeWithoutOmitEmpty"` // want "field A.PointerIntWithRangeWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStruct is a pointer struct field.
 	// +optional
@@ -104,11 +104,11 @@ type A struct {
 
 	// pointerStructWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithoutOmitEmpty B `json:"pointerStructWithoutOmitEmpty"` // want "field PointerStructWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStructWithoutOmitEmpty B `json:"pointerStructWithoutOmitEmpty"` // want "field A.PointerStructWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithoutOmitEmpty is a string field without omitempty.
 	// +optional
@@ -122,12 +122,12 @@ type A struct {
 	// stringWithMinLength1WithoutOmitEmpty with minimum length is a string field without omitempty.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	StringWithMinLength1WithoutOmitEmpty string `json:"stringWithMinLength1WithoutOmitEmpty,omitempty"` // want "field StringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StringWithMinLength1WithoutOmitEmpty string `json:"stringWithMinLength1WithoutOmitEmpty,omitempty"` // want "field A.StringWithMinLength1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// EnumString is a string field with an enum.
 	// +kubebuilder:validation:Enum=foo;bar;baz
@@ -137,7 +137,7 @@ type A struct {
 	// EnumStringWithEmptyValue is a string field with an enum, also allowing the empty string.
 	// +kubebuilder:validation:Enum=foo;bar;baz;""
 	// +optional
-	EnumStringWithEmptyValue *string `json:"enumStringWithEmptyValue,omitempty"` // want "field EnumStringWithEmptyValue has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumStringWithEmptyValue *string `json:"enumStringWithEmptyValue,omitempty"` // want "field A.EnumStringWithEmptyValue has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// stringWithMinLength0WithoutOmitEmpty with minimum length is a string field without omitempty.
 	// +kubebuilder:validation:MinLength=0
@@ -146,7 +146,7 @@ type A struct {
 
 	// int is an int field.
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -156,12 +156,12 @@ type A struct {
 	// intWithMinValue1WithoutOmitEmpty with minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	IntWithMinValue1WithoutOmitEmpty int `json:"intWithMinValue1WithoutOmitEmpty,omitempty"` // want "field IntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	IntWithMinValue1WithoutOmitEmpty int `json:"intWithMinValue1WithoutOmitEmpty,omitempty"` // want "field A.IntWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithMinValue0WithoutOmitEmpty with minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=0
@@ -176,12 +176,12 @@ type A struct {
 	// intWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is an int field without omitempty.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	IntWithNegativeMaximumValueWithoutOmitEmpty int `json:"intWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field IntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	IntWithNegativeMaximumValueWithoutOmitEmpty int `json:"intWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field A.IntWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithNegativeMinimumValueWithoutOmitEmpty with negative minimum value is an int field without omitempty.
 	// +kubebuilder:validation:Minimum=-1
@@ -191,7 +191,7 @@ type A struct {
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want  "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want  "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is an int field without omitempty.
 	// +kubebuilder:validation:Maximum=1
@@ -202,7 +202,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange *int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange *int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithRangeWithoutOmitEmpty is an int field with a range of values including 0 without omitempty.
 	// +kubebuilder:validation:Minimum=-10
@@ -213,16 +213,16 @@ type A struct {
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float *float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float *float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithoutOmitEmpty is a float field without omitempty.
 	// +optional
@@ -236,12 +236,12 @@ type A struct {
 	// floatWithMinValue1WithoutOmitEmpty with minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=1.0
 	// +optional
-	FloatWithMinValue1WithoutOmitEmpty float64 `json:"floatWithMinValue1WithoutOmitEmpty,omitempty"` // want "field FloatWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	FloatWithMinValue1WithoutOmitEmpty float64 `json:"floatWithMinValue1WithoutOmitEmpty,omitempty"` // want "field A.FloatWithMinValue1WithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithMinValue0WithoutOmitEmpty with minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=0.0
@@ -256,12 +256,12 @@ type A struct {
 	// floatWithNegativeMaximumValueWithoutOmitEmpty with negative maximum value is a float field without omitempty.
 	// +kubebuilder:validation:Maximum=-1.0
 	// +optional
-	FloatWithNegativeMaximumValueWithoutOmitEmpty float64 `json:"floatWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field FloatWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	FloatWithNegativeMaximumValueWithoutOmitEmpty float64 `json:"floatWithNegativeMaximumValueWithoutOmitEmpty,omitempty"` // want "field A.FloatWithNegativeMaximumValueWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithNegativeMinimumValueWithoutOmitEmpty with negative minimum value is a float field without omitempty.
 	// +kubebuilder:validation:Minimum=-1.0
@@ -271,7 +271,7 @@ type A struct {
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValueWithoutOmitEmpty with positive maximum value is a float field without omitempty.
 	// +kubebuilder:validation:Maximum=1.0
@@ -282,7 +282,7 @@ type A struct {
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithRangeWithoutOmitEmpty is a float field with a range of values including 0 without omitempty.
 	// +kubebuilder:validation:Minimum=-10.0
@@ -293,16 +293,16 @@ type A struct {
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithOptionalFieldsWithoutOmitEmpty is a struct field without omitempty.
 	// +optional
@@ -311,24 +311,24 @@ type A struct {
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinProperties *B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesWithoutOmitEmpty is a struct field with a minimum number of properties without omitempty.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinPropertiesWithoutOmitEmpty *B `json:"structWithMinPropertiesWithoutOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field StructWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithMinPropertiesWithoutOmitEmpty *B `json:"structWithMinPropertiesWithoutOmitEmpty,omitempty"` // want "field A.StructWithMinPropertiesWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field A.StructWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
+	StructWithMinPropertiesOnStruct *D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct has a valid zero value \\(\\{\\}\\) and should be a pointer."
 
 	// structWithMinPropertiesOnStructWithoutOmitEmpty is a struct field with a minimum number of properties on the struct without omitempty.
 	// +optional
-	StructWithMinPropertiesOnStructWithoutOmitEmpty *D `json:"structWithMinPropertiesOnStructWithoutOmitEmpty,omitempty"` // want "field StructWithMinPropertiesOnStructWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field StructWithMinPropertiesOnStructWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithMinPropertiesOnStructWithoutOmitEmpty *D `json:"structWithMinPropertiesOnStructWithoutOmitEmpty,omitempty"` // want "field A.StructWithMinPropertiesOnStructWithoutOmitEmpty has a valid zero value \\(\\{\\}\\) and should be a pointer." "field A.StructWithMinPropertiesOnStructWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsWithoutOmitEmpty is a struct field without omitempty.
 	// +optional
@@ -336,15 +336,15 @@ type A struct {
 
 	// structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty is a struct field with required fields but where the zero values are not valid.
 	// +optional
-	StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty *C `json:"structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty,omitempty"` // want "field StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer." "field StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty *C `json:"structWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty,omitempty"` // want "field A.StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer." "field A.StructWithRequiredFieldsWithNonZeroAllowedValuesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// structWithNonZeroByteArray is a struct field with a non-zero byte array.
 	// +optional
-	StructWithNonZeroByteArray *F `json:"structWithNonZeroByteArray,omitempty"` // want "field StructWithNonZeroByteArray has a valid zero value \\(\\{\"nonZeroByteArray\": \\[\\]\\}\\) and should be a pointer." "field StructWithNonZeroByteArray does not allow the zero value. It must have the omitempty tag."
+	StructWithNonZeroByteArray *F `json:"structWithNonZeroByteArray,omitempty"` // want "field A.StructWithNonZeroByteArray has a valid zero value \\(\\{\"nonZeroByteArray\": \\[\\]\\}\\) and should be a pointer." "field A.StructWithNonZeroByteArray does not allow the zero value. It must have the omitempty tag."
 
 	// structWithInvalidEmptyEnum is a struct field with an invalid empty enum.
 	// +optional
-	StructWithInvalidEmptyEnum *G `json:"structWithInvalidEmptyEnum,omitempty"` // want "field StructWithInvalidEmptyEnum has a valid zero value \\(\\{\"enumWithoutOmitEmpty\": \"\"\\}\\) and should be a pointer." "field StructWithInvalidEmptyEnum does not allow the zero value. It must have the omitempty tag."
+	StructWithInvalidEmptyEnum *G `json:"structWithInvalidEmptyEnum,omitempty"` // want "field A.StructWithInvalidEmptyEnum has a valid zero value \\(\\{\"enumWithoutOmitEmpty\": \"\"\\}\\) and should be a pointer." "field A.StructWithInvalidEmptyEnum does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -352,7 +352,7 @@ type A struct {
 
 	// pointerStructWithOptionalFieldsWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithOptionalFieldsWithoutOmitEmpty B `json:"pointerStructWithOptionalFieldsWithoutOmitEmpty"` // want "field PointerStructWithOptionalFieldsWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PointerStructWithOptionalFieldsWithoutOmitEmpty B `json:"pointerStructWithOptionalFieldsWithoutOmitEmpty"` // want "field A.PointerStructWithOptionalFieldsWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// pointerStructWithRequiredFields is a pointer struct field.
 	// +optional
@@ -360,7 +360,7 @@ type A struct {
 
 	// pointerStructWithRequiredFieldsWithoutOmitEmpty is a pointer struct field without omitempty.
 	// +optional
-	PointerStructWithRequiredFieldsWithoutOmitEmpty *C `json:"pointerStructWithRequiredFieldsWithoutOmitEmpty,omitempty"` // want "field PointerStructWithRequiredFieldsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	PointerStructWithRequiredFieldsWithoutOmitEmpty *C `json:"pointerStructWithRequiredFieldsWithoutOmitEmpty,omitempty"` // want "field A.PointerStructWithRequiredFieldsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// pointerStructWithRequiredFromAnotherFile is a pointer struct field.
 	// +optional
@@ -368,7 +368,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool *bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolWithoutOmitEmpty is a boolean field without omitempty.
 	// +optional
@@ -380,7 +380,7 @@ type A struct {
 
 	// boolPointerWithoutOmitEmpty is a pointer boolean field without omitempty.
 	// +optional
-	BoolPointerWithoutOmitEmpty bool `json:"boolPointerWithoutOmitEmpty"` // want "field BoolPointerWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	BoolPointerWithoutOmitEmpty bool `json:"boolPointerWithoutOmitEmpty"` // want "field A.BoolPointerWithoutOmitEmpty does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// slice is a slice field.
 	// +optional
@@ -394,7 +394,7 @@ type A struct {
 	// sliceWithMinItemsWithoutOmitEmpty is a slice field with a minimum number of items without omitempty.
 	// +kubebuilder:validation:MinItems=1
 	// +optional
-	SliceWithMinItemsWithoutOmitEmpty []string `json:"sliceWithMinItemsWithoutOmitEmpty,omitempty"` // want "field SliceWithMinItemsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	SliceWithMinItemsWithoutOmitEmpty []string `json:"sliceWithMinItemsWithoutOmitEmpty,omitempty"` // want "field A.SliceWithMinItemsWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// map is a map field.
 	// +optional
@@ -408,19 +408,19 @@ type A struct {
 	// mapWithMinPropertiesWithoutOmitEmpty is a map field with a minimum number of properties without omitempty.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	MapWithMinPropertiesWithoutOmitEmpty map[string]string `json:"mapWithMinPropertiesWithoutOmitEmpty,omitempty"` // want "field MapWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	MapWithMinPropertiesWithoutOmitEmpty map[string]string `json:"mapWithMinPropertiesWithoutOmitEmpty,omitempty"` // want "field A.MapWithMinPropertiesWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAliasWithEnum is a string alias field with enum validation.
 	// The zero value ("") is not in the enum, so this should NOT be a pointer.
@@ -430,11 +430,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field A.StringAliasWithEnumNoOmitEmpty does not allow the zero value. It must have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -442,11 +442,11 @@ type A struct {
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty"` // want "field StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
+	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty"` // want "field A.StructWithValidOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitempty"` // want "field StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field StructWithOnlyOmitZero does not allow the zero value. It must have the omitempty tag."
+	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitempty"` // want "field A.StructWithOnlyOmitZero has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed." "field A.StructWithOnlyOmitZero does not allow the zero value. It must have the omitempty tag."
 }
 
 type B struct {
@@ -467,7 +467,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -542,7 +542,7 @@ type F struct {
 	// nonZeroByteArray is a byte array field that does not allow the zero value.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	NonZeroByteArray []byte `json:"nonZeroByteArray,omitempty"` // want "field NonZeroByteArray does not allow the zero value. It must have the omitempty tag."
+	NonZeroByteArray []byte `json:"nonZeroByteArray,omitempty"` // want "field F.NonZeroByteArray does not allow the zero value. It must have the omitempty tag."
 }
 
 type G struct {
@@ -550,7 +550,7 @@ type G struct {
 	// It does need to allow the zero value, else the parent zero value is not valid.
 	// +optional
 	// +kubebuilder:validation:Enum=foo;bar
-	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty,omitempty"` // want "field EnumWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty,omitempty"` // want "field G.EnumWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 }
 
 // StringAliasWithEnum is a string alias with enum validation.

--- a/pkg/analysis/optionalfields/testdata/src/d/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/d/a.go
@@ -12,7 +12,7 @@ type A struct {
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 *string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -26,7 +26,7 @@ type A struct {
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 *int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -36,7 +36,7 @@ type A struct {
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue *int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -60,7 +60,7 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -70,11 +70,11 @@ type A struct {
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// int is an int field.
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -84,7 +84,7 @@ type A struct {
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithNegativeMaximumValue with negative maximum value is an int field.
 	// +kubebuilder:validation:Maximum=-1
@@ -94,32 +94,32 @@ type A struct {
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue int `json:"intWithPositiveMaximumValue,omitempty"` // want "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithRange is an int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithMinValue1 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=1.0
@@ -129,7 +129,7 @@ type A struct {
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithNegativeMaximumValue with negative maximum value is a float field.
 	// +kubebuilder:validation:Maximum=-1.0
@@ -139,49 +139,49 @@ type A struct {
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithRange is a float field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties B `json:"structWithMinProperties,omitempty"` // want "field A.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field StructWithMinPropertiesOnStruct does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitempty"` // want "field A.StructWithMinPropertiesOnStruct does not allow the zero value. It must have the omitzero tag."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsFromAnotherFile is a struct field.
 	// +optional
-	StructWithRequiredFieldsFromAnotherFile StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFieldsFromAnotherFile StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -197,7 +197,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolPointer is a pointer boolean field.
 	// +optional
@@ -213,15 +213,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice *[]string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap *map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -241,27 +241,27 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias *SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAlias is a string alias field.
 	// +optional
-	StringAlias StringAlias `json:"stringAlias,omitempty"` // want "field StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringAlias StringAlias `json:"stringAlias,omitempty"` // want "field A.StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// IntAlias is an int alias field.
 	// +optional
-	IntAlias IntAlias `json:"intAlias,omitempty"` // want "field IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntAlias IntAlias `json:"intAlias,omitempty"` // want "field A.IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// FloatAlias is a float alias field.
 	// +optional
-	FloatAlias FloatAlias `json:"floatAlias,omitempty"` // want "field FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatAlias FloatAlias `json:"floatAlias,omitempty"` // want "field A.FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// BoolAlias is a bool alias field.
 	// +optional
-	BoolAlias BoolAlias `json:"boolAlias,omitempty"` // want "field BoolAlias has a valid zero value \\(false\\) and should be a pointer."
+	BoolAlias BoolAlias `json:"boolAlias,omitempty"` // want "field A.BoolAlias has a valid zero value \\(false\\) and should be a pointer."
 
 	// SliceAlias is a slice alias field.
 	// +optional
@@ -279,11 +279,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -301,19 +301,19 @@ type A struct {
 
 	// structWithNotValidZeroValue is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithNotValidZeroValue *D `json:"structWithNotValidZeroValue,omitempty"` // want "field StructWithNotValidZeroValue does not allow the zero value. It must have the omitzero tag" "field StructWithNotValidZeroValue does not allow the zero value. The field does not need to be a pointer."
+	StructWithNotValidZeroValue *D `json:"structWithNotValidZeroValue,omitempty"` // want "field A.StructWithNotValidZeroValue does not allow the zero value. It must have the omitzero tag" "field A.StructWithNotValidZeroValue does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithNotValidZeroValueWithOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithNotValidZeroValueWithOmitZero *D `json:"structWithNotValidZeroValueWithOmitZero,omitzero,omitempty"` // want "field StructWithNotValidZeroValueWithOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithNotValidZeroValueWithOmitZero *D `json:"structWithNotValidZeroValueWithOmitZero,omitzero,omitempty"` // want "field A.StructWithNotValidZeroValueWithOmitZero does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field StructWithValidOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithValidOmitZero *D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field A.StructWithValidOmitZero does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field StructWithOnlyOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithOnlyOmitZero *D `json:"structWithOnlyOmitZero,omitzero"` // want "field A.StructWithOnlyOmitZero does not allow the zero value. The field does not need to be a pointer."
 }
 
 type B struct {
@@ -333,7 +333,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1

--- a/pkg/analysis/optionalfields/testdata/src/d/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/d/a.go.golden
@@ -12,7 +12,7 @@ type A struct {
 	// pointerStringWithMinLength1 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
-	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
+	PointerStringWithMinLength1 string `json:"pointerStringWithMinLength1,omitempty"` // want "field A.PointerStringWithMinLength1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerStringWithMinLength0 with minimum length is a pointer string field.
 	// +kubebuilder:validation:MinLength=0
@@ -26,7 +26,7 @@ type A struct {
 	// pointerIntWithMinValue1 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithMinValue1 int `json:"pointerIntWithMinValue1,omitempty"` // want "field A.PointerIntWithMinValue1 does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithMinValue0 with minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=0
@@ -36,7 +36,7 @@ type A struct {
 	// pointerIntWithNegativeMaximumValue with negative maximum value is a pointer int field.
 	// +kubebuilder:validation:Maximum=-1
 	// +optional
-	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
+	PointerIntWithNegativeMaximumValue int `json:"pointerIntWithNegativeMaximumValue,omitempty"` // want "field A.PointerIntWithNegativeMaximumValue does not allow the zero value. The field does not need to be a pointer."
 
 	// pointerIntWithNegativeMinimumValue with negative minimum value is a pointer int field.
 	// +kubebuilder:validation:Minimum=-1
@@ -60,7 +60,7 @@ type A struct {
 
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field A.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1
@@ -70,11 +70,11 @@ type A struct {
 	// stringWithMinLength0 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=0
 	// +optional
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field A.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// int is an int field.
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field A.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithMinValue1 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=1
@@ -84,7 +84,7 @@ type A struct {
 	// intWithMinValue0 with minimum value is an int field.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
+	IntWithMinValue0 *int `json:"intWithMinValue0,omitempty"` // want "field A.IntWithMinValue0 has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithNegativeMaximumValue with negative maximum value is an int field.
 	// +kubebuilder:validation:Maximum=-1
@@ -94,32 +94,32 @@ type A struct {
 	// intWithNegativeMinimumValue with negative minimum value is an int field.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
-	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumValue *int `json:"intWithNegativeMinimumValue,omitempty"` // want "field A.IntWithNegativeMinimumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithPositiveMaximumValue with positive maximum value is an int field.
 	// +kubebuilder:validation:Maximum=1
 	// +optional
-	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want "field IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumValue *int `json:"intWithPositiveMaximumValue,omitempty"` // want "field A.IntWithPositiveMaximumValue has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// intWithRange is an int field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	IntWithRange *int `json:"intWithRange,omitempty"` // want "field IntWithRange has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRange *int `json:"intWithRange,omitempty"` // want "field A.IntWithRange has a valid zero value \\(0\\) and should be a pointer."
 
 	// intWithInvalidMinimumValue with invalid minimum value is an int field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMinimumValue int `json:"intWithInvalidMinimumValue,omitempty"` // want "field A.IntWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// intWithInvalidMaximumValue with invalid maximum value is an int field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	IntWithInvalidMaximumValue int `json:"intWithInvalidMaximumValue,omitempty"` // want "field A.IntWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// float is a float field.
 	// +optional
-	Float *float64 `json:"float,omitempty"` // want "field Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float *float64 `json:"float,omitempty"` // want "field A.Float has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithMinValue1 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=1.0
@@ -129,7 +129,7 @@ type A struct {
 	// floatWithMinValue0 with minimum value is a float field.
 	// +kubebuilder:validation:Minimum=0.0
 	// +optional
-	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithMinValue0 *float64 `json:"floatWithMinValue0,omitempty"` // want "field A.FloatWithMinValue0 has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithNegativeMaximumValue with negative maximum value is a float field.
 	// +kubebuilder:validation:Maximum=-1.0
@@ -139,49 +139,49 @@ type A struct {
 	// floatWithNegativeMinimumValue with negative minimum value is a float field.
 	// +kubebuilder:validation:Minimum=-1.0
 	// +optional
-	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithNegativeMinimumValue *float64 `json:"floatWithNegativeMinimumValue,omitempty"` // want "field A.FloatWithNegativeMinimumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithPositiveMaximumValue with positive maximum value is a float field.
 	// +kubebuilder:validation:Maximum=1.0
 	// +optional
-	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatWithPositiveMaximumValue *float64 `json:"floatWithPositiveMaximumValue,omitempty"` // want "field A.FloatWithPositiveMaximumValue has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// floatWithRange is a float field with a range of values including 0.
 	// +kubebuilder:validation:Minimum=-10.0
 	// +kubebuilder:validation:Maximum=10.0
 	// +optional
-	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
+	FloatWithRange *float64 `json:"floatWithRange,omitempty"` // want "field A.FloatWithRange has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// floatWithInvalidMinimumValue with invalid minimum value is a float field.
 	// +kubebuilder:validation:Minimum=foo
 	// +optional
-	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMinimumValue float64 `json:"floatWithInvalidMinimumValue,omitempty"` // want "field A.FloatWithInvalidMinimumValue has an invalid minimum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// floatWithInvalidMaximumValue with invalid maximum value is a float field.
 	// +kubebuilder:validation:Maximum=foo
 	// +optional
-	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
+	FloatWithInvalidMaximumValue float64 `json:"floatWithInvalidMaximumValue,omitempty"` // want "field A.FloatWithInvalidMaximumValue has an invalid maximum marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"foo\\\": invalid syntax"
 
 	// structWithOptionalFields is a struct field.
 	// +optional
-	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithOptionalFields *B `json:"structWithOptionalFields,omitempty"` // want "field A.StructWithOptionalFields has a valid zero value \\(\\{\\}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// structWithMinProperties is a struct field with a minimum number of properties.
 	// +kubebuilder:validation:MinProperties=1
 	// +optional
-	StructWithMinProperties B `json:"structWithMinProperties,omitzero,omitempty"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties B `json:"structWithMinProperties,omitzero,omitempty"` // want "field A.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
 	// structWithMinPropertiesOnStruct is a struct field with a minimum number of properties on the struct.
 	// +optional
-	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitzero,omitempty"` // want "field StructWithMinPropertiesOnStruct does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesOnStruct D `json:"structWithMinPropertiesOnStruct,omitzero,omitempty"` // want "field A.StructWithMinPropertiesOnStruct does not allow the zero value. It must have the omitzero tag."
 
 	// structWithRequiredFields is a struct field.
 	// +optional
-	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFields *C `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFields has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// structWithRequiredFieldsFromAnotherFile is a struct field.
 	// +optional
-	StructWithRequiredFieldsFromAnotherFile *StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
+	StructWithRequiredFieldsFromAnotherFile *StructWithRequiredField `json:"structWithRequiredFields,omitempty"` // want "field A.StructWithRequiredFieldsFromAnotherFile has a valid zero value \\(\\{\"string\": \"\"\\}\\) and should be a pointer."
 
 	// pointerStructWithOptionalFields is a pointer struct field.
 	// +optional
@@ -197,7 +197,7 @@ type A struct {
 
 	// bool is a boolean field.
 	// +optional
-	Bool *bool `json:"bool,omitempty"` // want "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field A.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// boolPointer is a pointer boolean field.
 	// +optional
@@ -213,15 +213,15 @@ type A struct {
 
 	// PointerSlice is a pointer slice field.
 	// +optional
-	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSlice []string `json:"pointerSlice,omitempty"` // want "field A.PointerSlice underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMap is a pointer map field.
 	// +optional
-	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field PointerMap underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMap map[string]string `json:"pointerMap,omitempty"` // want "field A.PointerMap underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerPointerString is a double pointer string field.
 	// +optional
-	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
+	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field A.DoublePointerString underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerStringAlias is a pointer string alias field.
 	// +optional
@@ -241,27 +241,27 @@ type A struct {
 
 	// PointerSliceAlias is a pointer slice alias field.
 	// +optional
-	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerSliceAlias SliceAlias `json:"pointerSliceAlias,omitempty"` // want "field A.PointerSliceAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
-	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
+	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field A.PointerMapAlias underlying type does not need to be a pointer. The pointer should be removed."
 
 	// StringAlias is a string alias field.
 	// +optional
-	StringAlias *StringAlias `json:"stringAlias,omitempty"` // want "field StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringAlias *StringAlias `json:"stringAlias,omitempty"` // want "field A.StringAlias has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// IntAlias is an int alias field.
 	// +optional
-	IntAlias *IntAlias `json:"intAlias,omitempty"` // want "field IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntAlias *IntAlias `json:"intAlias,omitempty"` // want "field A.IntAlias has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// FloatAlias is a float alias field.
 	// +optional
-	FloatAlias *FloatAlias `json:"floatAlias,omitempty"` // want "field FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	FloatAlias *FloatAlias `json:"floatAlias,omitempty"` // want "field A.FloatAlias has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// BoolAlias is a bool alias field.
 	// +optional
-	BoolAlias *BoolAlias `json:"boolAlias,omitempty"` // want "field BoolAlias has a valid zero value \\(false\\) and should be a pointer."
+	BoolAlias *BoolAlias `json:"boolAlias,omitempty"` // want "field A.BoolAlias has a valid zero value \\(false\\) and should be a pointer."
 
 	// SliceAlias is a slice alias field.
 	// +optional
@@ -279,11 +279,11 @@ type A struct {
 	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
 	// This should NOT be a pointer since the zero value is not valid.
 	// +optional
-	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
+	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field A.StringAliasWithEnumPointer does not allow the zero value. The field does not need to be a pointer."
 
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
-	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
 
 	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
 	// +optional
@@ -301,19 +301,19 @@ type A struct {
 
 	// structWithNotValidZeroValue is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithNotValidZeroValue D `json:"structWithNotValidZeroValue,omitzero,omitempty"` // want "field StructWithNotValidZeroValue does not allow the zero value. It must have the omitzero tag" "field StructWithNotValidZeroValue does not allow the zero value. The field does not need to be a pointer."
+	StructWithNotValidZeroValue D `json:"structWithNotValidZeroValue,omitzero,omitempty"` // want "field A.StructWithNotValidZeroValue does not allow the zero value. It must have the omitzero tag" "field A.StructWithNotValidZeroValue does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithNotValidZeroValueWithOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithNotValidZeroValueWithOmitZero D `json:"structWithNotValidZeroValueWithOmitZero,omitzero,omitempty"` // want "field StructWithNotValidZeroValueWithOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithNotValidZeroValueWithOmitZero D `json:"structWithNotValidZeroValueWithOmitZero,omitzero,omitempty"` // want "field A.StructWithNotValidZeroValueWithOmitZero does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithValidOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithValidOmitZero D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field StructWithValidOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithValidOmitZero D `json:"structWithValidOmitZero,omitempty,omitzero"` // want "field A.StructWithValidOmitZero does not allow the zero value. The field does not need to be a pointer."
 
 	// structWithOnlyOmitZero is a struct field with a minimum number of properties on the struct so not a valid zero value.
 	// +optional
-	StructWithOnlyOmitZero D `json:"structWithOnlyOmitZero,omitzero"` // want "field StructWithOnlyOmitZero does not allow the zero value. The field does not need to be a pointer."
+	StructWithOnlyOmitZero D `json:"structWithOnlyOmitZero,omitzero"` // want "field A.StructWithOnlyOmitZero does not allow the zero value. The field does not need to be a pointer."
 }
 
 type B struct {
@@ -333,7 +333,7 @@ type C struct {
 type D struct {
 	// string is a string field.
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field D.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// stringWithMinLength1 with minimum length is a string field.
 	// +kubebuilder:validation:MinLength=1

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -93,14 +93,14 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, _ string) {
-		a.checkField(pass, field, markersAccess, jsonTagInfo)
+	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
+		a.checkField(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo, qualifiedFieldName string) {
 	if field == nil || len(field.Names) == 0 {
 		return
 	}
@@ -115,7 +115,7 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAcce
 		return
 	}
 
-	a.serializationCheck.Check(pass, field, markersAccess, jsonTags)
+	a.serializationCheck.Check(pass, field, markersAccess, jsonTags, qualifiedFieldName)
 }
 
 func defaultConfig(cfg *RequiredFieldsConfig) {

--- a/pkg/analysis/requiredfields/testdata/src/a/arrays.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/arrays.go
@@ -2,13 +2,13 @@ package a
 
 type TestArrays struct {
 	// +required
-	Array []string `json:"array"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array"` // want "field TestArrays.Array should have the omitempty tag."
 
 	// +required
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
 	// +required
-	ArrayPtr []*string `json:"arrayPtr"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	// +required
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
@@ -16,7 +16,7 @@ type TestArrays struct {
 	// This is not picked up as the field is marked as optional.
 	// +kubebuilder:validation:MinItems=1
 	// +required
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// This is not picked up as the field is marked as optional.
 	// +kubebuilder:validation:MinItems=1
@@ -29,7 +29,7 @@ type TestArrays struct {
 
 	// +kubebuilder:validation:MinItems=0
 	// +required
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	// +optional
@@ -42,7 +42,7 @@ type TestArrays struct {
 
 	// +kubebuilder:validation:MinLength=1
 	// +required
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	// +required
@@ -56,8 +56,8 @@ type TestArrays struct {
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +required
-	PtrArray *[]string `json:"ptrArray"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray *[]string `json:"ptrArray"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +required
-	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/arrays.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/arrays.go.golden
@@ -2,13 +2,13 @@ package a
 
 type TestArrays struct {
 	// +required
-	Array []string `json:"array,omitempty"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array,omitempty"` // want "field TestArrays.Array should have the omitempty tag."
 
 	// +required
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
 	// +required
-	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	// +required
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
@@ -16,7 +16,7 @@ type TestArrays struct {
     // This is not picked up as the field is marked as optional.
 	// +kubebuilder:validation:MinItems=1
 	// +required
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// This is not picked up as the field is marked as optional.
 	// +kubebuilder:validation:MinItems=1
@@ -29,7 +29,7 @@ type TestArrays struct {
 
 	// +kubebuilder:validation:MinItems=0
 	// +required
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	// +optional
@@ -42,7 +42,7 @@ type TestArrays struct {
 
 	// +kubebuilder:validation:MinLength=1
 	// +required
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	// +required
@@ -56,8 +56,8 @@ type TestArrays struct {
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +required
-	PtrArray []string `json:"ptrArray,omitempty"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray []string `json:"ptrArray,omitempty"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +required
-	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/bool.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/bool.go
@@ -2,13 +2,13 @@ package a
 
 type TestBools struct {
 	// +kubebuilder:validation:Required
-	Bool bool `json:"bool"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
 	// +kubebuilder:validation:Required
-	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
 	// +kubebuilder:validation:Required
-	BoolPtr *bool `json:"boolPtr"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Required
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/requiredfields/testdata/src/a/bool.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/bool.go.golden
@@ -2,13 +2,13 @@ package a
 
 type TestBools struct {
     // +kubebuilder:validation:Required
-	Bool *bool `json:"bool,omitempty"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
     // +kubebuilder:validation:Required
-	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
     // +kubebuilder:validation:Required
-	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
     // +kubebuilder:validation:Required
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/requiredfields/testdata/src/a/maps.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/maps.go
@@ -2,20 +2,20 @@ package a
 
 type TestMaps struct {
 	// +required
-	Map map[string]string `json:"map"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map"` // want "field TestMaps.Map should have the omitempty tag."
 
 	// +required
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
 	// +required
-	MapPtr *map[string]string `json:"mapPtr"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr *map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +required
-	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
 	// +required
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	// +required
@@ -23,7 +23,7 @@ type TestMaps struct {
 
 	// +kubebuilder:validation:MinProperties=0
 	// +required
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	// +required

--- a/pkg/analysis/requiredfields/testdata/src/a/maps.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/maps.go.golden
@@ -2,20 +2,20 @@ package a
 
 type TestMaps struct {
     // +required
-	Map map[string]string `json:"map,omitempty"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map,omitempty"` // want "field TestMaps.Map should have the omitempty tag."
 
     // +required
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
     // +required
-	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
     // +required
-	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
 	// +required
-    MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+    MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	// +required
@@ -23,7 +23,7 @@ type TestMaps struct {
 
 	// +kubebuilder:validation:MinProperties=0
 	// +required
-    MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+    MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	// +required

--- a/pkg/analysis/requiredfields/testdata/src/a/numbers.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/numbers.go
@@ -2,14 +2,14 @@ package a
 
 type TestNumbers struct {
 	// +required
-	Int int `json:"int"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
@@ -17,39 +17,39 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
@@ -58,30 +58,30 @@ type TestNumbers struct {
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
-	IntPtr *int `json:"intPtr"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	// +required
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
@@ -89,7 +89,7 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
@@ -97,7 +97,7 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
@@ -105,7 +105,7 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
@@ -113,16 +113,16 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
@@ -130,78 +130,78 @@ type TestNumbers struct {
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
 	// +required
-	Int32 int32 `json:"int32"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 int32 `json:"int32"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
-	Int64 int64 `json:"int64"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 int64 `json:"int64"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +required
-	Float32 float32 `json:"float32"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 float32 `json:"float32"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
@@ -209,39 +209,39 @@ type TestNumbers struct {
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
@@ -250,42 +250,42 @@ type TestNumbers struct {
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
-	Float64 float64 `json:"float64"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 float64 `json:"float64"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/numbers.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/numbers.go.golden
@@ -2,14 +2,14 @@ package a
 
 type TestNumbers struct {
     // +required
-	Int *int `json:"int,omitempty"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
@@ -17,39 +17,39 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
@@ -58,30 +58,30 @@ type TestNumbers struct {
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
-	IntPtr *int `json:"intPtr,omitempty"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr,omitempty"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
     // +required
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
@@ -89,7 +89,7 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
@@ -97,7 +97,7 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
@@ -105,7 +105,7 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
@@ -113,16 +113,16 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
@@ -130,78 +130,78 @@ type TestNumbers struct {
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
     // +required
-	Int32 *int32 `json:"int32,omitempty"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 *int32 `json:"int32,omitempty"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
-	Int64 *int64 `json:"int64,omitempty"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 *int64 `json:"int64,omitempty"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
     // +required
-	Float32 *float32 `json:"float32,omitempty"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 *float32 `json:"float32,omitempty"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
@@ -209,39 +209,39 @@ type TestNumbers struct {
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
@@ -250,42 +250,42 @@ type TestNumbers struct {
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
-	Float64 *float64 `json:"float64,omitempty"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 *float64 `json:"float64,omitempty"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/strings.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/strings.go
@@ -2,20 +2,20 @@ package a
 
 type TestStrings struct {
 	// +required
-	String string `json:"string"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	StringPtr *string `json:"stringPtr"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	// +required
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:MinLength=1
@@ -23,23 +23,23 @@ type TestStrings struct {
 
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:MinLength=0
@@ -47,7 +47,7 @@ type TestStrings struct {
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString"` // want "field TestStrings.EnumString should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c
@@ -55,23 +55,23 @@ type TestStrings struct {
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr *string `json:"enumStringPtr"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +required
 	// +kubebuilder:validation:Enum=a;b;c;""

--- a/pkg/analysis/requiredfields/testdata/src/a/strings.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/strings.go.golden
@@ -2,20 +2,20 @@ package a
 
 type TestStrings struct {
     // +required
-	String *string `json:"string,omitempty"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	StringPtr *string `json:"stringPtr,omitempty"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr,omitempty"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
     // +required
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
     // +required
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:MinLength=1
@@ -23,23 +23,23 @@ type TestStrings struct {
 
     // +required
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:MinLength=0
@@ -47,7 +47,7 @@ type TestStrings struct {
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString,omitempty"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString,omitempty"` // want "field TestStrings.EnumString should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c
@@ -55,23 +55,23 @@ type TestStrings struct {
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
     // +required
 	// +kubebuilder:validation:Enum=a;b;c;""

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go
@@ -4,13 +4,13 @@ type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
 	// +required
-	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +required
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	// +required
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
@@ -18,27 +18,27 @@ type TestStructs struct {
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
 	// +required
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
-	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
 	// +required
-	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
 	// +required
-	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
 	// +required
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	// +required
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
@@ -46,13 +46,13 @@ type TestStructs struct {
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
 	// +required
-	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
 	// +required
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
 	// +required
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	// +required
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
@@ -60,30 +60,30 @@ type TestStructs struct {
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
 	// +required
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
-	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
 	// +required
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
 	// +required
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
 	// +required
-	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }
 
 type StructWithAllOptionalFields struct {
@@ -109,10 +109,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -121,10 +121,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -132,7 +132,7 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
 	Int int32 `json:"int,omitempty"`
@@ -142,5 +142,5 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
@@ -5,13 +5,13 @@ type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
     // +required
-	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
     // +required
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
     // +required
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
@@ -19,27 +19,27 @@ type TestStructs struct {
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
     // +required
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties,omitzero"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties,omitzero"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructPtrWithMinProperties StructWithMinProperties `json:"structPtrWithMinProperties,omitzero"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinProperties StructWithMinProperties `json:"structPtrWithMinProperties,omitzero"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
 
     // +required
-	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
     // +required
-	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
     // +required
-	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
     // +required
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
     // +required
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
@@ -47,13 +47,13 @@ type TestStructs struct {
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
     // +required
-	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
     // +required
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
     // +required
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
     // +required
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
@@ -61,30 +61,30 @@ type TestStructs struct {
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
     // +required
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructPtrWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitzero"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitzero"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
 
     // +required
-	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
     // +required
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitzero"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
     // +required
-	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
     // +required
-	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }
 
 type StructWithAllOptionalFields struct {
@@ -110,10 +110,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -122,10 +122,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -133,7 +133,7 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
 	Int int32 `json:"int,omitempty"`
@@ -143,5 +143,5 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/serialization_check.go
+++ b/pkg/analysis/utils/serialization/serialization_check.go
@@ -28,7 +28,7 @@ import (
 
 // SerializationCheck is an interface for checking serialization of fields.
 type SerializationCheck interface {
-	Check(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo)
+	Check(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo, qualifiedFieldName string)
 }
 
 // New creates a new SerializationCheck with the given configuration.
@@ -87,10 +87,10 @@ type serializationCheck struct {
 
 // Check checks the serialization of the field.
 // It will check if the zero value of the field is valid, and whether the field should be a pointer or not.
-func (s *serializationCheck) Check(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo) {
+func (s *serializationCheck) Check(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, jsonTags extractjsontags.FieldTagInfo, qualifiedFieldName string) {
 	fieldName := utils.FieldName(field)
 
-	hasValidZeroValue, completeValidation := utils.IsZeroValueValid(pass, field, field.Type, markersAccess, s.omitZeroPolicy != OmitZeroPolicyForbid)
+	hasValidZeroValue, completeValidation := utils.IsZeroValueValid(pass, field, field.Type, markersAccess, s.omitZeroPolicy != OmitZeroPolicyForbid, qualifiedFieldName)
 	hasOmitEmpty := jsonTags.OmitEmpty
 	hasOmitZero := jsonTags.OmitZero
 	isPointer, underlying := utils.IsStarExpr(field.Type)
@@ -99,45 +99,45 @@ func (s *serializationCheck) Check(pass *analysis.Pass, field *ast.Field, marker
 	switch s.pointerPreference {
 	case PointersPreferenceAlways:
 		// The field must always be a pointer, pointers require omitempty, so enforce that too.
-		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "should be a pointer.")
-		s.handleFieldShouldHaveOmitEmpty(pass, field, fieldName, hasOmitEmpty, jsonTags)
+		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "should be a pointer.", qualifiedFieldName)
+		s.handleFieldShouldHaveOmitEmpty(pass, field, qualifiedFieldName, hasOmitEmpty, jsonTags)
 	case PointersPreferenceWhenRequired:
-		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct, markersAccess)
+		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct, markersAccess, qualifiedFieldName)
 
 		if s.omitEmptyPolicy != OmitEmptyPolicyIgnore || hasOmitEmpty {
 			// If we require omitempty, or the field has omitempty, we can check the field properties based on it being an omitempty field.
-			s.checkFieldPropertiesWithOmitEmptyRequired(pass, field, fieldName, jsonTags, underlying, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess)
+			s.checkFieldPropertiesWithOmitEmptyRequired(pass, field, fieldName, jsonTags, underlying, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess, qualifiedFieldName)
 		} else {
 			// The field does not have omitempty, and does not require it.
-			s.checkFieldPropertiesWithoutOmitEmpty(pass, field, fieldName, jsonTags, underlying, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess)
+			s.checkFieldPropertiesWithoutOmitEmpty(pass, field, fieldName, jsonTags, underlying, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess, qualifiedFieldName)
 		}
 	default:
 		panic(fmt.Sprintf("unknown pointer preference: %s", s.pointerPreference))
 	}
 }
 
-func (s *serializationCheck) handleFieldOmitZero(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitZero, hasValidZeroValue, isPointer, isStruct bool, markersAccess markershelper.Markers) {
+func (s *serializationCheck) handleFieldOmitZero(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitZero, hasValidZeroValue, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	switch s.omitZeroPolicy {
 	case OmitZeroPolicyForbid:
 		// when the omitzero policy is set to forbid, we need to report removing omitzero if set on the struct fields.
-		s.checkFieldPropertiesWithOmitZeroForbidPolicy(pass, field, fieldName, isStruct, hasOmitZero, jsonTags)
+		s.checkFieldPropertiesWithOmitZeroForbidPolicy(pass, field, qualifiedFieldName, isStruct, hasOmitZero, jsonTags)
 	case OmitZeroPolicyWarn, OmitZeroPolicySuggestFix:
 		// If we require omitzero, or the field has omitzero, we can check the field properties based on it being an omitzero field.
-		s.checkFieldPropertiesWithOmitZeroRequired(pass, field, fieldName, jsonTags, underlying, hasOmitZero, isPointer, isStruct, hasValidZeroValue, markersAccess)
+		s.checkFieldPropertiesWithOmitZeroRequired(pass, field, fieldName, jsonTags, underlying, hasOmitZero, isPointer, isStruct, hasValidZeroValue, markersAccess, qualifiedFieldName)
 	default:
 		panic(fmt.Sprintf("unknown omit zero policy: %s", s.omitZeroPolicy))
 	}
 }
 
-func (s *serializationCheck) handleFieldShouldHaveOmitEmpty(pass *analysis.Pass, field *ast.Field, fieldName string, hasOmitEmpty bool, jsonTags extractjsontags.FieldTagInfo) {
+func (s *serializationCheck) handleFieldShouldHaveOmitEmpty(pass *analysis.Pass, field *ast.Field, qualifiedFieldName string, hasOmitEmpty bool, jsonTags extractjsontags.FieldTagInfo) {
 	if hasOmitEmpty {
 		return
 	}
 
-	reportShouldAddOmitEmpty(pass, field, s.omitEmptyPolicy, fieldName, "field %s should have the omitempty tag.", jsonTags)
+	reportShouldAddOmitEmpty(pass, field, s.omitEmptyPolicy, qualifiedFieldName, "field %s should have the omitempty tag.", jsonTags)
 }
 
-func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers) {
+func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	switch {
 	case isStruct && !hasValidZeroValue && s.omitZeroPolicy != OmitZeroPolicyForbid:
 		// The struct field need not be pointer if it does not have a valid zero value.
@@ -146,72 +146,72 @@ func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *ana
 		zeroValue := utils.GetTypedZeroValue(pass, underlying)
 		validationHint := utils.GetTypedValidationHint(pass, underlying)
 
-		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, fmt.Sprintf("has a valid zero value (%s), but the validation is not complete (e.g. %s). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer.", zeroValue, validationHint))
+		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, fmt.Sprintf("has a valid zero value (%s), but the validation is not complete (e.g. %s). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer.", zeroValue, validationHint), qualifiedFieldName)
 	case hasValidZeroValue, isStruct:
 		// The field validation infers that the zero value is valid, the field needs to be a pointer.
 		// Structs with omitempty should always be pointers, else they won't actually be omitted.
 		zeroValue := utils.GetTypedZeroValue(pass, underlying)
 
-		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, fmt.Sprintf("has a valid zero value (%s) and should be a pointer.", zeroValue))
+		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, fmt.Sprintf("has a valid zero value (%s) and should be a pointer.", zeroValue), qualifiedFieldName)
 	case !hasValidZeroValue && completeValidation && !isStruct:
 		// The validation is fully complete, and the zero value is not valid, so we don't need a pointer.
-		s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not allow the zero value. The field does not need to be a pointer.")
+		s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not allow the zero value. The field does not need to be a pointer.", qualifiedFieldName)
 	}
 
 	// In this case, we should always add the omitempty if it isn't present.
-	s.handleFieldShouldHaveOmitEmpty(pass, field, fieldName, hasOmitEmpty, jsonTags)
+	s.handleFieldShouldHaveOmitEmpty(pass, field, qualifiedFieldName, hasOmitEmpty, jsonTags)
 }
 
-func (s *serializationCheck) checkFieldPropertiesWithoutOmitEmpty(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers) {
+func (s *serializationCheck) checkFieldPropertiesWithoutOmitEmpty(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	switch {
 	case hasValidZeroValue:
 		// The field is not omitempty, and the zero value is valid, the field does not need to be a pointer.
-		s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not have omitempty and allows the zero value. The field does not need to be a pointer.")
+		s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not have omitempty and allows the zero value. The field does not need to be a pointer.", qualifiedFieldName)
 	case !hasValidZeroValue:
 		// The zero value would not be accepted, so the field needs to have omitempty.
 		// Force the omitempty policy to suggest a fix. We can only get to this function when the policy is configured to Ignore.
 		// Since we absolutely have to add the omitempty tag, we can report it as a suggestion.
-		reportShouldAddOmitEmpty(pass, field, OmitEmptyPolicySuggestFix, fieldName, "field %s does not allow the zero value. It must have the omitempty tag.", jsonTags)
+		reportShouldAddOmitEmpty(pass, field, OmitEmptyPolicySuggestFix, qualifiedFieldName, "field %s does not allow the zero value. It must have the omitempty tag.", jsonTags)
 		// Once it has the omitempty tag, it will also need to be a pointer in some cases.
 		// Now handle it as if it had the omitempty already.
 		// We already handle the omitempty tag above, so force the `hasOmitEmpty` to true.
-		s.checkFieldPropertiesWithOmitEmptyRequired(pass, field, fieldName, jsonTags, underlying, true, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess)
+		s.checkFieldPropertiesWithOmitEmptyRequired(pass, field, fieldName, jsonTags, underlying, true, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess, qualifiedFieldName)
 	}
 }
 
-func (s *serializationCheck) checkFieldPropertiesWithOmitZeroRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitZero, isPointer, isStruct, hasValidZeroValue bool, markersAccess markershelper.Markers) {
+func (s *serializationCheck) checkFieldPropertiesWithOmitZeroRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitZero, isPointer, isStruct, hasValidZeroValue bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	if !isStruct || hasValidZeroValue {
 		return
 	}
 
-	s.handleFieldShouldHaveOmitZero(pass, field, fieldName, hasOmitZero, jsonTags)
-	s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not allow the zero value. The field does not need to be a pointer.")
+	s.handleFieldShouldHaveOmitZero(pass, field, qualifiedFieldName, hasOmitZero, jsonTags)
+	s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not allow the zero value. The field does not need to be a pointer.", qualifiedFieldName)
 }
 
-func (s *serializationCheck) checkFieldPropertiesWithOmitZeroForbidPolicy(pass *analysis.Pass, field *ast.Field, fieldName string, isStruct, hasOmitZero bool, jsonTags extractjsontags.FieldTagInfo) {
+func (s *serializationCheck) checkFieldPropertiesWithOmitZeroForbidPolicy(pass *analysis.Pass, field *ast.Field, qualifiedFieldName string, isStruct, hasOmitZero bool, jsonTags extractjsontags.FieldTagInfo) {
 	if !isStruct || !hasOmitZero {
 		// Handle omitzero only for struct field having omitZero tag.
 		return
 	}
 
-	reportShouldRemoveOmitZero(pass, field, fieldName, jsonTags)
+	reportShouldRemoveOmitZero(pass, field, qualifiedFieldName, jsonTags)
 }
 
-func (s *serializationCheck) handleFieldShouldHaveOmitZero(pass *analysis.Pass, field *ast.Field, fieldName string, hasOmitZero bool, jsonTags extractjsontags.FieldTagInfo) {
+func (s *serializationCheck) handleFieldShouldHaveOmitZero(pass *analysis.Pass, field *ast.Field, qualifiedFieldName string, hasOmitZero bool, jsonTags extractjsontags.FieldTagInfo) {
 	if hasOmitZero {
 		return
 	}
 
 	// Currently, add omitzero tags to only struct fields.
-	reportShouldAddOmitZero(pass, field, s.omitZeroPolicy, fieldName, "field %s does not allow the zero value. It must have the omitzero tag.", jsonTags)
+	reportShouldAddOmitZero(pass, field, s.omitZeroPolicy, qualifiedFieldName, "field %s does not allow the zero value. It must have the omitzero tag.", jsonTags)
 }
 
-func (s *serializationCheck) handleFieldShouldBePointer(pass *analysis.Pass, field *ast.Field, fieldName string, isPointer bool, underlying ast.Expr, markersAccess markershelper.Markers, reason string) {
+func (s *serializationCheck) handleFieldShouldBePointer(pass *analysis.Pass, field *ast.Field, fieldName string, isPointer bool, underlying ast.Expr, markersAccess markershelper.Markers, reason, qualifiedFieldName string) {
 	if utils.IsPointerType(pass, underlying) {
 		if isPointer {
-			s.handlePointerToPointerType(pass, field, fieldName, underlying, markersAccess)
+			s.handlePointerToPointerType(pass, field, fieldName, underlying, markersAccess, qualifiedFieldName)
 		} else if s.pointerPreference == PointersPreferenceAlways {
-			s.handleNonPointerToPointerType(pass, field, fieldName, underlying, markersAccess)
+			s.handleNonPointerToPointerType(pass, field, fieldName, underlying, markersAccess, qualifiedFieldName)
 		}
 
 		return
@@ -221,10 +221,10 @@ func (s *serializationCheck) handleFieldShouldBePointer(pass *analysis.Pass, fie
 		return
 	}
 
-	s.reportShouldAddPointerMessage(pass, field, fieldName, reason)
+	s.reportShouldAddPointerMessage(pass, field, fieldName, reason, qualifiedFieldName)
 }
 
-func (s *serializationCheck) handlePointerToPointerType(pass *analysis.Pass, field *ast.Field, fieldName string, underlying ast.Expr, markersAccess markershelper.Markers) {
+func (s *serializationCheck) handlePointerToPointerType(pass *analysis.Pass, field *ast.Field, fieldName string, underlying ast.Expr, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	// Check if this is a pointer-to-slice/map with explicit MinItems=0 or MinProperties=0
 	// In this case, the pointer is intentional to distinguish nil from empty
 	if hasExplicitZeroMinValidation(pass, field, underlying, markersAccess) {
@@ -233,32 +233,32 @@ func (s *serializationCheck) handlePointerToPointerType(pass *analysis.Pass, fie
 
 	switch s.pointerPolicy {
 	case PointersPolicySuggestFix:
-		reportShouldRemovePointer(pass, field, PointersPolicySuggestFix, fieldName, "field %s underlying type does not need to be a pointer. The pointer should be removed.", fieldName)
+		reportShouldRemovePointer(pass, field, PointersPolicySuggestFix, fieldName, "field %s underlying type does not need to be a pointer. The pointer should be removed.", qualifiedFieldName)
 	case PointersPolicyWarn:
-		pass.Reportf(field.Pos(), "field %s underlying type does not need to be a pointer. The pointer should be removed.", fieldName)
+		pass.Reportf(field.Pos(), "field %s underlying type does not need to be a pointer. The pointer should be removed.", qualifiedFieldName)
 	}
 }
 
-func (s *serializationCheck) handleNonPointerToPointerType(pass *analysis.Pass, field *ast.Field, fieldName string, underlying ast.Expr, markersAccess markershelper.Markers) {
+func (s *serializationCheck) handleNonPointerToPointerType(pass *analysis.Pass, field *ast.Field, fieldName string, underlying ast.Expr, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	// Check if this is a slice/map WITHOUT a pointer but with explicit MinItems=0 or MinProperties=0
 	// In this case, we should suggest adding a pointer to distinguish nil from empty
 	if !hasExplicitZeroMinValidation(pass, field, underlying, markersAccess) {
 		return
 	}
 
-	s.reportShouldAddPointerMessage(pass, field, fieldName, "with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil (unset) from empty.")
+	s.reportShouldAddPointerMessage(pass, field, fieldName, "with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil (unset) from empty.", qualifiedFieldName)
 }
 
-func (s *serializationCheck) reportShouldAddPointerMessage(pass *analysis.Pass, field *ast.Field, fieldName, reason string) {
+func (s *serializationCheck) reportShouldAddPointerMessage(pass *analysis.Pass, field *ast.Field, fieldName, reason, qualifiedFieldName string) {
 	switch s.pointerPolicy {
 	case PointersPolicySuggestFix:
-		reportShouldAddPointer(pass, field, PointersPolicySuggestFix, fieldName, "field %s %s", fieldName, reason)
+		reportShouldAddPointer(pass, field, PointersPolicySuggestFix, fieldName, "field %s %s", qualifiedFieldName, reason)
 	case PointersPolicyWarn:
-		pass.Reportf(field.Pos(), "field %s %s", fieldName, reason)
+		pass.Reportf(field.Pos(), "field %s %s", qualifiedFieldName, reason)
 	}
 }
 
-func (s *serializationCheck) handleFieldShouldNotBePointer(pass *analysis.Pass, field *ast.Field, fieldName string, isPointer bool, underlying ast.Expr, markersAccess markershelper.Markers, message string) {
+func (s *serializationCheck) handleFieldShouldNotBePointer(pass *analysis.Pass, field *ast.Field, fieldName string, isPointer bool, underlying ast.Expr, markersAccess markershelper.Markers, message, qualifiedFieldName string) {
 	if !isPointer {
 		return
 	}
@@ -269,7 +269,7 @@ func (s *serializationCheck) handleFieldShouldNotBePointer(pass *analysis.Pass, 
 		return
 	}
 
-	reportShouldRemovePointer(pass, field, s.pointerPolicy, fieldName, message, fieldName)
+	reportShouldRemovePointer(pass, field, s.pointerPolicy, fieldName, message, qualifiedFieldName)
 }
 
 // hasExplicitZeroMinValidation checks if a field has an explicit MinItems=0 or MinProperties=0 marker.

--- a/pkg/analysis/utils/serialization/serialization_check_test.go
+++ b/pkg/analysis/utils/serialization/serialization_check_test.go
@@ -107,8 +107,8 @@ func testSerializationAnalyzer(cfg *serialization.Config) *analysis.Analyzer {
 				return nil, errCouldNotGetInspector
 			}
 
-			inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, _ string) {
-				serialization.New(cfg).Check(pass, field, markersAccess, jsonTagInfo)
+			inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
+				serialization.New(cfg).Check(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
 			})
 
 			return nil, nil

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag." "field ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag." "field TestArrays.ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field TestArrays.ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
-	ByteArray []byte `json:"byteArray"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray *[]string `json:"ptrArray"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray *[]string `json:"ptrArray"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/arrays.go.golden
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array,omitempty"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array,omitempty"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems *[]string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag." "field ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItems *[]string `json:"arrayWithZeroMinItems,omitempty"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag." "field TestArrays.ArrayWithZeroMinItems with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsWithOmitEmpty *[]string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItemsWithOmitEmpty *[]string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"` // want "field TestArrays.ArrayWithZeroMinItemsWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
-	ByteArray []byte `json:"byteArray,omitempty"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray,omitempty"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 		// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray []string `json:"ptrArray,omitempty"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray []string `json:"ptrArray,omitempty"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/bool.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/bool.go
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool bool `json:"bool"` // want "field Bool should have the omitempty tag." "field Bool should be a pointer."
+	Bool bool `json:"bool"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool should be a pointer."
 
-	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty should be a pointer."
+	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/bool.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/bool.go.golden
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool *bool `json:"bool,omitempty"` // want "field Bool should have the omitempty tag." "field Bool should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool should be a pointer."
 
-	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty should be a pointer."
+	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go
@@ -1,23 +1,23 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr *map[string]string `json:"mapPtr"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr *map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag." "field MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag." "field TestMaps.MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field TestMaps.MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/maps.go.golden
@@ -1,23 +1,23 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map,omitempty"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map,omitempty"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties *map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag." "field MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinProperties *map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag." "field TestMaps.MapWithZeroMinProperties with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesWithOmitEmpty *map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinPropertiesWithOmitEmpty *map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"` // want "field TestMaps.MapWithZeroMinPropertiesWithOmitEmpty with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/numbers.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/numbers.go
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int int `json:"int"` // want "field Int should have the omitempty tag." "field Int should be a pointer."
+	Int int `json:"int"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int should be a pointer."
 
-	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty should be a pointer."
-
-	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field IntWithPositiveMinimum should have the omitempty tag." "field IntWithPositiveMinimum should be a pointer."
+	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMinimumWithOmitEmpty should be a pointer."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntWithPositiveMinimum should be a pointer."
+
+	// +kubebuilder:validation:Minimum=1
+	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum should be a pointer."
+	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum should be a pointer."
+	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty should be a pointer."
+	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum should be a pointer."
+	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty should be a pointer."
+	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum should be a pointer."
+	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field IntWithNegativeMaximum should have the omitempty tag." "field IntWithNegativeMaximum should be a pointer."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntWithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMaximumWithOmitEmpty should be a pointer."
+	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero should be a pointer."
+	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty should be a pointer."
 
-	IntPtr *int `json:"intPtr"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 int32 `json:"int32"` // want "field Int32 should have the omitempty tag." "field Int32 should be a pointer."
+	Int32 int32 `json:"int32"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field Int32WithPositiveMinimum should have the omitempty tag." "field Int32WithPositiveMinimum should be a pointer."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum should be a pointer."
+	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum should be a pointer."
+	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum should be a pointer."
+	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum should be a pointer."
+	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field Int32WithNegativeMaximum should have the omitempty tag." "field Int32WithNegativeMaximum should be a pointer."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero should be a pointer."
+	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero should be a pointer."
 
-	Int64 int64 `json:"int64"` // want "field Int64 should have the omitempty tag." "field Int64 should be a pointer."
+	Int64 int64 `json:"int64"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field Int64WithPositiveMinimum should have the omitempty tag." "field Int64WithPositiveMinimum should be a pointer."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum should be a pointer."
+	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum should be a pointer."
+	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum should be a pointer."
+	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum should be a pointer."
+	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field Int64WithNegativeMaximum should have the omitempty tag." "field Int64WithNegativeMaximum should be a pointer."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero should be a pointer."
+	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero should be a pointer."
 
-	Float32 float32 `json:"float32"` // want "field Float32 should have the omitempty tag." "field Float32 should be a pointer."
+	Float32 float32 `json:"float32"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 should be a pointer."
 
-	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty should be a pointer."
+	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field Float32WithPositiveMinimum should have the omitempty tag." "field Float32WithPositiveMinimum should be a pointer."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMinimumWithOmitEmpty should be a pointer."
+	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum should be a pointer."
+	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum should be a pointer."
+	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty should be a pointer."
+	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum should be a pointer."
+	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty should be a pointer."
+	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum should be a pointer."
+	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field Float32WithNegativeMaximum should have the omitempty tag." "field Float32WithNegativeMaximum should be a pointer."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMaximumWithOmitEmpty should be a pointer."
+	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero should be a pointer."
+	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty should be a pointer."
 
-	Float64 float64 `json:"float64"` // want "field Float64 should have the omitempty tag." "field Float64 should be a pointer."
+	Float64 float64 `json:"float64"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field Float64WithPositiveMinimum should have the omitempty tag." "field Float64WithPositiveMinimum should be a pointer."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum should be a pointer."
+	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum should be a pointer."
+	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum should be a pointer."
+	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum should be a pointer."
+	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field Float64WithNegativeMaximum should have the omitempty tag." "field Float64WithNegativeMaximum should be a pointer."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero should be a pointer."
+	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/numbers.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/numbers.go.golden
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int *int `json:"int,omitempty"` // want "field Int should have the omitempty tag." "field Int should be a pointer."
+	Int *int `json:"int,omitempty"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int should be a pointer."
 
-	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty should be a pointer."
-
-	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum *int `json:"intWithPositiveMinimum,omitempty"` // want "field IntWithPositiveMinimum should have the omitempty tag." "field IntWithPositiveMinimum should be a pointer."
+	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimumWithOmitEmpty *int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMinimumWithOmitEmpty should be a pointer."
+	IntWithPositiveMinimum *int `json:"intWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntWithPositiveMinimum should be a pointer."
+
+	// +kubebuilder:validation:Minimum=1
+	IntWithPositiveMinimumWithOmitEmpty *int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum should be a pointer."
+	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum should be a pointer."
+	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty should be a pointer."
+	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum should be a pointer."
+	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty should be a pointer."
+	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum should be a pointer."
+	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum *int `json:"intWithNegativeMaximum,omitempty"` // want "field IntWithNegativeMaximum should have the omitempty tag." "field IntWithNegativeMaximum should be a pointer."
+	IntWithNegativeMaximum *int `json:"intWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntWithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximumWithOmitEmpty *int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMaximumWithOmitEmpty should be a pointer."
+	IntWithNegativeMaximumWithOmitEmpty *int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero should be a pointer."
+	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty should be a pointer."
 
-	IntPtr *int `json:"intPtr,omitempty"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr,omitempty"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 *int32 `json:"int32,omitempty"` // want "field Int32 should have the omitempty tag." "field Int32 should be a pointer."
+	Int32 *int32 `json:"int32,omitempty"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum *int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field Int32WithPositiveMinimum should have the omitempty tag." "field Int32WithPositiveMinimum should be a pointer."
+	Int32WithPositiveMinimum *int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum should be a pointer."
+	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum should be a pointer."
+	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum should be a pointer."
+	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum should be a pointer."
+	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum *int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field Int32WithNegativeMaximum should have the omitempty tag." "field Int32WithNegativeMaximum should be a pointer."
+	Int32WithNegativeMaximum *int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero should be a pointer."
+	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero should be a pointer."
 
-	Int64 *int64 `json:"int64,omitempty"` // want "field Int64 should have the omitempty tag." "field Int64 should be a pointer."
+	Int64 *int64 `json:"int64,omitempty"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum *int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field Int64WithPositiveMinimum should have the omitempty tag." "field Int64WithPositiveMinimum should be a pointer."
+	Int64WithPositiveMinimum *int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum should be a pointer."
+	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum should be a pointer."
+	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum should be a pointer."
+	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum should be a pointer."
+	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum *int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field Int64WithNegativeMaximum should have the omitempty tag." "field Int64WithNegativeMaximum should be a pointer."
+	Int64WithNegativeMaximum *int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero should be a pointer."
+	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero should be a pointer."
 
-	Float32 *float32 `json:"float32,omitempty"` // want "field Float32 should have the omitempty tag." "field Float32 should be a pointer."
+	Float32 *float32 `json:"float32,omitempty"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 should be a pointer."
 
-	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty should be a pointer."
+	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum *float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field Float32WithPositiveMinimum should have the omitempty tag." "field Float32WithPositiveMinimum should be a pointer."
+	Float32WithPositiveMinimum *float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimumWithOmitEmpty *float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMinimumWithOmitEmpty should be a pointer."
+	Float32WithPositiveMinimumWithOmitEmpty *float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum should be a pointer."
+	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum should be a pointer."
+	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty should be a pointer."
+	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum should be a pointer."
+	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty should be a pointer."
+	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum should be a pointer."
+	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum *float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field Float32WithNegativeMaximum should have the omitempty tag." "field Float32WithNegativeMaximum should be a pointer."
+	Float32WithNegativeMaximum *float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximumWithOmitEmpty *float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMaximumWithOmitEmpty should be a pointer."
+	Float32WithNegativeMaximumWithOmitEmpty *float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximumWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero should be a pointer."
+	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty should be a pointer."
 
-	Float64 *float64 `json:"float64,omitempty"` // want "field Float64 should have the omitempty tag." "field Float64 should be a pointer."
+	Float64 *float64 `json:"float64,omitempty"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 should be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum *float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field Float64WithPositiveMinimum should have the omitempty tag." "field Float64WithPositiveMinimum should be a pointer."
+	Float64WithPositiveMinimum *float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum should be a pointer."
+	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum should be a pointer."
+	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum should be a pointer."
+	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum should be a pointer."
+	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum *float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field Float64WithNegativeMaximum should have the omitempty tag." "field Float64WithNegativeMaximum should be a pointer."
+	Float64WithNegativeMaximum *float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMaximum should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero should be a pointer."
+	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go
@@ -8,7 +8,7 @@ type TestPointerToSliceWithMinZeroAlways struct {
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty"` // want "field PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
+	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty"` // want "field TestPointerToSliceWithMinZeroAlways.PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
 }
 
 type TestPointerToMapWithMinZeroAlways struct {
@@ -19,32 +19,32 @@ type TestPointerToMapWithMinZeroAlways struct {
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty"` // want "field TestPointerToMapWithMinZeroAlways.MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
 
 	// Non-pointer version should suggest adding pointer
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesNoPtr map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinPropertiesNoPtr map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field TestPointerToMapWithMinZeroAlways.MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that slices WITHOUT pointers are flagged when MinItems is zero
 type TestSliceWithMinZeroAlways struct {
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsNoPtr []string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItemsNoPtr []string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field TestSliceWithMinZeroAlways.ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero
 type TestPointerToSliceWithNonZeroMinAlways struct {
 	// +kubebuilder:validation:MinItems=1
-	PtrArrayWithNonZeroMinItems *[]string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field PtrArrayWithNonZeroMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithNonZeroMinItems *[]string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMinAlways.PtrArrayWithNonZeroMinItems underlying type does not need to be a pointer. The pointer should be removed."
 
 	// No MinItems validation
-	PtrArrayWithoutMinItems *[]string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithoutMinItems *[]string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMinAlways.PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
 }
 
 type TestPointerToMapWithNonZeroMinAlways struct {
 	// +kubebuilder:validation:MinProperties=1
-	MapPtrWithNonZeroMinProperties *map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field MapPtrWithNonZeroMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithNonZeroMinProperties *map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMinAlways.MapPtrWithNonZeroMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 
 	// No MinProperties validation
-	MapPtrWithoutMinProperties *map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithoutMinProperties *map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMinAlways.MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/pointer_to_slice_with_minzero.go.golden
@@ -8,7 +8,7 @@ type TestPointerToSliceWithMinZeroAlways struct {
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty,omitempty"` // want "field PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
+	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty,omitempty"` // want "field TestPointerToSliceWithMinZeroAlways.PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
 }
 
 type TestPointerToMapWithMinZeroAlways struct {
@@ -19,32 +19,32 @@ type TestPointerToMapWithMinZeroAlways struct {
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty,omitempty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty,omitempty"` // want "field TestPointerToMapWithMinZeroAlways.MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
 
 	// Non-pointer version should suggest adding pointer
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinPropertiesNoPtr *map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	MapWithZeroMinPropertiesNoPtr *map[string]string `json:"mapWithZeroMinPropertiesNoPtr,omitempty"` // want "field TestPointerToMapWithMinZeroAlways.MapWithZeroMinPropertiesNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that slices WITHOUT pointers are flagged when MinItems is zero
 type TestSliceWithMinZeroAlways struct {
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItemsNoPtr *[]string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
+	ArrayWithZeroMinItemsNoPtr *[]string `json:"arrayWithZeroMinItemsNoPtr,omitempty"` // want "field TestSliceWithMinZeroAlways.ArrayWithZeroMinItemsNoPtr with MinItems=0/MinProperties=0, underlying type should be a pointer to distinguish nil \\(unset\\) from empty."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero
 type TestPointerToSliceWithNonZeroMinAlways struct {
 	// +kubebuilder:validation:MinItems=1
-	PtrArrayWithNonZeroMinItems []string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field PtrArrayWithNonZeroMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithNonZeroMinItems []string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMinAlways.PtrArrayWithNonZeroMinItems underlying type does not need to be a pointer. The pointer should be removed."
 
 	// No MinItems validation
-	PtrArrayWithoutMinItems []string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithoutMinItems []string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMinAlways.PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
 }
 
 type TestPointerToMapWithNonZeroMinAlways struct {
 	// +kubebuilder:validation:MinProperties=1
-	MapPtrWithNonZeroMinProperties map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field MapPtrWithNonZeroMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithNonZeroMinProperties map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMinAlways.MapPtrWithNonZeroMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 
 	// No MinProperties validation
-	MapPtrWithoutMinProperties map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithoutMinProperties map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMinAlways.MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/strings.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/strings.go
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String string `json:"string"` // want "field String should have the omitempty tag." "field String should be a pointer."
+	String string `json:"string"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String should be a pointer."
 
-	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty should be a pointer."
+	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty should be a pointer."
 
-	StringPtr *string `json:"stringPtr"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength"` // want "field StringWithMinLength should have the omitempty tag." "field StringWithMinLength should be a pointer."
+	StringWithMinLength string `json:"stringWithMinLength"` // want "field TestStrings.StringWithMinLength should have the omitempty tag." "field TestStrings.StringWithMinLength should be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"` // want "field StringWithMinLengthWithOmitEmpty should be a pointer."
+	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLengthWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field StringPtrWithMinLength should have the omitempty tag."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty should be a pointer."
+	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString"` // want "field EnumString should have the omitempty tag." "field EnumString should be a pointer."
+	EnumString string `json:"enumString"` // want "field TestStrings.EnumString should have the omitempty tag." "field TestStrings.EnumString should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"` // want "field EnumStringWithOmitEmpty should be a pointer."
+	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr"` // want "field EnumStringPtr should have the omitempty tag."
+	EnumStringPtr *string `json:"enumStringPtr"` // want "field TestStrings.EnumStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring should be a pointer."
+	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/strings.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/strings.go.golden
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String *string `json:"string,omitempty"` // want "field String should have the omitempty tag." "field String should be a pointer."
+	String *string `json:"string,omitempty"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String should be a pointer."
 
-	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty should be a pointer."
+	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty should be a pointer."
 
-	StringPtr *string `json:"stringPtr,omitempty"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr,omitempty"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength *string `json:"stringWithMinLength,omitempty"` // want "field StringWithMinLength should have the omitempty tag." "field StringWithMinLength should be a pointer."
+	StringWithMinLength *string `json:"stringWithMinLength,omitempty"` // want "field TestStrings.StringWithMinLength should have the omitempty tag." "field TestStrings.StringWithMinLength should be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLengthWithOmitEmpty *string `json:"stringWithMinLengthWithOmitEmpty,omitempty"` // want "field StringWithMinLengthWithOmitEmpty should be a pointer."
+	StringWithMinLengthWithOmitEmpty *string `json:"stringWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLengthWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength,omitempty"` // want "field StringPtrWithMinLength should have the omitempty tag."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength,omitempty"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty should be a pointer."
+	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString *string `json:"enumString,omitempty"` // want "field EnumString should have the omitempty tag." "field EnumString should be a pointer."
+	EnumString *string `json:"enumString,omitempty"` // want "field TestStrings.EnumString should have the omitempty tag." "field TestStrings.EnumString should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringWithOmitEmpty *string `json:"enumStringWithOmitEmpty,omitempty"` // want "field EnumStringWithOmitEmpty should be a pointer."
+	EnumStringWithOmitEmpty *string `json:"enumStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr,omitempty"` // want "field EnumStringPtr should have the omitempty tag."
+	EnumStringPtr *string `json:"enumStringPtr,omitempty"` // want "field TestStrings.EnumStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring should be a pointer."
+	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/structs.go
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields should be a pointer."
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields should be a pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty should be a pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty should be a pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field StructWithMinProperties should have the omitempty tag." "field StructWithMinProperties should be a pointer."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties should have the omitempty tag." "field TestStructs.StructWithMinProperties should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field StructPtrWithMinProperties should have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties should have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields should be a pointer."
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field StructWithOmittedRequiredField should have the omitempty tag." "field StructWithOmittedRequiredField should be a pointer."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField should have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field StructPtrWithOmittedRequiredField should have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField should have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String string `json:"string,omitempty"` // want "field String should be a pointer."
+	String string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String should be a pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int should be a pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String string `json:"string"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFields.String should be a pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int should be a pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFields.Int should be a pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFieldsAndMinProperties.String should be a pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int should be a pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int should be a pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String should be a pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int int32 `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int should be a pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String string `json:"string,omitempty"` // want "field String should be a pointer."
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_always/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_always/structs.go.golden
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields should be a pointer."
+	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields should be a pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty should be a pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty should be a pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties should have the omitempty tag." "field StructWithMinProperties should be a pointer."
+	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field TestStructs.StructWithMinProperties should have the omitempty tag." "field TestStructs.StructWithMinProperties should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field StructPtrWithMinProperties should have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field TestStructs.StructPtrWithMinProperties should have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields should be a pointer."
+	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field StructWithOmittedRequiredField should have the omitempty tag." "field StructWithOmittedRequiredField should be a pointer."
+	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructWithOmittedRequiredField should have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field StructPtrWithOmittedRequiredField should have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredField should have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String should be a pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String should be a pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int *int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int should be a pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFields.String should be a pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int should be a pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFields.Int should be a pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.String should be a pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int should be a pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int should be a pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String should be a pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String should be a pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int *int32 `json:"int,omitempty"` // want "field Int should be a pointer."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int should be a pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String should be a pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/arrays.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/arrays.go
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
 
-	ByteArray []byte `json:"byteArray"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray *[]string `json:"ptrArray"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray *[]string `json:"ptrArray"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/arrays.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/arrays.go.golden
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array,omitempty"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array,omitempty"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
 
-	ByteArray []byte `json:"byteArray,omitempty"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray,omitempty"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray []string `json:"ptrArray,omitempty"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray []string `json:"ptrArray,omitempty"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/bool.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/bool.go
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool bool `json:"bool"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/bool.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/bool.go.golden
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool *bool `json:"bool,omitempty"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/maps.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/maps.go
@@ -1,22 +1,22 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr *map[string]string `json:"mapPtr"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr *map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/maps.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/maps.go.golden
@@ -1,22 +1,22 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map,omitempty"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map,omitempty"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/numbers.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/numbers.go
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int int `json:"int"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr *int `json:"intPtr"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 int32 `json:"int32"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 int32 `json:"int32"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Int64 int64 `json:"int64"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 int64 `json:"int64"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Float32 float32 `json:"float32"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 float32 `json:"float32"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
-	Float64 float64 `json:"float64"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 float64 `json:"float64"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/numbers.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/numbers.go.golden
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int *int `json:"int,omitempty"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr *int `json:"intPtr,omitempty"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr,omitempty"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 *int32 `json:"int32,omitempty"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 *int32 `json:"int32,omitempty"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Int64 *int64 `json:"int64,omitempty"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 *int64 `json:"int64,omitempty"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Float32 *float32 `json:"float32,omitempty"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 *float32 `json:"float32,omitempty"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
-	Float64 *float64 `json:"float64,omitempty"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 *float64 `json:"float64,omitempty"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go
@@ -8,7 +8,7 @@ type TestPointerToSliceWithMinZero struct {
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty"` // want "field PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
+	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty"` // want "field TestPointerToSliceWithMinZero.PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
 }
 
 type TestPointerToMapWithMinZero struct {
@@ -19,22 +19,22 @@ type TestPointerToMapWithMinZero struct {
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty"` // want "field TestPointerToMapWithMinZero.MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero
 type TestPointerToSliceWithNonZeroMin struct {
 	// +kubebuilder:validation:MinItems=1
-	PtrArrayWithNonZeroMinItems *[]string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field PtrArrayWithNonZeroMinItems does not allow the zero value. The field does not need to be a pointer."
+	PtrArrayWithNonZeroMinItems *[]string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMin.PtrArrayWithNonZeroMinItems does not allow the zero value. The field does not need to be a pointer."
 
 	// No MinItems validation
-	PtrArrayWithoutMinItems *[]string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithoutMinItems *[]string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMin.PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
 }
 
 type TestPointerToMapWithNonZeroMin struct {
 	// +kubebuilder:validation:MinProperties=1
-	MapPtrWithNonZeroMinProperties *map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field MapPtrWithNonZeroMinProperties does not allow the zero value. The field does not need to be a pointer."
+	MapPtrWithNonZeroMinProperties *map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMin.MapPtrWithNonZeroMinProperties does not allow the zero value. The field does not need to be a pointer."
 
 	// No MinProperties validation
-	MapPtrWithoutMinProperties *map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithoutMinProperties *map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMin.MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/pointer_to_slice_with_minzero.go.golden
@@ -8,7 +8,7 @@ type TestPointerToSliceWithMinZero struct {
 	PtrArrayWithZeroMinItems *[]string `json:"ptrArrayWithZeroMinItems,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty,omitempty"` // want "field PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
+	PtrArrayWithZeroMinItemsNoOmitEmpty *[]string `json:"ptrArrayWithZeroMinItemsNoOmitEmpty,omitempty"` // want "field TestPointerToSliceWithMinZero.PtrArrayWithZeroMinItemsNoOmitEmpty should have the omitempty tag."
 }
 
 type TestPointerToMapWithMinZero struct {
@@ -19,22 +19,22 @@ type TestPointerToMapWithMinZero struct {
 	MapPtrWithZeroMinProperties *map[string]string `json:"mapPtrWithZeroMinProperties,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty,omitempty"` // want "field MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
+	MapPtrWithZeroMinPropertiesNoOmitEmpty *map[string]string `json:"mapPtrWithZeroMinPropertiesNoOmitEmpty,omitempty"` // want "field TestPointerToMapWithMinZero.MapPtrWithZeroMinPropertiesNoOmitEmpty should have the omitempty tag."
 }
 
 // Test that pointers ARE still flagged when MinItems/MinProperties is NOT zero
 type TestPointerToSliceWithNonZeroMin struct {
 	// +kubebuilder:validation:MinItems=1
-	PtrArrayWithNonZeroMinItems []string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field PtrArrayWithNonZeroMinItems does not allow the zero value. The field does not need to be a pointer."
+	PtrArrayWithNonZeroMinItems []string `json:"ptrArrayWithNonZeroMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMin.PtrArrayWithNonZeroMinItems does not allow the zero value. The field does not need to be a pointer."
 
 	// No MinItems validation
-	PtrArrayWithoutMinItems []string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithoutMinItems []string `json:"ptrArrayWithoutMinItems,omitempty"` // want "field TestPointerToSliceWithNonZeroMin.PtrArrayWithoutMinItems underlying type does not need to be a pointer. The pointer should be removed."
 }
 
 type TestPointerToMapWithNonZeroMin struct {
 	// +kubebuilder:validation:MinProperties=1
-	MapPtrWithNonZeroMinProperties map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field MapPtrWithNonZeroMinProperties does not allow the zero value. The field does not need to be a pointer."
+	MapPtrWithNonZeroMinProperties map[string]string `json:"mapPtrWithNonZeroMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMin.MapPtrWithNonZeroMinProperties does not allow the zero value. The field does not need to be a pointer."
 
 	// No MinProperties validation
-	MapPtrWithoutMinProperties map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithoutMinProperties map[string]string `json:"mapPtrWithoutMinProperties,omitempty"` // want "field TestPointerToMapWithNonZeroMin.MapPtrWithoutMinProperties underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String string `json:"string"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr *string `json:"stringPtr"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString"` // want "field TestStrings.EnumString should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr *string `json:"enumStringPtr"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/strings.go.golden
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String *string `json:"string,omitempty"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr *string `json:"stringPtr,omitempty"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr,omitempty"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString,omitempty"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString,omitempty"` // want "field TestStrings.EnumString should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/structs.go
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field StructWithMinProperties should have the omitempty tag." "field StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties should have the omitempty tag." "field TestStructs.StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field StructPtrWithMinProperties should have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties should have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field StructWithOmittedRequiredField should have the omitempty tag." "field StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField should have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field StructPtrWithOmittedRequiredField should have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField should have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required/structs.go.golden
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties should have the omitempty tag." "field StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field TestStructs.StructWithMinProperties should have the omitempty tag." "field TestStructs.StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field StructPtrWithMinProperties should have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field TestStructs.StructPtrWithMinProperties should have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties should have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties should have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field StructWithOmittedRequiredField should have the omitempty tag." "field StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructWithOmittedRequiredField should have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field StructPtrWithOmittedRequiredField should have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredField should have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/arrays.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/arrays.go
@@ -10,7 +10,7 @@ type TestArrays struct {
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field ArrayWithPositiveMinItems does not allow the zero value. It must have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field TestArrays.ArrayWithPositiveMinItems does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
@@ -26,7 +26,7 @@ type TestArrays struct {
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field ByteArrayWithMinLength does not allow the zero value. It must have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field TestArrays.ByteArrayWithMinLength does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
@@ -37,7 +37,7 @@ type TestArrays struct {
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray *[]string `json:"ptrArray"` // want "field PtrArray does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PtrArray *[]string `json:"ptrArray"` // want "field TestArrays.PtrArray does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
-	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/arrays.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/arrays.go.golden
@@ -10,7 +10,7 @@ type TestArrays struct {
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field ArrayWithPositiveMinItems does not allow the zero value. It must have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field TestArrays.ArrayWithPositiveMinItems does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
@@ -26,7 +26,7 @@ type TestArrays struct {
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field ByteArrayWithMinLength does not allow the zero value. It must have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field TestArrays.ByteArrayWithMinLength does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
@@ -37,7 +37,7 @@ type TestArrays struct {
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray []string `json:"ptrArray"` // want "field PtrArray does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	PtrArray []string `json:"ptrArray"` // want "field TestArrays.PtrArray does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
-	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/bool.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/bool.go
@@ -3,9 +3,9 @@ package a
 type TestBools struct {
 	Bool bool `json:"bool"`
 
-	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr"` // want "field BoolPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	BoolPtr *bool `json:"boolPtr"` // want "field TestBools.BoolPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/bool.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/bool.go.golden
@@ -3,9 +3,9 @@ package a
 type TestBools struct {
 	Bool bool `json:"bool"`
 
-	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr bool `json:"boolPtr"` // want "field BoolPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	BoolPtr bool `json:"boolPtr"` // want "field TestBools.BoolPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/maps.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/maps.go
@@ -5,12 +5,12 @@ type TestMaps struct {
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr *map[string]string `json:"mapPtr"` // want "field MapPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	MapPtr *map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
-	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field MapWithPositiveMinProperties does not allow the zero value. It must have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field TestMaps.MapWithPositiveMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/maps.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/maps.go.golden
@@ -5,12 +5,12 @@ type TestMaps struct {
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr map[string]string `json:"mapPtr"` // want "field MapPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	MapPtr map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
-	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field MapWithPositiveMinProperties does not allow the zero value. It must have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field TestMaps.MapWithPositiveMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/numbers.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/numbers.go
@@ -3,10 +3,10 @@ package a
 type TestNumbers struct {
 	Int int `json:"int"`
 
-	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field IntWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field TestNumbers.IntWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
@@ -15,28 +15,28 @@ type TestNumbers struct {
 	IntWithZeroMinimum int `json:"intWithZeroMinimum"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	IntWithZeroMaximum int `json:"intWithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field IntWithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field TestNumbers.IntWithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
@@ -47,51 +47,51 @@ type TestNumbers struct {
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr *int `json:"intPtr"` // want "field IntPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtr *int `json:"intPtr"` // want "field TestNumbers.IntPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer." "field IntPtrWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field IntPtrWithNegativeMaximum does not allow the zero value. It must have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. It must have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -100,7 +100,7 @@ type TestNumbers struct {
 	Int32 int32 `json:"int32"`
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field Int32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field TestNumbers.Int32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"`
@@ -115,7 +115,7 @@ type TestNumbers struct {
 	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field Int32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field TestNumbers.Int32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -124,7 +124,7 @@ type TestNumbers struct {
 	Int64 int64 `json:"int64"`
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field Int64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field TestNumbers.Int64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"`
@@ -139,7 +139,7 @@ type TestNumbers struct {
 	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field Int64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field TestNumbers.Int64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -147,10 +147,10 @@ type TestNumbers struct {
 
 	Float32 float32 `json:"float32"`
 
-	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field Float32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field TestNumbers.Float32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
@@ -159,28 +159,28 @@ type TestNumbers struct {
 	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"`
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"`
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field Float32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field TestNumbers.Float32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
@@ -191,12 +191,12 @@ type TestNumbers struct {
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	Float64 float64 `json:"float64"`
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field Float64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field TestNumbers.Float64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"`
@@ -211,7 +211,7 @@ type TestNumbers struct {
 	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field Float64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field TestNumbers.Float64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/numbers.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/numbers.go.golden
@@ -3,10 +3,10 @@ package a
 type TestNumbers struct {
 	Int int `json:"int"`
 
-	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field IntWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
@@ -15,28 +15,28 @@ type TestNumbers struct {
 	IntWithZeroMinimum int `json:"intWithZeroMinimum"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	IntWithZeroMaximum int `json:"intWithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field IntWithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntWithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
@@ -47,51 +47,51 @@ type TestNumbers struct {
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr int `json:"intPtr"` // want "field IntPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtr int `json:"intPtr"` // want "field TestNumbers.IntPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer." "field IntPtrWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithZeroMinimum int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMinimum int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMaximum int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithZeroMaximum int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field IntPtrWithNegativeMaximum does not allow the zero value. It must have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. It must have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	IntPtrWithRangeIncludingZero int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -100,7 +100,7 @@ type TestNumbers struct {
 	Int32 int32 `json:"int32"`
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field Int32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"`
@@ -115,7 +115,7 @@ type TestNumbers struct {
 	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field Int32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -124,7 +124,7 @@ type TestNumbers struct {
 	Int64 int64 `json:"int64"`
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field Int64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"`
@@ -139,7 +139,7 @@ type TestNumbers struct {
 	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field Int64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
@@ -147,10 +147,10 @@ type TestNumbers struct {
 
 	Float32 float32 `json:"float32"`
 
-	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field Float32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
@@ -159,28 +159,28 @@ type TestNumbers struct {
 	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"`
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
 	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"`
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
 	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field Float32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
@@ -191,12 +191,12 @@ type TestNumbers struct {
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	Float64 float64 `json:"float64"`
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field Float64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float64WithPositiveMinimum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"`
@@ -211,7 +211,7 @@ type TestNumbers struct {
 	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"`
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field Float64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float64WithNegativeMaximum does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/strings.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/strings.go
@@ -3,56 +3,56 @@ package a
 type TestStrings struct {
 	String string `json:"string"`
 
-	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr *string `json:"stringPtr"` // want "field StringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StringPtr *string `json:"stringPtr"` // want "field TestStrings.StringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength"` // want "field StringWithMinLength does not allow the zero value. It must have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength"` // want "field TestStrings.StringWithMinLength does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field StringPtrWithMinLength does not allow the zero value. It must have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field TestStrings.StringPtrWithMinLength does not allow the zero value. It must have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
 	StringWithMinLength0 string `json:"stringWithMinLength0"`
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString"` // want "field EnumString does not allow the zero value. It must have the omitempty tag."
+	EnumString string `json:"enumString"` // want "field TestStrings.EnumString does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr"` // want "field EnumStringPtr does not allow the zero value. It must have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr *string `json:"enumStringPtr"` // want "field TestStrings.EnumStringPtr does not allow the zero value. It must have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptytring string `json:"enumValidEmptytring"`
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/strings.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/strings.go.golden
@@ -3,56 +3,56 @@ package a
 type TestStrings struct {
 	String string `json:"string"`
 
-	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr string `json:"stringPtr"` // want "field StringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StringPtr string `json:"stringPtr"` // want "field TestStrings.StringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field StringWithMinLength does not allow the zero value. It must have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field TestStrings.StringWithMinLength does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field StringPtrWithMinLength does not allow the zero value. It must have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field TestStrings.StringPtrWithMinLength does not allow the zero value. It must have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
 	StringWithMinLength0 string `json:"stringWithMinLength0"`
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength0 string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString,omitempty"` // want "field EnumString does not allow the zero value. It must have the omitempty tag."
+	EnumString string `json:"enumString,omitempty"` // want "field TestStrings.EnumString does not allow the zero value. It must have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field EnumStringPtr does not allow the zero value. It must have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field TestStrings.EnumStringPtr does not allow the zero value. It must have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptytring string `json:"enumValidEmptytring"`
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	EnumValidEmptyStringPtr string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/structs.go
@@ -5,19 +5,19 @@ type TestStructs struct {
 
 	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"`
 
-	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitempty tag." "field StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
@@ -25,9 +25,9 @@ type TestStructs struct {
 
 	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"`
 
-	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
@@ -35,42 +35,42 @@ type TestStructs struct {
 
 	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"`
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag." "field StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -111,12 +111,12 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 	String string `json:"string"`
 
 	// +optional
-	Int int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore/structs.go.golden
@@ -5,19 +5,19 @@ type TestStructs struct {
 
 	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"`
 
-	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithAllOptionalFields StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitempty tag." "field StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinProperties *StructWithMinProperties `json:"structWithMinProperties,omitempty"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithMinProperties has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties,omitempty"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"`
 
@@ -25,9 +25,9 @@ type TestStructs struct {
 
 	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"`
 
-	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithNonOmittedFields StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
@@ -35,42 +35,42 @@ type TestStructs struct {
 
 	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"`
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
+	StructPtrWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag." "field StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\"}\\) and should be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag." "field StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag." "field TestStructs.StructWithOmittedRequiredField has a valid zero value \\({}\\) and should be a pointer."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
+	StructWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty has a valid zero value \\({}\\) and should be a pointer."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitempty tag."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"`
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -111,12 +111,12 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 	String string `json:"string"`
 
 	// +optional
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/arrays.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/arrays.go
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
 
-	ByteArray []byte `json:"byteArray"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray *[]string `json:"ptrArray"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray *[]string `json:"ptrArray"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty *[]string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/arrays.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/arrays.go.golden
@@ -1,43 +1,43 @@
 package a
 
 type TestArrays struct {
-	Array []string `json:"array,omitempty"` // want "field Array should have the omitempty tag."
+	Array []string `json:"array,omitempty"` // want "field TestArrays.Array should have the omitempty tag."
 
 	ArrayWithOmitEmpty []string `json:"arrayWithOmitEmpty,omitempty"`
 
-	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field ArrayPtr should have the omitempty tag."
+	ArrayPtr []*string `json:"arrayPtr,omitempty"` // want "field TestArrays.ArrayPtr should have the omitempty tag."
 
 	ArrayWithOmitEmptyPtr []*string `json:"arrayWithOmitEmptyPtr,omitempty"`
 
 	// +kubebuilder:validation:MinItems=1
-	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field ArrayWithPositiveMinItems should have the omitempty tag."
+	ArrayWithPositiveMinItems []string `json:"arrayWithPositiveMinItems,omitempty"` // want "field TestArrays.ArrayWithPositiveMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=1
 	ArrayWithPositiveMinItemsWithOmitEmpty []string `json:"arrayWithPositiveMinItemsWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinItems=0
-	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field ArrayWithZeroMinItems should have the omitempty tag."
+	ArrayWithZeroMinItems []string `json:"arrayWithZeroMinItems,omitempty"` // want "field TestArrays.ArrayWithZeroMinItems should have the omitempty tag."
 
 	// +kubebuilder:validation:MinItems=0
 	ArrayWithZeroMinItemsWithOmitEmpty []string `json:"arrayWithZeroMinItemsWithOmitEmpty,omitempty"`
 
-	ByteArray []byte `json:"byteArray,omitempty"` // want "field ByteArray should have the omitempty tag."
+	ByteArray []byte `json:"byteArray,omitempty"` // want "field TestArrays.ByteArray should have the omitempty tag."
 
 	ByteArrayWithOmitEmpty []byte `json:"byteArrayWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field ByteArrayWithMinLength should have the omitempty tag."
+	ByteArrayWithMinLength []byte `json:"byteArrayWithMinLength,omitempty"` // want "field TestArrays.ByteArrayWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	ByteArrayWithMinLengthWithOmitEmpty []byte `json:"byteArrayWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=0
-	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field ByteArrayWithMinLength0 should have the omitempty tag."
+	ByteArrayWithMinLength0 []byte `json:"byteArrayWithMinLength0,omitempty"` // want "field TestArrays.ByteArrayWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	ByteArrayWithMinLength0WithOmitEmpty []byte `json:"byteArrayWithMinLength0WithOmitEmpty,omitempty"`
 
-	PtrArray []string `json:"ptrArray,omitempty"` // want "field PtrArray should have the omitempty tag." "field PtrArray underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArray []string `json:"ptrArray,omitempty"` // want "field TestArrays.PtrArray should have the omitempty tag." "field TestArrays.PtrArray underlying type does not need to be a pointer. The pointer should be removed."
 
-	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	PtrArrayWithOmitEmpty []string `json:"ptrArrayWithOmitEmpty,omitempty"` // want "field TestArrays.PtrArrayWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/bool.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/bool.go
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool bool `json:"bool"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool bool `json:"bool"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/bool.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/bool.go.golden
@@ -1,11 +1,11 @@
 package a
 
 type TestBools struct {
-	Bool *bool `json:"bool,omitempty"` // want "field Bool should have the omitempty tag." "field Bool has a valid zero value \\(false\\) and should be a pointer."
+	Bool *bool `json:"bool,omitempty"` // want "field TestBools.Bool should have the omitempty tag." "field TestBools.Bool has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
+	BoolWithOmitEmpty *bool `json:"boolWithOmitEmpty,omitempty"` // want "field TestBools.BoolWithOmitEmpty has a valid zero value \\(false\\) and should be a pointer."
 
-	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field BoolPtr should have the omitempty tag."
+	BoolPtr *bool `json:"boolPtr,omitempty"` // want "field TestBools.BoolPtr should have the omitempty tag."
 
 	BoolPtrWithOmitEmpty *bool `json:"boolPtrWithOmitEmpty,omitempty"`
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/maps.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/maps.go
@@ -1,22 +1,22 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr *map[string]string `json:"mapPtr"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr *map[string]string `json:"mapPtr"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty *map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/maps.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/maps.go.golden
@@ -1,22 +1,22 @@
 package a
 
 type TestMaps struct {
-	Map map[string]string `json:"map,omitempty"` // want "field Map should have the omitempty tag."
+	Map map[string]string `json:"map,omitempty"` // want "field TestMaps.Map should have the omitempty tag."
 
 	MapWithOmitEmpty map[string]string `json:"mapWithOmitEmpty,omitempty"`
 
-	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field MapPtr should have the omitempty tag." "field MapPtr underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtr map[string]string `json:"mapPtr,omitempty"` // want "field TestMaps.MapPtr should have the omitempty tag." "field TestMaps.MapPtr underlying type does not need to be a pointer. The pointer should be removed."
 
-	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
+	MapPtrWithOmitEmpty map[string]string `json:"mapPtrWithOmitEmpty,omitempty"` // want "field TestMaps.MapPtrWithOmitEmpty underlying type does not need to be a pointer. The pointer should be removed."
 
 	// +kubebuilder:validation:MinProperties=1
-	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field MapWithPositiveMinProperties should have the omitempty tag."
+	MapWithPositiveMinProperties map[string]string `json:"mapWithPositiveMinProperties,omitempty"` // want "field TestMaps.MapWithPositiveMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=1
 	MapWithPositiveMinPropertiesWithOmitEmpty map[string]string `json:"mapWithPositiveMinPropertiesWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinProperties=0
-	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field MapWithZeroMinProperties should have the omitempty tag."
+	MapWithZeroMinProperties map[string]string `json:"mapWithZeroMinProperties,omitempty"` // want "field TestMaps.MapWithZeroMinProperties should have the omitempty tag."
 
 	// +kubebuilder:validation:MinProperties=0
 	MapWithZeroMinPropertiesWithOmitEmpty map[string]string `json:"mapWithZeroMinPropertiesWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/numbers.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/numbers.go
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int int `json:"int"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum int `json:"intWithZeroMinimum"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum int `json:"intWithNegativeMinimum"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum int `json:"intWithPositiveMaximum"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum int `json:"intWithZeroMaximum"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero int `json:"intWithRangeIncludingZero"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr *int `json:"intPtr"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum *int `json:"intPtrWithPositiveMinimum"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty *int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum *int `json:"intPtrWithNegativeMaximum"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty *int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 int32 `json:"int32"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 int32 `json:"int32"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum int32 `json:"int32WithZeroMinimum"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum int32 `json:"int32WithNegativeMinimum"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum int32 `json:"int32WithPositiveMaximum"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum int32 `json:"int32WithZeroMaximum"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero int32 `json:"int32WithRangeIncludingZero"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Int64 int64 `json:"int64"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 int64 `json:"int64"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum int64 `json:"int64WithZeroMinimum"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum int64 `json:"int64WithNegativeMinimum"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum int64 `json:"int64WithPositiveMaximum"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum int64 `json:"int64WithZeroMaximum"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero int64 `json:"int64WithRangeIncludingZero"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Float32 float32 `json:"float32"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 float32 `json:"float32"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum float32 `json:"float32WithZeroMinimum"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum float32 `json:"float32WithNegativeMinimum"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum float32 `json:"float32WithPositiveMaximum"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum float32 `json:"float32WithZeroMaximum"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero float32 `json:"float32WithRangeIncludingZero"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
-	Float64 float64 `json:"float64"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 float64 `json:"float64"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum float64 `json:"float64WithZeroMinimum"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum float64 `json:"float64WithNegativeMinimum"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum float64 `json:"float64WithPositiveMaximum"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum float64 `json:"float64WithZeroMaximum"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero float64 `json:"float64WithRangeIncludingZero"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/numbers.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/numbers.go.golden
@@ -1,219 +1,219 @@
 package a
 
 type TestNumbers struct {
-	Int *int `json:"int,omitempty"` // want "field Int should have the omitempty tag." "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field TestNumbers.Int should have the omitempty tag." "field TestNumbers.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithOmitEmpty *int `json:"intWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field IntWithPositiveMinimum should have the omitempty tag."
+	IntWithPositiveMinimum int `json:"intWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntWithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	IntWithPositiveMinimumWithOmitEmpty int `json:"intWithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field IntWithZeroMinimum should have the omitempty tag." "field IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimum *int `json:"intWithZeroMinimum,omitempty"` // want "field TestNumbers.IntWithZeroMinimum should have the omitempty tag." "field TestNumbers.IntWithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMinimumWithOmitEmpty *int `json:"intWithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMinimumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field IntWithNegativeMinimum should have the omitempty tag." "field IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimum *int `json:"intWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntWithNegativeMinimum should have the omitempty tag." "field TestNumbers.IntWithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithNegativeMinimumWithOmitEmpty *int `json:"intWithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithNegativeMinimumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field IntWithPositiveMaximum should have the omitempty tag." "field IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximum *int `json:"intWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntWithPositiveMaximum should have the omitempty tag." "field TestNumbers.IntWithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IntWithPositiveMaximumWithOmitEmpty *int `json:"intWithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithPositiveMaximumWithOmitEmpty has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field IntWithZeroMaximum should have the omitempty tag." "field IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximum *int `json:"intWithZeroMaximum,omitempty"` // want "field TestNumbers.IntWithZeroMaximum should have the omitempty tag." "field TestNumbers.IntWithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithZeroMaximumWithOmitEmpty *int `json:"intWithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithZeroMaximumWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field IntWithNegativeMaximum should have the omitempty tag."
+	IntWithNegativeMaximum int `json:"intWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntWithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	IntWithNegativeMaximumWithOmitEmpty int `json:"intWithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field IntWithRangeIncludingZero should have the omitempty tag." "field IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZero *int `json:"intWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZero should have the omitempty tag." "field TestNumbers.IntWithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
+	IntWithRangeIncludingZeroWithOmitEmpty *int `json:"intWithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.IntWithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0\\) and should be a pointer."
 
-	IntPtr *int `json:"intPtr,omitempty"` // want "field IntPtr should have the omitempty tag."
+	IntPtr *int `json:"intPtr,omitempty"` // want "field TestNumbers.IntPtr should have the omitempty tag."
 
 	IntPtrWithOmitEmpty *int `json:"intPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field IntPtrWithPositiveMinimum should have the omitempty tag." "field IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimum int `json:"intPtrWithPositiveMinimum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimum should have the omitempty tag." "field TestNumbers.IntPtrWithPositiveMinimum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithPositiveMinimumWithOmitEmpty int `json:"intPtrWithPositiveMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMinimumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field IntPtrWithZeroMinimum should have the omitempty tag."
+	IntPtrWithZeroMinimum *int `json:"intPtrWithZeroMinimum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
 	IntPtrWithZeroMinimumWithOmitEmpty *int `json:"intPtrWithZeroMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
-	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field IntPtrWithNegativeMinimum should have the omitempty tag."
+	IntPtrWithNegativeMinimum *int `json:"intPtrWithNegativeMinimum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	IntPtrWithNegativeMinimumWithOmitEmpty *int `json:"intPtrWithNegativeMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field IntPtrWithPositiveMaximum should have the omitempty tag."
+	IntPtrWithPositiveMaximum *int `json:"intPtrWithPositiveMaximum,omitempty"` // want "field TestNumbers.IntPtrWithPositiveMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithPositiveMaximumWithOmitEmpty *int `json:"intPtrWithPositiveMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=0
-	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field IntPtrWithZeroMaximum should have the omitempty tag."
+	IntPtrWithZeroMaximum *int `json:"intPtrWithZeroMaximum,omitempty"` // want "field TestNumbers.IntPtrWithZeroMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=0
 	IntPtrWithZeroMaximumWithOmitEmpty *int `json:"intPtrWithZeroMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field IntPtrWithNegativeMaximum should have the omitempty tag." "field IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximum int `json:"intPtrWithNegativeMaximum,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximum should have the omitempty tag." "field TestNumbers.IntPtrWithNegativeMaximum does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	IntPtrWithNegativeMaximumWithOmitEmpty int `json:"intPtrWithNegativeMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.IntPtrWithNegativeMaximumWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field IntPtrWithRangeIncludingZero should have the omitempty tag."
+	IntPtrWithRangeIncludingZero *int `json:"intPtrWithRangeIncludingZero,omitempty"` // want "field TestNumbers.IntPtrWithRangeIncludingZero should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
 	IntPtrWithRangeIncludingZeroWithOmitEmpty *int `json:"intPtrWithRangeIncludingZeroWithOmitEmpty,omitempty"`
 
-	Int32 *int32 `json:"int32,omitempty"` // want "field Int32 should have the omitempty tag." "field Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32 *int32 `json:"int32,omitempty"` // want "field TestNumbers.Int32 should have the omitempty tag." "field TestNumbers.Int32 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field Int32WithPositiveMinimum should have the omitempty tag."
+	Int32WithPositiveMinimum int32 `json:"int32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field Int32WithZeroMinimum should have the omitempty tag." "field Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMinimum *int32 `json:"int32WithZeroMinimum,omitempty"` // want "field TestNumbers.Int32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int32WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field Int32WithNegativeMinimum should have the omitempty tag." "field Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithNegativeMinimum *int32 `json:"int32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int32WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field Int32WithPositiveMaximum should have the omitempty tag." "field Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int32WithPositiveMaximum *int32 `json:"int32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int32WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field Int32WithZeroMaximum should have the omitempty tag." "field Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithZeroMaximum *int32 `json:"int32WithZeroMaximum,omitempty"` // want "field TestNumbers.Int32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int32WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field Int32WithNegativeMaximum should have the omitempty tag."
+	Int32WithNegativeMaximum int32 `json:"int32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field Int32WithRangeIncludingZero should have the omitempty tag." "field Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int32WithRangeIncludingZero *int32 `json:"int32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int32WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Int64 *int64 `json:"int64,omitempty"` // want "field Int64 should have the omitempty tag." "field Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64 *int64 `json:"int64,omitempty"` // want "field TestNumbers.Int64 should have the omitempty tag." "field TestNumbers.Int64 has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field Int64WithPositiveMinimum should have the omitempty tag."
+	Int64WithPositiveMinimum int64 `json:"int64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Int64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field Int64WithZeroMinimum should have the omitempty tag." "field Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMinimum *int64 `json:"int64WithZeroMinimum,omitempty"` // want "field TestNumbers.Int64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Int64WithZeroMinimum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field Int64WithNegativeMinimum should have the omitempty tag." "field Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithNegativeMinimum *int64 `json:"int64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Int64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Int64WithNegativeMinimum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field Int64WithPositiveMaximum should have the omitempty tag." "field Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int64WithPositiveMaximum *int64 `json:"int64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Int64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Int64WithPositiveMaximum has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field Int64WithZeroMaximum should have the omitempty tag." "field Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithZeroMaximum *int64 `json:"int64WithZeroMaximum,omitempty"` // want "field TestNumbers.Int64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Int64WithZeroMaximum has a valid zero value \\(0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field Int64WithNegativeMaximum should have the omitempty tag."
+	Int64WithNegativeMaximum int64 `json:"int64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Int64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field Int64WithRangeIncludingZero should have the omitempty tag." "field Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
+	Int64WithRangeIncludingZero *int64 `json:"int64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Int64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Int64WithRangeIncludingZero has a valid zero value \\(0\\) and should be a pointer."
 
-	Float32 *float32 `json:"float32,omitempty"` // want "field Float32 should have the omitempty tag." "field Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32 *float32 `json:"float32,omitempty"` // want "field TestNumbers.Float32 should have the omitempty tag." "field TestNumbers.Float32 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithOmitEmpty *float32 `json:"float32WithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field Float32WithPositiveMinimum should have the omitempty tag."
+	Float32WithPositiveMinimum float32 `json:"float32WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float32WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=1
 	Float32WithPositiveMinimumWithOmitEmpty float32 `json:"float32WithPositiveMinimumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field Float32WithZeroMinimum should have the omitempty tag." "field Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimum *float32 `json:"float32WithZeroMinimum,omitempty"` // want "field TestNumbers.Float32WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float32WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=0
-	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMinimumWithOmitEmpty *float32 `json:"float32WithZeroMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMinimumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field Float32WithNegativeMinimum should have the omitempty tag." "field Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimum *float32 `json:"float32WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float32WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithNegativeMinimumWithOmitEmpty *float32 `json:"float32WithNegativeMinimumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithNegativeMinimumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field Float32WithPositiveMaximum should have the omitempty tag." "field Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximum *float32 `json:"float32WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float32WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float32WithPositiveMaximumWithOmitEmpty *float32 `json:"float32WithPositiveMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithPositiveMaximumWithOmitEmpty has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field Float32WithZeroMaximum should have the omitempty tag." "field Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximum *float32 `json:"float32WithZeroMaximum,omitempty"` // want "field TestNumbers.Float32WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float32WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithZeroMaximumWithOmitEmpty *float32 `json:"float32WithZeroMaximumWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithZeroMaximumWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field Float32WithNegativeMaximum should have the omitempty tag."
+	Float32WithNegativeMaximum float32 `json:"float32WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float32WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Maximum=-1
 	Float32WithNegativeMaximumWithOmitEmpty float32 `json:"float32WithNegativeMaximumWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field Float32WithRangeIncludingZero should have the omitempty tag." "field Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZero *float32 `json:"float32WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float32WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
+	Float32WithRangeIncludingZeroWithOmitEmpty *float32 `json:"float32WithRangeIncludingZeroWithOmitEmpty,omitempty"` // want "field TestNumbers.Float32WithRangeIncludingZeroWithOmitEmpty has a valid zero value \\(0.0\\) and should be a pointer."
 
-	Float64 *float64 `json:"float64,omitempty"` // want "field Float64 should have the omitempty tag." "field Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64 *float64 `json:"float64,omitempty"` // want "field TestNumbers.Float64 should have the omitempty tag." "field TestNumbers.Float64 has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Minimum=1
-	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field Float64WithPositiveMinimum should have the omitempty tag."
+	Float64WithPositiveMinimum float64 `json:"float64WithPositiveMinimum,omitempty"` // want "field TestNumbers.Float64WithPositiveMinimum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=0
-	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field Float64WithZeroMinimum should have the omitempty tag." "field Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMinimum *float64 `json:"float64WithZeroMinimum,omitempty"` // want "field TestNumbers.Float64WithZeroMinimum should have the omitempty tag." "field TestNumbers.Float64WithZeroMinimum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Minimum=-1
-	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field Float64WithNegativeMinimum should have the omitempty tag." "field Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithNegativeMinimum *float64 `json:"float64WithNegativeMinimum,omitempty"` // want "field TestNumbers.Float64WithNegativeMinimum should have the omitempty tag." "field TestNumbers.Float64WithNegativeMinimum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=1
-	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field Float64WithPositiveMaximum should have the omitempty tag." "field Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Float64WithPositiveMaximum *float64 `json:"float64WithPositiveMaximum,omitempty"` // want "field TestNumbers.Float64WithPositiveMaximum should have the omitempty tag." "field TestNumbers.Float64WithPositiveMaximum has a valid zero value \\(0.0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +kubebuilder:validation:Maximum=0
-	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field Float64WithZeroMaximum should have the omitempty tag." "field Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithZeroMaximum *float64 `json:"float64WithZeroMaximum,omitempty"` // want "field TestNumbers.Float64WithZeroMaximum should have the omitempty tag." "field TestNumbers.Float64WithZeroMaximum has a valid zero value \\(0.0\\) and should be a pointer."
 
 	// +kubebuilder:validation:Maximum=-1
-	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field Float64WithNegativeMaximum should have the omitempty tag."
+	Float64WithNegativeMaximum float64 `json:"float64WithNegativeMaximum,omitempty"` // want "field TestNumbers.Float64WithNegativeMaximum should have the omitempty tag."
 
 	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:validation:Maximum=1
-	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field Float64WithRangeIncludingZero should have the omitempty tag." "field Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
+	Float64WithRangeIncludingZero *float64 `json:"float64WithRangeIncludingZero,omitempty"` // want "field TestNumbers.Float64WithRangeIncludingZero should have the omitempty tag." "field TestNumbers.Float64WithRangeIncludingZero has a valid zero value \\(0.0\\) and should be a pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/strings.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/strings.go
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String string `json:"string"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr *string `json:"stringPtr"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength *string `json:"stringPtrWithMinLength"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty *string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 string `json:"stringWithMinLength0"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString"` // want "field TestStrings.EnumString should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr *string `json:"enumStringPtr"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr *string `json:"enumStringPtr"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty *string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring string `json:"enumValidEmptytring"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/strings.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/strings.go.golden
@@ -1,58 +1,58 @@
 package a
 
 type TestStrings struct {
-	String *string `json:"string,omitempty"` // want "field String should have the omitempty tag." "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field TestStrings.String should have the omitempty tag." "field TestStrings.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StringWithOmitEmpty *string `json:"stringWithOmitEmpty,omitempty"` // want "field TestStrings.StringWithOmitEmpty has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StringPtr *string `json:"stringPtr,omitempty"` // want "field StringPtr should have the omitempty tag."
+	StringPtr *string `json:"stringPtr,omitempty"` // want "field TestStrings.StringPtr should have the omitempty tag."
 
 	StringPtrWithOmitEmpty *string `json:"stringPtrWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field StringWithMinLength should have the omitempty tag."
+	StringWithMinLength string `json:"stringWithMinLength,omitempty"` // want "field TestStrings.StringWithMinLength should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=1
 	StringWithMinLengthWithOmitEmpty string `json:"stringWithMinLengthWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field StringPtrWithMinLength should have the omitempty tag." "field StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLength string `json:"stringPtrWithMinLength,omitempty"` // want "field TestStrings.StringPtrWithMinLength should have the omitempty tag." "field TestStrings.StringPtrWithMinLength does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=1
-	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StringPtrWithMinLengthWithOmitEmpty string `json:"stringPtrWithMinLengthWithOmitEmpty,omitempty"` // want "field TestStrings.StringPtrWithMinLengthWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field StringWithMinLength0 should have the omitempty tag." "field StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0 *string `json:"stringWithMinLength0,omitempty"` // want "field TestStrings.StringWithMinLength0 should have the omitempty tag." "field TestStrings.StringWithMinLength0 has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	StringWithMinLength0WithOmitEmpty *string `json:"stringWithMinLength0WithOmitEmpty,omitempty"` // want "field TestStrings.StringWithMinLength0WithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:MinLength=0
-	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field StringPtrWithMinLength0 should have the omitempty tag."
+	StringPtrWithMinLength0 *string `json:"stringPtrWithMinLength0,omitempty"` // want "field TestStrings.StringPtrWithMinLength0 should have the omitempty tag."
 
 	// +kubebuilder:validation:MinLength=0
 	StringPtrWithMinLength0WithOmitEmpty *string `json:"stringPtrWithMinLength0WithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumString string `json:"enumString,omitempty"` // want "field EnumString should have the omitempty tag."
+	EnumString string `json:"enumString,omitempty"` // want "field TestStrings.EnumString should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c
 	EnumStringWithOmitEmpty string `json:"enumStringWithOmitEmpty,omitempty"`
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field EnumStringPtr should have the omitempty tag." "field EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtr string `json:"enumStringPtr,omitempty"` // want "field TestStrings.EnumStringPtr should have the omitempty tag." "field TestStrings.EnumStringPtr does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c
-	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	EnumStringPtrWithOmitEmpty string `json:"enumStringPtrWithOmitEmpty,omitempty"` // want "field TestStrings.EnumStringPtrWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field EnumValidEmptytring should have the omitempty tag." "field EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptytring *string `json:"enumValidEmptytring,omitempty"` // want "field TestStrings.EnumValidEmptytring should have the omitempty tag." "field TestStrings.EnumValidEmptytring has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
+	EnumValidEmptyStringWithOmitEmpty *string `json:"enumValidEmptyStringWithOmitEmpty,omitempty"` // want "field TestStrings.EnumValidEmptyStringWithOmitEmpty has a valid zero value \\(\"\"\\) and should be a pointer."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
-	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field EnumValidEmptyStringPtr should have the omitempty tag."
+	EnumValidEmptyStringPtr *string `json:"enumValidEmptyStringPtr,omitempty"` // want "field TestStrings.EnumValidEmptyStringPtr should have the omitempty tag."
 
 	// +kubebuilder:validation:Enum=a;b;c;""
 	EnumValidEmptyStringPtrWithOmitEmpty *string `json:"enumValidEmptyStringPtrWithOmitEmpty,omitempty"`

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int int32 `json:"int"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int int32 `json:"int"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String string `json:"string"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String string `json:"string"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
@@ -3,74 +3,74 @@ package a
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
-	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field StructWithAllOptionalFields should have the omitempty tag." "field StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFields *StructWithAllOptionalFields `json:"structWithAllOptionalFields,omitempty"` // want "field TestStructs.StructWithAllOptionalFields should have the omitempty tag." "field TestStructs.StructWithAllOptionalFields has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
-	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field StructPtrWithAllOptionalFields should have the omitempty tag."
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties,omitzero"` // want "field StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties,omitzero"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
 
-	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithMinProperties StructWithMinProperties `json:"structPtrWithMinProperties,omitzero"` // want "field StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinProperties StructWithMinProperties `json:"structPtrWithMinProperties,omitzero"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
-	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field StructWithNonOmittedFields should have the omitempty tag." "field StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFields *StructWithNonOmittedFields `json:"structWithNonOmittedFields,omitempty"` // want "field TestStructs.StructWithNonOmittedFields should have the omitempty tag." "field TestStructs.StructWithNonOmittedFields has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field StructPtrWithNonOmittedFields should have the omitempty tag."
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFields should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
 
 	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
 
-	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinProperties should have the omitempty tag." "field TestStructs.StructWithNonOmittedFieldsAndMinProperties has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
 
-	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties,omitempty"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties should have the omitempty tag."
 
 	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
 
 	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
 
-	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero"` // want "field StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
 
-	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitzero"` // want "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitzero"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
 	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
 
-	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitzero"` // want "field StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
 
-	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
 
-	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
-	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 }
 
 type StructWithAllOptionalFields struct {
 	// +optional
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	StringPtr *string `json:"stringPtr,omitempty"`
 
 	// +optional
-	Int *int `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// +optional
 	IntPtr *int `json:"intPtr,omitempty"`
@@ -85,10 +85,10 @@ type StructWithMinProperties struct {
 
 type StructWithNonOmittedFields struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFields.Int should have the omitempty tag."
 }
 
 // Struct with non-omitted fields and minProperties marker.
@@ -97,10 +97,10 @@ type StructWithNonOmittedFields struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithNonOmittedFieldsAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.String should have the omitempty tag."
 
 	// +required
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field Int should have the omitempty tag."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithNonOmittedFieldsAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithNonOmittedFieldsAndMinProperties.Int should have the omitempty tag."
 }
 
 // Struct with one non-omitted field, and one omitted field and minProperties marker.
@@ -108,15 +108,15 @@ type StructWithNonOmittedFieldsAndMinProperties struct {
 // +kubebuilder:validation:MinProperties=2
 type StructWithOneNonOmittedFieldAndMinProperties struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field String should have the omitempty tag."
+	String *string `json:"string,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field StructWithOneNonOmittedFieldAndMinProperties.String should have the omitempty tag."
 
 	// +optional
-	Int *int32 `json:"int,omitempty"` // want "field Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Int *int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }
 
 // Struct with an omitted required field.
 // The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
 type StructWithOmittedRequiredField struct {
 	// +required
-	String *string `json:"string,omitempty"` // want "field String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 }

--- a/pkg/analysis/utils/serialization/util.go
+++ b/pkg/analysis/utils/serialization/util.go
@@ -80,15 +80,15 @@ func reportShouldRemovePointer(pass *analysis.Pass, field *ast.Field, pointerPol
 }
 
 // reportShouldAddOmitEmpty adds an analysis diagnostic that explains that an omitempty tag should be added.
-func reportShouldAddOmitEmpty(pass *analysis.Pass, field *ast.Field, omitEmptyPolicy OmitEmptyPolicy, fieldName, messageFmt string, fieldTagInfo extractjsontags.FieldTagInfo) {
+func reportShouldAddOmitEmpty(pass *analysis.Pass, field *ast.Field, omitEmptyPolicy OmitEmptyPolicy, qualifiedFieldName, messageFmt string, fieldTagInfo extractjsontags.FieldTagInfo) {
 	switch omitEmptyPolicy {
 	case OmitEmptyPolicySuggestFix:
 		pass.Report(analysis.Diagnostic{
 			Pos:     field.Pos(),
-			Message: fmt.Sprintf(messageFmt, fieldName),
+			Message: fmt.Sprintf(messageFmt, qualifiedFieldName),
 			SuggestedFixes: []analysis.SuggestedFix{
 				{
-					Message: fmt.Sprintf("should add 'omitempty' to the field tag for field %s", fieldName),
+					Message: fmt.Sprintf("should add 'omitempty' to the field tag for field %s", qualifiedFieldName),
 					TextEdits: []analysis.TextEdit{
 						{
 							Pos:     fieldTagInfo.Pos + token.Pos(len(fieldTagInfo.Name)),
@@ -99,7 +99,7 @@ func reportShouldAddOmitEmpty(pass *analysis.Pass, field *ast.Field, omitEmptyPo
 			},
 		})
 	case OmitEmptyPolicyWarn:
-		pass.Reportf(field.Pos(), messageFmt, fieldName)
+		pass.Reportf(field.Pos(), messageFmt, qualifiedFieldName)
 	case OmitEmptyPolicyIgnore:
 		// Do nothing, as the policy is to ignore the missing omitempty tag.
 	default:
@@ -108,15 +108,15 @@ func reportShouldAddOmitEmpty(pass *analysis.Pass, field *ast.Field, omitEmptyPo
 }
 
 // reportShouldAddOmitZero adds an analysis diagnostic that explains that an omitzero tag should be added.
-func reportShouldAddOmitZero(pass *analysis.Pass, field *ast.Field, omitZeroPolicy OmitZeroPolicy, fieldName, messageFmt string, fieldTagInfo extractjsontags.FieldTagInfo) {
+func reportShouldAddOmitZero(pass *analysis.Pass, field *ast.Field, omitZeroPolicy OmitZeroPolicy, qualifiedFieldName, messageFmt string, fieldTagInfo extractjsontags.FieldTagInfo) {
 	switch omitZeroPolicy {
 	case OmitZeroPolicySuggestFix:
 		pass.Report(analysis.Diagnostic{
 			Pos:     field.Pos(),
-			Message: fmt.Sprintf(messageFmt, fieldName),
+			Message: fmt.Sprintf(messageFmt, qualifiedFieldName),
 			SuggestedFixes: []analysis.SuggestedFix{
 				{
-					Message: fmt.Sprintf("should add 'omitzero' to the field tag for field %s", fieldName),
+					Message: fmt.Sprintf("should add 'omitzero' to the field tag for field %s", qualifiedFieldName),
 					TextEdits: []analysis.TextEdit{
 						{
 							Pos:     fieldTagInfo.Pos + token.Pos(len(fieldTagInfo.Name)),
@@ -127,7 +127,7 @@ func reportShouldAddOmitZero(pass *analysis.Pass, field *ast.Field, omitZeroPoli
 			},
 		})
 	case OmitZeroPolicyWarn:
-		pass.Reportf(field.Pos(), messageFmt, fieldName)
+		pass.Reportf(field.Pos(), messageFmt, qualifiedFieldName)
 	case OmitZeroPolicyForbid:
 		// Do nothing, as the policy is to forbid the missing omitzero tag.
 	default:
@@ -136,12 +136,12 @@ func reportShouldAddOmitZero(pass *analysis.Pass, field *ast.Field, omitZeroPoli
 }
 
 // reportShouldRemoveOmitZero adds an analysis diagnostic that explains that an omitzero tag should be removed.
-func reportShouldRemoveOmitZero(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo) {
+func reportShouldRemoveOmitZero(pass *analysis.Pass, field *ast.Field, qualifiedFieldName string, jsonTags extractjsontags.FieldTagInfo) {
 	omitZeroPos := jsonTags.Pos + token.Pos(strings.Index(jsonTags.RawValue, ",omitzero"))
 
 	pass.Report(analysis.Diagnostic{
 		Pos:     field.Pos(),
-		Message: fmt.Sprintf("field %s has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed.", fieldName),
+		Message: fmt.Sprintf("field %s has the omitzero tag, but by policy is not allowed. The omitzero tag should be removed.", qualifiedFieldName),
 		SuggestedFixes: []analysis.SuggestedFix{
 			{
 				Message: "should remove the omitzero tag",

--- a/pkg/analysis/utils/zero_value_test.go
+++ b/pkg/analysis/utils/zero_value_test.go
@@ -70,7 +70,7 @@ func testZeroValueAnalyzer(considerOmitZero bool) *analysis.Analyzer {
 					return
 				}
 
-				zeroValueValid, complete := utils.IsZeroValueValid(pass, field, field.Type, markers, considerOmitZero)
+				zeroValueValid, complete := utils.IsZeroValueValid(pass, field, field.Type, markers, considerOmitZero, utils.GetQualifiedFieldName(pass, field))
 				if !zeroValueValid {
 					pass.Reportf(field.Pos(), "zero value is not valid")
 				} else {

--- a/tests/integration/testdata/default_configurations/affinity.go
+++ b/tests/integration/testdata/default_configurations/affinity.go
@@ -203,7 +203,7 @@ type Taint struct {
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"` // want "optionalorrequired: field Taint.Key must be marked as optional or required"
 	// The taint value corresponding to the taint key. // want "commentstart: godoc for field Taint.Value should start with 'value ...'"
 	// +optional
-	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"` // want "optionalfields: field Value should be a pointer."
+	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"` // want "optionalfields: field Taint.Value should be a pointer."
 	// Required. The effect of the taint on pods // want "commentstart: godoc for field Taint.Effect should start with 'effect ...'"
 	// that do not tolerate the taint.
 	// Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
@@ -245,21 +245,21 @@ type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys. // want "commentstart: godoc for field Toleration.Key should start with 'key ...'"
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
-	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"` // want "optionalfields: field Key should be a pointer."
+	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"` // want "optionalfields: field Toleration.Key should be a pointer."
 	// Operator represents a key's relationship to the value. // want "commentstart: godoc for field Toleration.Operator should start with 'operator ...'"
 	// Valid operators are Exists and Equal. Defaults to Equal.
 	// Exists is equivalent to wildcard for value, so that a pod can
 	// tolerate all taints of a particular category.
 	// +optional
-	Operator TolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"` // want "optionalfields: field Operator should be a pointer."
+	Operator TolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"` // want "optionalfields: field Toleration.Operator should be a pointer."
 	// Value is the taint value the toleration matches to. // want "commentstart: godoc for field Toleration.Value should start with 'value ...'"
 	// If the operator is Exists, the value should be empty, otherwise just a regular string.
 	// +optional
-	Value string `json:"value,omitempty" protobuf:"bytes,3,opt,name=value"` // want "optionalfields: field Value should be a pointer."
+	Value string `json:"value,omitempty" protobuf:"bytes,3,opt,name=value"` // want "optionalfields: field Toleration.Value should be a pointer."
 	// Effect indicates the taint effect to match. Empty means match all taint effects. // want "commentstart: godoc for field Toleration.Effect should start with 'effect ...'"
 	// When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
 	// +optional
-	Effect TaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"` // want "optionalfields: field Effect should be a pointer."
+	Effect TaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"` // want "optionalfields: field Toleration.Effect should be a pointer."
 	// TolerationSeconds represents the period of time the toleration (which must be // want "commentstart: godoc for field Toleration.TolerationSeconds should start with 'tolerationSeconds ...'"
 	// of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
 	// it is not set, which means tolerate the taint forever (do not evict). Zero and

--- a/tests/integration/testdata/default_configurations/container.go
+++ b/tests/integration/testdata/default_configurations/container.go
@@ -11,7 +11,7 @@ type Container struct {
 	// This field is optional to allow higher level config management to default or override
 	// container images in workload controllers like Deployments and StatefulSets.
 	// +optional
-	Image string `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"` // want "optionalfields: field Image should be a pointer."
+	Image string `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"` // want "optionalfields: field Container.Image should be a pointer."
 	// Entrypoint array. Not executed within a shell. // want "commentstart: godoc for field Container.Command should start with 'command ...'"
 	// The container image's ENTRYPOINT is used if this is not provided.
 	// Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
@@ -39,7 +39,7 @@ type Container struct {
 	// might be configured in the container image.
 	// Cannot be updated.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"` // want "optionalfields: field WorkingDir should be a pointer."
+	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"` // want "optionalfields: field Container.WorkingDir should be a pointer."
 	// List of ports to expose from the container. Not specifying a port here // want "commentstart: godoc for field Container.Ports should start with 'ports ...'"
 	// DOES NOT prevent that port from being exposed. Any port which is
 	// listening on the default "0.0.0.0" address inside a container will be
@@ -75,7 +75,7 @@ type Container struct {
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// +optional
-	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"` // want "optionalfields: field Resources should be a pointer."
+	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"` // want "optionalfields: field Container.Resources should be a pointer."
 	// Resources resize policy for the container. // want "commentstart: godoc for field Container.ResizePolicy should start with 'resizePolicy ...'"
 	// This field cannot be set on ephemeral containers.
 	// +featureGate=InPlacePodVerticalScaling
@@ -162,7 +162,7 @@ type Container struct {
 	// Defaults to /dev/termination-log.
 	// Cannot be updated.
 	// +optional
-	TerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"` // want "optionalfields: field TerminationMessagePath should be a pointer."
+	TerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"` // want "optionalfields: field Container.TerminationMessagePath should be a pointer."
 	// Indicate how the termination message should be populated. File will use the contents of // want "commentstart: godoc for field Container.TerminationMessagePolicy should start with 'terminationMessagePolicy ...'"
 	// terminationMessagePath to populate the container status message on both success and failure.
 	// FallbackToLogsOnError will use the last chunk of container log output if the termination
@@ -171,14 +171,14 @@ type Container struct {
 	// Defaults to File.
 	// Cannot be updated.
 	// +optional
-	TerminationMessagePolicy TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"` // want "optionalfields: field TerminationMessagePolicy should be a pointer."
+	TerminationMessagePolicy TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"` // want "optionalfields: field Container.TerminationMessagePolicy should be a pointer."
 	// Image pull policy. // want "commentstart: godoc for field Container.ImagePullPolicy should start with 'imagePullPolicy ...'"
 	// One of Always, Never, IfNotPresent.
 	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
 	// +optional
-	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"` // want "optionalfields: field ImagePullPolicy should be a pointer."
+	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"` // want "optionalfields: field Container.ImagePullPolicy should be a pointer."
 	// SecurityContext defines the security options the container should be run with. // want "commentstart: godoc for field Container.SecurityContext should start with 'securityContext ...'"
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -192,7 +192,7 @@ type Container struct {
 	// is not set, reads from stdin in the container will always result in EOF.
 	// Default is false.
 	// +optional
-	Stdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"` // want "optionalfields: field Stdin should be a pointer."
+	Stdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"` // want "optionalfields: field Container.Stdin should be a pointer."
 	// Whether the container runtime should close the stdin channel after it has been opened by // want "commentstart: godoc for field Container.StdinOnce should start with 'stdinOnce ...'"
 	// a single attach. When stdin is true the stdin stream will remain open across multiple attach
 	// sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
@@ -201,11 +201,11 @@ type Container struct {
 	// flag is false, a container processes that reads from stdin will never receive an EOF.
 	// Default is false
 	// +optional
-	StdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"` // want "optionalfields: field StdinOnce should be a pointer."
+	StdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"` // want "optionalfields: field Container.StdinOnce should be a pointer."
 	// Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. // want "commentstart: godoc for field Container.TTY should start with 'tty ...'"
 	// Default is false.
 	// +optional
-	TTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"` // want "optionalfields: field TTY should be a pointer."
+	TTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"` // want "optionalfields: field Container.TTY should be a pointer."
 }
 
 // Protocol defines network protocols supported for things like container ports.
@@ -227,13 +227,13 @@ type ContainerPort struct {
 	// named port in a pod must have a unique name. Name for the port that can be
 	// referred to by services.
 	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field Name should be a pointer."
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field ContainerPort.Name should be a pointer."
 	// Number of port to expose on the host. // want "commentstart: godoc for field ContainerPort.HostPort should start with 'hostPort ...'"
 	// If specified, this must be a valid port number, 0 < x < 65536.
 	// If HostNetwork is specified, this must match ContainerPort.
 	// Most containers do not need this.
 	// +optional
-	HostPort int32 `json:"hostPort,omitempty" protobuf:"varint,2,opt,name=hostPort"` // want "optionalfields: field HostPort should be a pointer."
+	HostPort int32 `json:"hostPort,omitempty" protobuf:"varint,2,opt,name=hostPort"` // want "optionalfields: field ContainerPort.HostPort should be a pointer."
 	// Number of port to expose on the pod's IP address. // want "commentstart: godoc for field ContainerPort.ContainerPort should start with 'containerPort ...'"
 	// This must be a valid port number, 0 < x < 65536.
 	ContainerPort int32 `json:"containerPort" protobuf:"varint,3,opt,name=containerPort"` // want "optionalorrequired: field ContainerPort.ContainerPort must be marked as optional or required"
@@ -241,10 +241,10 @@ type ContainerPort struct {
 	// Defaults to "TCP".
 	// +optional
 	// +default="TCP"
-	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,4,opt,name=protocol,casttype=Protocol"` // want "optionalfields: field Protocol should be a pointer."
+	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,4,opt,name=protocol,casttype=Protocol"` // want "optionalfields: field ContainerPort.Protocol should be a pointer."
 	// What host IP to bind the external port to. // want "commentstart: godoc for field ContainerPort.HostIP should start with 'hostIP ...'"
 	// +optional
-	HostIP string `json:"hostIP,omitempty" protobuf:"bytes,5,opt,name=hostIP"` // want "optionalfields: field HostIP should be a pointer."
+	HostIP string `json:"hostIP,omitempty" protobuf:"bytes,5,opt,name=hostIP"` // want "optionalfields: field ContainerPort.HostIP should be a pointer."
 }
 
 // EnvVar represents an environment variable present in a Container.
@@ -265,7 +265,7 @@ type EnvVar struct {
 	// exists or not.
 	// Defaults to "".
 	// +optional
-	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"` // want "optionalfields: field Value should be a pointer."
+	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"` // want "optionalfields: field EnvVar.Value should be a pointer."
 	// Source for the environment variable's value. Cannot be used if value is not empty. // want "commentstart: godoc for field EnvVar.ValueFrom should start with 'valueFrom ...'"
 	// +optional
 	ValueFrom *EnvVarSource `json:"valueFrom,omitempty" protobuf:"bytes,3,opt,name=valueFrom"`
@@ -300,16 +300,16 @@ type EnvVarSource struct {
 type FileKeySelector struct {
 	// The name of the volume mount containing the env file. // want "commentstart: godoc for field FileKeySelector.VolumeName should start with 'volumeName ...'"
 	// +required
-	VolumeName string `json:"volumeName" protobuf:"bytes,1,opt,name=volumeName"` // want "requiredfields: field VolumeName should have the omitempty tag." "requiredfields: field VolumeName has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	VolumeName string `json:"volumeName" protobuf:"bytes,1,opt,name=volumeName"` // want "requiredfields: field FileKeySelector.VolumeName should have the omitempty tag." "requiredfields: field FileKeySelector.VolumeName has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 	// The path within the volume from which to select the file. // want "commentstart: godoc for field FileKeySelector.Path should start with 'path ...'"
 	// Must be relative and may not contain the '..' path or start with '..'.
 	// +required
-	Path string `json:"path" protobuf:"bytes,2,opt,name=path"` // want "requiredfields: field Path should have the omitempty tag." "requiredfields: field Path has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Path string `json:"path" protobuf:"bytes,2,opt,name=path"` // want "requiredfields: field FileKeySelector.Path should have the omitempty tag." "requiredfields: field FileKeySelector.Path has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 	// The key within the env file. An invalid key will prevent the pod from starting. // want "commentstart: godoc for field FileKeySelector.Key should start with 'key ...'"
 	// The keys defined within a source may consist of any printable ASCII characters except '='.
 	// During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
 	// +required
-	Key string `json:"key" protobuf:"bytes,3,opt,name=key"` // want "requiredfields: field Key should have the omitempty tag." "requiredfields: field Key has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Key string `json:"key" protobuf:"bytes,3,opt,name=key"` // want "requiredfields: field FileKeySelector.Key should have the omitempty tag." "requiredfields: field FileKeySelector.Key has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 	// Specify whether the file or its key must be defined. If the file or key // want "commentstart: godoc for field FileKeySelector.Optional should start with 'optional ...'"
 	// does not exist, then the env var is not published.
 	// If optional is set to true and the specified key does not exist,
@@ -327,7 +327,7 @@ type FileKeySelector struct {
 type ObjectFieldSelector struct {
 	// Version of the schema the FieldPath is written in terms of, defaults to "v1". // want "commentstart: godoc for field ObjectFieldSelector.APIVersion should start with 'apiVersion ...'"
 	// +optional
-	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,opt,name=apiVersion"` // want "optionalfields: field APIVersion should be a pointer."
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,opt,name=apiVersion"` // want "optionalfields: field ObjectFieldSelector.APIVersion should be a pointer."
 	// Path of the field to select in the specified API version. // want "commentstart: godoc for field ObjectFieldSelector.FieldPath should start with 'fieldPath ...'"
 	FieldPath string `json:"fieldPath" protobuf:"bytes,2,opt,name=fieldPath"` // want "optionalorrequired: field ObjectFieldSelector.FieldPath must be marked as optional or required"
 }
@@ -337,7 +337,7 @@ type ObjectFieldSelector struct {
 type ResourceFieldSelector struct {
 	// Container name: required for volumes, optional for env vars // want "commentstart: godoc for field ResourceFieldSelector.ContainerName should start with 'containerName ...'"
 	// +optional
-	ContainerName string `json:"containerName,omitempty" protobuf:"bytes,1,opt,name=containerName"` // want "optionalfields: field ContainerName should be a pointer."
+	ContainerName string `json:"containerName,omitempty" protobuf:"bytes,1,opt,name=containerName"` // want "optionalfields: field ResourceFieldSelector.ContainerName should be a pointer."
 	// Required: resource to select // want "commentstart: godoc for field ResourceFieldSelector.Resource should start with 'resource ...'"
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"` // want "optionalorrequired: field ResourceFieldSelector.Resource must be marked as optional or required"
 	// Specifies the output format of the exposed resources, defaults to "1"
@@ -374,7 +374,7 @@ type EnvFromSource struct {
 	// Optional text to prepend to the name of each environment variable. // want "commentstart: godoc for field EnvFromSource.Prefix should start with 'prefix ...'"
 	// May consist of any printable ASCII characters except '='.
 	// +optional
-	Prefix string `json:"prefix,omitempty" protobuf:"bytes,1,opt,name=prefix"` // want "optionalfields: field Prefix should be a pointer."
+	Prefix string `json:"prefix,omitempty" protobuf:"bytes,1,opt,name=prefix"` // want "optionalfields: field EnvFromSource.Prefix should be a pointer."
 	// The ConfigMap to select from // want "commentstart: godoc for field EnvFromSource.ConfigMapRef should start with 'configMapRef ...'"
 	// +optional
 	ConfigMapRef *ConfigMapEnvSource `json:"configMapRef,omitempty" protobuf:"bytes,2,opt,name=configMapRef"`
@@ -449,7 +449,7 @@ type ResourceClaim struct {
 	// only the result of this request.
 	//
 	// +optional
-	Request string `json:"request,omitempty" protobuf:"bytes,2,opt,name=request"` // want "optionalfields: field Request should be a pointer."
+	Request string `json:"request,omitempty" protobuf:"bytes,2,opt,name=request"` // want "optionalfields: field ResourceClaim.Request should be a pointer."
 }
 
 // ResourceResizeRestartPolicy specifies how to handle container resource resize.
@@ -498,7 +498,7 @@ type ContainerRestartRule struct {
 	// are satisfied. The only possible value is "Restart" to restart the
 	// container.
 	// +required
-	Action ContainerRestartRuleAction `json:"action,omitempty" proto:"bytes,1,opt,name=action" protobuf:"bytes,1,opt,name=action,casttype=ContainerRestartRuleAction"` // want "requiredfields: field Action has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Action ContainerRestartRuleAction `json:"action,omitempty" proto:"bytes,1,opt,name=action" protobuf:"bytes,1,opt,name=action,casttype=ContainerRestartRuleAction"` // want "requiredfields: field ContainerRestartRule.Action has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// Represents the exit codes to check on container exits. // want "commentstart: godoc for field ContainerRestartRule.ExitCodes should start with 'exitCodes ...'"
 	// +optional
@@ -525,7 +525,7 @@ type ContainerRestartRuleOnExitCodes struct {
 	// - NotIn: the requirement is satisfied if the container exit code is
 	//   not in the set of specified values.
 	// +required
-	Operator ContainerRestartRuleOnExitCodesOperator `json:"operator,omitempty" proto:"bytes,1,opt,name=operator" protobuf:"bytes,1,opt,name=operator,casttype=ContainerRestartRuleOnExitCodesOperator"` // want "requiredfields: field Operator has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	Operator ContainerRestartRuleOnExitCodesOperator `json:"operator,omitempty" proto:"bytes,1,opt,name=operator" protobuf:"bytes,1,opt,name=operator,casttype=ContainerRestartRuleOnExitCodesOperator"` // want "requiredfields: field ContainerRestartRuleOnExitCodes.Operator has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// Specifies the set of values to check for container exit codes. // want "commentstart: godoc for field ContainerRestartRuleOnExitCodes.Values should start with 'values ...'"
 	// At most 255 elements are allowed.
@@ -551,24 +551,24 @@ type Probe struct {
 	// Number of seconds after the container has started before liveness probes are initiated. // want "commentstart: godoc for field Probe.InitialDelaySeconds should start with 'initialDelaySeconds ...'"
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	// +optional
-	InitialDelaySeconds int32 `json:"initialDelaySeconds,omitempty" protobuf:"varint,2,opt,name=initialDelaySeconds"` // want "optionalfields: field InitialDelaySeconds should be a pointer."
+	InitialDelaySeconds int32 `json:"initialDelaySeconds,omitempty" protobuf:"varint,2,opt,name=initialDelaySeconds"` // want "optionalfields: field Probe.InitialDelaySeconds should be a pointer."
 	// Number of seconds after which the probe times out. // want "commentstart: godoc for field Probe.TimeoutSeconds should start with 'timeoutSeconds ...'"
 	// Defaults to 1 second. Minimum value is 1.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	// +optional
-	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty" protobuf:"varint,3,opt,name=timeoutSeconds"` // want "optionalfields: field TimeoutSeconds should be a pointer."
+	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty" protobuf:"varint,3,opt,name=timeoutSeconds"` // want "optionalfields: field Probe.TimeoutSeconds should be a pointer."
 	// How often (in seconds) to perform the probe. // want "commentstart: godoc for field Probe.PeriodSeconds should start with 'periodSeconds ...'"
 	// Default to 10 seconds. Minimum value is 1.
 	// +optional
-	PeriodSeconds int32 `json:"periodSeconds,omitempty" protobuf:"varint,4,opt,name=periodSeconds"` // want "optionalfields: field PeriodSeconds should be a pointer."
+	PeriodSeconds int32 `json:"periodSeconds,omitempty" protobuf:"varint,4,opt,name=periodSeconds"` // want "optionalfields: field Probe.PeriodSeconds should be a pointer."
 	// Minimum consecutive successes for the probe to be considered successful after having failed. // want "commentstart: godoc for field Probe.SuccessThreshold should start with 'successThreshold ...'"
 	// Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
 	// +optional
-	SuccessThreshold int32 `json:"successThreshold,omitempty" protobuf:"varint,5,opt,name=successThreshold"` // want "optionalfields: field SuccessThreshold should be a pointer."
+	SuccessThreshold int32 `json:"successThreshold,omitempty" protobuf:"varint,5,opt,name=successThreshold"` // want "optionalfields: field Probe.SuccessThreshold should be a pointer."
 	// Minimum consecutive failures for the probe to be considered failed after having succeeded. // want "commentstart: godoc for field Probe.FailureThreshold should start with 'failureThreshold ...'"
 	// Defaults to 3. Minimum value is 1.
 	// +optional
-	FailureThreshold int32 `json:"failureThreshold,omitempty" protobuf:"varint,6,opt,name=failureThreshold"` // want "optionalfields: field FailureThreshold should be a pointer."
+	FailureThreshold int32 `json:"failureThreshold,omitempty" protobuf:"varint,6,opt,name=failureThreshold"` // want "optionalfields: field Probe.FailureThreshold should be a pointer."
 	// Optional duration in seconds the pod needs to terminate gracefully upon probe failure. // want "commentstart: godoc for field Probe.TerminationGracePeriodSeconds should start with 'terminationGracePeriodSeconds ...'"
 	// The grace period is the duration in seconds after the processes running in the pod are sent
 	// a termination signal and the time when the processes are forcibly halted with a kill signal.
@@ -604,7 +604,7 @@ type ProbeHandler struct {
 type HTTPGetAction struct {
 	// Path to access on the HTTP server. // want "commentstart: godoc for field HTTPGetAction.Path should start with 'path ...'"
 	// +optional
-	Path string `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"` // want "optionalfields: field Path should be a pointer."
+	Path string `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"` // want "optionalfields: field HTTPGetAction.Path should be a pointer."
 	// Name or number of the port to access on the container.
 	// Number must be in the range 1 to 65535.
 	// Name must be an IANA_SVC_NAME.
@@ -613,11 +613,11 @@ type HTTPGetAction struct {
 	// Host name to connect to, defaults to the pod IP. You probably want to set // want "commentstart: godoc for field HTTPGetAction.Host should start with 'host ...'"
 	// "Host" in httpHeaders instead.
 	// +optional
-	Host string `json:"host,omitempty" protobuf:"bytes,3,opt,name=host"` // want "optionalfields: field Host should be a pointer."
+	Host string `json:"host,omitempty" protobuf:"bytes,3,opt,name=host"` // want "optionalfields: field HTTPGetAction.Host should be a pointer."
 	// Scheme to use for connecting to the host. // want "commentstart: godoc for field HTTPGetAction.Scheme should start with 'scheme ...'"
 	// Defaults to HTTP.
 	// +optional
-	Scheme URIScheme `json:"scheme,omitempty" protobuf:"bytes,4,opt,name=scheme,casttype=URIScheme"` // want "optionalfields: field Scheme should be a pointer."
+	Scheme URIScheme `json:"scheme,omitempty" protobuf:"bytes,4,opt,name=scheme,casttype=URIScheme"` // want "optionalfields: field HTTPGetAction.Scheme should be a pointer."
 	// Custom headers to set in the request. HTTP allows repeated headers. // want "commentstart: godoc for field HTTPGetAction.HTTPHeaders should start with 'httpHeaders ...'"
 	// +optional
 	// +listType=atomic
@@ -653,7 +653,7 @@ type TCPSocketAction struct {
 
 	// Optional: Host name to connect to, defaults to the pod IP. // want "commentstart: godoc for field TCPSocketAction.Host should start with 'host ...'"
 	// +optional
-	Host string `json:"host,omitempty" protobuf:"bytes,2,opt,name=host"` // want "optionalfields: field Host should be a pointer."
+	Host string `json:"host,omitempty" protobuf:"bytes,2,opt,name=host"` // want "optionalfields: field TCPSocketAction.Host should be a pointer."
 }
 
 // GRPCAction specifies an action involving a GRPC service.
@@ -667,7 +667,7 @@ type GRPCAction struct {
 	// If this is not specified, the default behavior is defined by gRPC.
 	// +optional
 	// +default=""
-	Service *string `json:"service" protobuf:"bytes,2,opt,name=service"` // want "optionalfields: field Service should have the omitempty tag."
+	Service *string `json:"service" protobuf:"bytes,2,opt,name=service"` // want "optionalfields: field GRPCAction.Service should have the omitempty tag."
 }
 
 // ExecAction describes a "run in container" action.
@@ -952,16 +952,16 @@ type Capabilities struct {
 type SELinuxOptions struct {
 	// User is a SELinux user label that applies to the container. // want "commentstart: godoc for field SELinuxOptions.User should start with 'user ...'"
 	// +optional
-	User string `json:"user,omitempty" protobuf:"bytes,1,opt,name=user"` // want "optionalfields: field User should be a pointer."
+	User string `json:"user,omitempty" protobuf:"bytes,1,opt,name=user"` // want "optionalfields: field SELinuxOptions.User should be a pointer."
 	// Role is a SELinux role label that applies to the container. // want "commentstart: godoc for field SELinuxOptions.Role should start with 'role ...'"
 	// +optional
-	Role string `json:"role,omitempty" protobuf:"bytes,2,opt,name=role"` // want "optionalfields: field Role should be a pointer."
+	Role string `json:"role,omitempty" protobuf:"bytes,2,opt,name=role"` // want "optionalfields: field SELinuxOptions.Role should be a pointer."
 	// Type is a SELinux type label that applies to the container. // want "commentstart: godoc for field SELinuxOptions.Type should start with 'type ...'"
 	// +optional
-	Type string `json:"type,omitempty" protobuf:"bytes,3,opt,name=type"` // want "optionalfields: field Type should be a pointer."
+	Type string `json:"type,omitempty" protobuf:"bytes,3,opt,name=type"` // want "optionalfields: field SELinuxOptions.Type should be a pointer."
 	// Level is SELinux level label that applies to the container. // want "commentstart: godoc for field SELinuxOptions.Level should start with 'level ...'"
 	// +optional
-	Level string `json:"level,omitempty" protobuf:"bytes,4,opt,name=level"` // want "optionalfields: field Level should be a pointer."
+	Level string `json:"level,omitempty" protobuf:"bytes,4,opt,name=level"` // want "optionalfields: field SELinuxOptions.Level should be a pointer."
 }
 
 // WindowsSecurityContextOptions contain Windows-specific options and credentials.
@@ -1062,7 +1062,7 @@ const (
 type HostAlias struct {
 	// IP address of the host file entry. // want "commentstart: godoc for field HostAlias.IP should start with 'ip ...'"
 	// +required
-	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"` // want "requiredfields: field IP should have the omitempty tag." "requiredfields: field IP has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"` // want "requiredfields: field HostAlias.IP should have the omitempty tag." "requiredfields: field HostAlias.IP has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 	// Hostnames for the above IP address. // want "commentstart: godoc for field HostAlias.Hostnames should start with 'hostnames ...'"
 	// +listType=atomic
 	Hostnames []string `json:"hostnames,omitempty" protobuf:"bytes,2,rep,name=hostnames"` // want "optionalorrequired: field HostAlias.Hostnames must be marked as optional or required"

--- a/tests/integration/testdata/default_configurations/ephemeral_container.go
+++ b/tests/integration/testdata/default_configurations/ephemeral_container.go
@@ -22,7 +22,7 @@ type EphemeralContainer struct {
 	// The container runtime must implement support for this feature. If the runtime does not
 	// support namespace targeting then the result of setting this field is undefined.
 	// +optional
-	TargetContainerName string `json:"targetContainerName,omitempty" protobuf:"bytes,2,opt,name=targetContainerName"` // want "optionalfields: field TargetContainerName should be a pointer."
+	TargetContainerName string `json:"targetContainerName,omitempty" protobuf:"bytes,2,opt,name=targetContainerName"` // want "optionalfields: field EphemeralContainer.TargetContainerName should be a pointer."
 }
 
 // EphemeralContainerCommon is a copy of all fields in Container to be inlined in
@@ -63,7 +63,7 @@ type EphemeralContainerCommon struct {
 	// might be configured in the container image.
 	// Cannot be updated.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"` // want "optionalfields: field WorkingDir should be a pointer."
+	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"` // want "optionalfields: field EphemeralContainerCommon.WorkingDir should be a pointer."
 	// Ports are not allowed for ephemeral containers. // want "commentstart: godoc for field EphemeralContainerCommon.Ports should start with 'ports ...'"
 	// +optional
 	// +patchMergeKey=containerPort
@@ -92,7 +92,7 @@ type EphemeralContainerCommon struct {
 	// Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources // want "commentstart: godoc for field EphemeralContainerCommon.Resources should start with 'resources ...'"
 	// already allocated to the pod.
 	// +optional
-	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"` // want "optionalfields: field Resources should be a pointer."
+	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"` // want "optionalfields: field EphemeralContainerCommon.Resources should be a pointer."
 	// Resources resize policy for the container. // want "commentstart: godoc for field EphemeralContainerCommon.ResizePolicy should start with 'resizePolicy ...'"
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional
@@ -145,7 +145,7 @@ type EphemeralContainerCommon struct {
 	// Defaults to /dev/termination-log.
 	// Cannot be updated.
 	// +optional
-	TerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"` // want "optionalfields: field TerminationMessagePath should be a pointer."
+	TerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"` // want "optionalfields: field EphemeralContainerCommon.TerminationMessagePath should be a pointer."
 	// Indicate how the termination message should be populated. File will use the contents of // want "commentstart: godoc for field EphemeralContainerCommon.TerminationMessagePolicy should start with 'terminationMessagePolicy ...'"
 	// terminationMessagePath to populate the container status message on both success and failure.
 	// FallbackToLogsOnError will use the last chunk of container log output if the termination
@@ -154,14 +154,14 @@ type EphemeralContainerCommon struct {
 	// Defaults to File.
 	// Cannot be updated.
 	// +optional
-	TerminationMessagePolicy TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"` // want "optionalfields: field TerminationMessagePolicy should be a pointer."
+	TerminationMessagePolicy TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"` // want "optionalfields: field EphemeralContainerCommon.TerminationMessagePolicy should be a pointer."
 	// Image pull policy. // want "commentstart: godoc for field EphemeralContainerCommon.ImagePullPolicy should start with 'imagePullPolicy ...'"
 	// One of Always, Never, IfNotPresent.
 	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
 	// +optional
-	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"` // want "optionalfields: field ImagePullPolicy should be a pointer."
+	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"` // want "optionalfields: field EphemeralContainerCommon.ImagePullPolicy should be a pointer."
 	// Optional: SecurityContext defines the security options the ephemeral container should be run with. // want "commentstart: godoc for field EphemeralContainerCommon.SecurityContext should start with 'securityContext ...'"
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// +optional
@@ -174,7 +174,7 @@ type EphemeralContainerCommon struct {
 	// is not set, reads from stdin in the container will always result in EOF.
 	// Default is false.
 	// +optional
-	Stdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"` // want "optionalfields: field Stdin should be a pointer."
+	Stdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"` // want "optionalfields: field EphemeralContainerCommon.Stdin should be a pointer."
 	// Whether the container runtime should close the stdin channel after it has been opened by // want "commentstart: godoc for field EphemeralContainerCommon.StdinOnce should start with 'stdinOnce ...'"
 	// a single attach. When stdin is true the stdin stream will remain open across multiple attach
 	// sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
@@ -183,9 +183,9 @@ type EphemeralContainerCommon struct {
 	// flag is false, a container processes that reads from stdin will never receive an EOF.
 	// Default is false
 	// +optional
-	StdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"` // want "optionalfields: field StdinOnce should be a pointer."
+	StdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"` // want "optionalfields: field EphemeralContainerCommon.StdinOnce should be a pointer."
 	// Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. // want "commentstart: godoc for field EphemeralContainerCommon.TTY should start with 'tty ...'"
 	// Default is false.
 	// +optional
-	TTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"` // want "optionalfields: field TTY should be a pointer."
+	TTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"` // want "optionalfields: field EphemeralContainerCommon.TTY should be a pointer."
 }

--- a/tests/integration/testdata/default_configurations/object_references.go
+++ b/tests/integration/testdata/default_configurations/object_references.go
@@ -24,26 +24,26 @@ type ObjectReference struct {
 	// Kind of the referent. // want "commentstart: godoc for field ObjectReference.Kind should start with 'kind ...'"
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	// +optional
-	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"` // want "optionalfields: field Kind should be a pointer."
+	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"` // want "optionalfields: field ObjectReference.Kind should be a pointer."
 	// Namespace of the referent. // want "commentstart: godoc for field ObjectReference.Namespace should start with 'namespace ...'"
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	// +optional
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"` // want "optionalfields: field Namespace should be a pointer."
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"` // want "optionalfields: field ObjectReference.Namespace should be a pointer."
 	// Name of the referent. // want "commentstart: godoc for field ObjectReference.Name should start with 'name ...'"
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"` // want "optionalfields: field Name should be a pointer."
+	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"` // want "optionalfields: field ObjectReference.Name should be a pointer."
 	// UID of the referent. // want "commentstart: godoc for field ObjectReference.UID should start with 'uid ...'"
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 	// +optional
-	UID types.UID `json:"uid,omitempty" protobuf:"bytes,4,opt,name=uid,casttype=k8s.io/apimachinery/pkg/types.UID"` // want "optionalfields: field UID should be a pointer."
+	UID types.UID `json:"uid,omitempty" protobuf:"bytes,4,opt,name=uid,casttype=k8s.io/apimachinery/pkg/types.UID"` // want "optionalfields: field ObjectReference.UID should be a pointer."
 	// API version of the referent. // want "commentstart: godoc for field ObjectReference.APIVersion should start with 'apiVersion ...'"
 	// +optional
-	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,5,opt,name=apiVersion"` // want "optionalfields: field APIVersion should be a pointer."
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,5,opt,name=apiVersion"` // want "optionalfields: field ObjectReference.APIVersion should be a pointer."
 	// Specific resourceVersion to which this reference is made, if any. // want "commentstart: godoc for field ObjectReference.ResourceVersion should start with 'resourceVersion ...'"
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 	// +optional
-	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,6,opt,name=resourceVersion"` // want "optionalfields: field ResourceVersion should be a pointer."
+	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,6,opt,name=resourceVersion"` // want "optionalfields: field ObjectReference.ResourceVersion should be a pointer."
 
 	// If referring to a piece of an object instead of an entire object, this string // want "commentstart: godoc for field ObjectReference.FieldPath should start with 'fieldPath ...'"
 	// should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
@@ -54,7 +54,7 @@ type ObjectReference struct {
 	// referencing a part of an object.
 	// TODO: this design is not final and this field is subject to change in the future.
 	// +optional
-	FieldPath string `json:"fieldPath,omitempty" protobuf:"bytes,7,opt,name=fieldPath"` // want "optionalfields: field FieldPath should be a pointer."
+	FieldPath string `json:"fieldPath,omitempty" protobuf:"bytes,7,opt,name=fieldPath"` // want "optionalfields: field ObjectReference.FieldPath should be a pointer."
 }
 
 // LocalObjectReference contains enough information to let you locate the
@@ -81,7 +81,7 @@ type LocalObjectReference struct {
 	// +default=""
 	// +kubebuilder:default=""
 	// TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field Name should be a pointer."
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field LocalObjectReference.Name should be a pointer."
 }
 
 // TypedLocalObjectReference contains enough information to let you locate the
@@ -106,7 +106,7 @@ type TypedLocalObjectReference struct {
 	// If APIGroup is not specified, the specified Kind must be in the core API group.
 	// For any other third-party types, APIGroup is required.
 	// +optional
-	APIGroup *string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"` // want "optionalfields: field APIGroup should have the omitempty tag."
+	APIGroup *string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"` // want "optionalfields: field TypedLocalObjectReference.APIGroup should have the omitempty tag."
 	// Kind is the type of resource being referenced // want "commentstart: godoc for field TypedLocalObjectReference.Kind should start with 'kind ...'"
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"` // want "optionalorrequired: field TypedLocalObjectReference.Kind must be marked as optional or required"
 	// Name is the name of resource being referenced // want "commentstart: godoc for field TypedLocalObjectReference.Name should start with 'name ...'"
@@ -119,10 +119,10 @@ type TypedLocalObjectReference struct {
 type SecretReference struct {
 	// name is unique within a namespace to reference a secret resource.
 	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field Name should be a pointer."
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"` // want "optionalfields: field SecretReference.Name should be a pointer."
 	// namespace defines the space within which the secret name must be unique.
 	// +optional
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"` // want "optionalfields: field Namespace should be a pointer."
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"` // want "optionalfields: field SecretReference.Namespace should be a pointer."
 }
 
 // TypedObjectReference contains enough information to let you locate the typed referenced object
@@ -131,7 +131,7 @@ type TypedObjectReference struct {
 	// If APIGroup is not specified, the specified Kind must be in the core API group.
 	// For any other third-party types, APIGroup is required.
 	// +optional
-	APIGroup *string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"` // want "optionalfields: field APIGroup should have the omitempty tag."
+	APIGroup *string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"` // want "optionalfields: field TypedObjectReference.APIGroup should have the omitempty tag."
 	// Kind is the type of resource being referenced // want "commentstart: godoc for field TypedObjectReference.Kind should start with 'kind ...'"
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"` // want "optionalorrequired: field TypedObjectReference.Kind must be marked as optional or required"
 	// Name is the name of resource being referenced // want "commentstart: godoc for field TypedObjectReference.Name should start with 'name ...'"

--- a/tests/integration/testdata/default_configurations/pod.go
+++ b/tests/integration/testdata/default_configurations/pod.go
@@ -52,7 +52,7 @@ type PodSpec struct {
 	// Default to Always.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
 	// +optional
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" protobuf:"bytes,3,opt,name=restartPolicy,casttype=RestartPolicy"` // want "optionalfields: field RestartPolicy should be a pointer."
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" protobuf:"bytes,3,opt,name=restartPolicy,casttype=RestartPolicy"` // want "optionalfields: field PodSpec.RestartPolicy should be a pointer."
 	// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. // want "commentstart: godoc for field PodSpec.TerminationGracePeriodSeconds should start with 'terminationGracePeriodSeconds ...'"
 	// Value must be non-negative integer. The value zero indicates stop immediately via
 	// the kill signal (no opportunity to shut down).
@@ -75,7 +75,7 @@ type PodSpec struct {
 	// To have DNS options set along with hostNetwork, you have to specify DNS policy
 	// explicitly to 'ClusterFirstWithHostNet'.
 	// +optional
-	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty" protobuf:"bytes,6,opt,name=dnsPolicy,casttype=DNSPolicy"` // want "optionalfields: field DNSPolicy should be a pointer."
+	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty" protobuf:"bytes,6,opt,name=dnsPolicy,casttype=DNSPolicy"` // want "optionalfields: field PodSpec.DNSPolicy should be a pointer."
 	// NodeSelector is a selector which must be true for the pod to fit on a node. // want "commentstart: godoc for field PodSpec.NodeSelector should start with 'nodeSelector ...'"
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -86,12 +86,12 @@ type PodSpec struct {
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod. // want "commentstart: godoc for field PodSpec.ServiceAccountName should start with 'serviceAccountName ...'"
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty" protobuf:"bytes,8,opt,name=serviceAccountName"` // want "optionalfields: field ServiceAccountName should be a pointer."
+	ServiceAccountName string `json:"serviceAccountName,omitempty" protobuf:"bytes,8,opt,name=serviceAccountName"` // want "optionalfields: field PodSpec.ServiceAccountName should be a pointer."
 	// DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. // want "commentstart: godoc for field PodSpec.DeprecatedServiceAccount should start with 'serviceAccount ...'"
 	// Deprecated: Use serviceAccountName instead.
 	// +k8s:conversion-gen=false
 	// +optional
-	DeprecatedServiceAccount string `json:"serviceAccount,omitempty" protobuf:"bytes,9,opt,name=serviceAccount"` // want "optionalfields: field DeprecatedServiceAccount should be a pointer."
+	DeprecatedServiceAccount string `json:"serviceAccount,omitempty" protobuf:"bytes,9,opt,name=serviceAccount"` // want "optionalfields: field PodSpec.DeprecatedServiceAccount should be a pointer."
 	// AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. // want "commentstart: godoc for field PodSpec.AutomountServiceAccountToken should start with 'automountServiceAccountToken ...'"
 	// +optional
 	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty" protobuf:"varint,21,opt,name=automountServiceAccountToken"`
@@ -102,7 +102,7 @@ type PodSpec struct {
 	// This field should not be used to express a desire for the pod to be scheduled on a specific node.
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
 	// +optional
-	NodeName string `json:"nodeName,omitempty" protobuf:"bytes,10,opt,name=nodeName"` // want "optionalfields: field NodeName should be a pointer."
+	NodeName string `json:"nodeName,omitempty" protobuf:"bytes,10,opt,name=nodeName"` // want "optionalfields: field PodSpec.NodeName should be a pointer."
 	// Host networking requested for this pod. Use the host's network namespace. // want "commentstart: godoc for field PodSpec.HostNetwork should start with 'hostNetwork ...'"
 	// When using HostNetwork you should specify ports so the scheduler is aware.
 	// When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
@@ -110,17 +110,17 @@ type PodSpec struct {
 	// Default to false.
 	// +k8s:conversion-gen=false
 	// +optional
-	HostNetwork bool `json:"hostNetwork,omitempty" protobuf:"varint,11,opt,name=hostNetwork"` // want "optionalfields: field HostNetwork should be a pointer."
+	HostNetwork bool `json:"hostNetwork,omitempty" protobuf:"varint,11,opt,name=hostNetwork"` // want "optionalfields: field PodSpec.HostNetwork should be a pointer."
 	// Use the host's pid namespace. // want "commentstart: godoc for field PodSpec.HostPID should start with 'hostPID ...'"
 	// Optional: Default to false.
 	// +k8s:conversion-gen=false
 	// +optional
-	HostPID bool `json:"hostPID,omitempty" protobuf:"varint,12,opt,name=hostPID"` // want "optionalfields: field HostPID should be a pointer."
+	HostPID bool `json:"hostPID,omitempty" protobuf:"varint,12,opt,name=hostPID"` // want "optionalfields: field PodSpec.HostPID should be a pointer."
 	// Use the host's ipc namespace. // want "commentstart: godoc for field PodSpec.HostIPC should start with 'hostIPC ...'"
 	// Optional: Default to false.
 	// +k8s:conversion-gen=false
 	// +optional
-	HostIPC bool `json:"hostIPC,omitempty" protobuf:"varint,13,opt,name=hostIPC"` // want "optionalfields: field HostIPC should be a pointer."
+	HostIPC bool `json:"hostIPC,omitempty" protobuf:"varint,13,opt,name=hostIPC"` // want "optionalfields: field PodSpec.HostIPC should be a pointer."
 	// Share a single process namespace between all of the containers in a pod. // want "commentstart: godoc for field PodSpec.ShareProcessNamespace should start with 'shareProcessNamespace ...'"
 	// When this is set containers will be able to view and signal processes from other containers
 	// in the same pod, and the first process in each container will not be assigned PID 1.
@@ -145,18 +145,18 @@ type PodSpec struct {
 	// Specifies the hostname of the Pod // want "commentstart: godoc for field PodSpec.Hostname should start with 'hostname ...'"
 	// If not specified, the pod's hostname will be set to a system-defined value.
 	// +optional
-	Hostname string `json:"hostname,omitempty" protobuf:"bytes,16,opt,name=hostname"` // want "optionalfields: field Hostname should be a pointer."
+	Hostname string `json:"hostname,omitempty" protobuf:"bytes,16,opt,name=hostname"` // want "optionalfields: field PodSpec.Hostname should be a pointer."
 	// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". // want "commentstart: godoc for field PodSpec.Subdomain should start with 'subdomain ...'"
 	// If not specified, the pod will not have a domainname at all.
 	// +optional
-	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,17,opt,name=subdomain"` // want "optionalfields: field Subdomain should be a pointer."
+	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,17,opt,name=subdomain"` // want "optionalfields: field PodSpec.Subdomain should be a pointer."
 	// If specified, the pod's scheduling constraints // want "commentstart: godoc for field PodSpec.Affinity should start with 'affinity ...'"
 	// +optional
 	Affinity *Affinity `json:"affinity,omitempty" protobuf:"bytes,18,opt,name=affinity"`
 	// If specified, the pod will be dispatched by specified scheduler. // want "commentstart: godoc for field PodSpec.SchedulerName should start with 'schedulerName ...'"
 	// If not specified, the pod will be dispatched by default scheduler.
 	// +optional
-	SchedulerName string `json:"schedulerName,omitempty" protobuf:"bytes,19,opt,name=schedulerName"` // want "optionalfields: field SchedulerName should be a pointer."
+	SchedulerName string `json:"schedulerName,omitempty" protobuf:"bytes,19,opt,name=schedulerName"` // want "optionalfields: field PodSpec.SchedulerName should be a pointer."
 	// If specified, the pod's tolerations. // want "commentstart: godoc for field PodSpec.Tolerations should start with 'tolerations ...'"
 	// +optional
 	// +listType=atomic
@@ -176,7 +176,7 @@ type PodSpec struct {
 	// If not specified, the pod priority will be default or zero if there is no
 	// default.
 	// +optional
-	PriorityClassName string `json:"priorityClassName,omitempty" protobuf:"bytes,24,opt,name=priorityClassName"` // want "optionalfields: field PriorityClassName should be a pointer."
+	PriorityClassName string `json:"priorityClassName,omitempty" protobuf:"bytes,24,opt,name=priorityClassName"` // want "optionalfields: field PodSpec.PriorityClassName should be a pointer."
 	// The priority value. Various system components use this field to find the // want "commentstart: godoc for field PodSpec.Priority should start with 'priority ...'"
 	// priority of the pod. When Priority Admission Controller is enabled, it
 	// prevents users from setting this field. The admission controller populates

--- a/tests/integration/testdata/default_configurations/volume.go
+++ b/tests/integration/testdata/default_configurations/volume.go
@@ -7,7 +7,7 @@ type VolumeMount struct {
 	// Mounted read-only if true, read-write otherwise (false or unspecified). // want "commentstart: godoc for field VolumeMount.ReadOnly should start with 'readOnly ...'"
 	// Defaults to false.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"` // want "optionalfields: field VolumeMount.ReadOnly should be a pointer."
 	// RecursiveReadOnly specifies whether read-only mounts should be handled // want "commentstart: godoc for field VolumeMount.RecursiveReadOnly should start with 'recursiveReadOnly ...'"
 	// recursively.
 	//
@@ -32,7 +32,7 @@ type VolumeMount struct {
 	// Path within the volume from which the container's volume should be mounted. // want "commentstart: godoc for field VolumeMount.SubPath should start with 'subPath ...'"
 	// Defaults to "" (volume's root).
 	// +optional
-	SubPath string `json:"subPath,omitempty" protobuf:"bytes,4,opt,name=subPath"` // want "optionalfields: field SubPath should be a pointer."
+	SubPath string `json:"subPath,omitempty" protobuf:"bytes,4,opt,name=subPath"` // want "optionalfields: field VolumeMount.SubPath should be a pointer."
 	// mountPropagation determines how mounts are propagated from the host
 	// to container and the other way around.
 	// When not set, MountPropagationNone is used.
@@ -46,7 +46,7 @@ type VolumeMount struct {
 	// Defaults to "" (volume's root).
 	// SubPathExpr and SubPath are mutually exclusive.
 	// +optional
-	SubPathExpr string `json:"subPathExpr,omitempty" protobuf:"bytes,6,opt,name=subPathExpr"` // want "optionalfields: field SubPathExpr should be a pointer."
+	SubPathExpr string `json:"subPathExpr,omitempty" protobuf:"bytes,6,opt,name=subPathExpr"` // want "optionalfields: field VolumeMount.SubPathExpr should be a pointer."
 }
 
 // MountPropagationMode describes mount propagation.
@@ -291,7 +291,7 @@ type ProjectedVolumeSource struct {
 	// handles one source.
 	// +optional
 	// +listType=atomic
-	Sources []VolumeProjection `json:"sources" protobuf:"bytes,1,rep,name=sources"` // want "optionalfields: field Sources should have the omitempty tag." "arrayofstruct: ProjectedVolumeSource.Sources is an array of structs, but the struct has no required fields. At least one field should be marked as required to prevent ambiguous YAML configurations"
+	Sources []VolumeProjection `json:"sources" protobuf:"bytes,1,rep,name=sources"` // want "optionalfields: field ProjectedVolumeSource.Sources should have the omitempty tag." "arrayofstruct: ProjectedVolumeSource.Sources is an array of structs, but the struct has no required fields. At least one field should be marked as required to prevent ambiguous YAML configurations"
 	// defaultMode are the mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
@@ -311,7 +311,7 @@ type ImageVolumeSource struct {
 	// This field is optional to allow higher level config management to default or override
 	// container images in workload controllers like Deployments and StatefulSets.
 	// +optional
-	Reference string `json:"reference,omitempty" protobuf:"bytes,1,opt,name=reference"` // want "optionalfields: field Reference should be a pointer." "noreferences: naming convention \"reference-to-ref\": field ImageVolumeSource.Reference: field names should use 'Ref' instead of 'Reference'"
+	Reference string `json:"reference,omitempty" protobuf:"bytes,1,opt,name=reference"` // want "optionalfields: field ImageVolumeSource.Reference should be a pointer." "noreferences: naming convention \"reference-to-ref\": field ImageVolumeSource.Reference: field names should use 'Ref' instead of 'Reference'"
 
 	// Policy for pulling OCI objects. Possible values are: // want "commentstart: godoc for field ImageVolumeSource.PullPolicy should start with 'pullPolicy ...'"
 	// Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
@@ -319,7 +319,7 @@ type ImageVolumeSource struct {
 	// IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
 	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
 	// +optional
-	PullPolicy PullPolicy `json:"pullPolicy,omitempty" protobuf:"bytes,2,opt,name=pullPolicy,casttype=PullPolicy"` // want "optionalfields: field PullPolicy should be a pointer."
+	PullPolicy PullPolicy `json:"pullPolicy,omitempty" protobuf:"bytes,2,opt,name=pullPolicy,casttype=PullPolicy"` // want "optionalfields: field ImageVolumeSource.PullPolicy should be a pointer."
 }
 
 // PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.
@@ -333,7 +333,7 @@ type PersistentVolumeClaimVolumeSource struct {
 	// readOnly Will force the ReadOnly setting in VolumeMounts.
 	// Default false.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"` // want "optionalfields: field PersistentVolumeClaimVolumeSource.ReadOnly should be a pointer."
 }
 
 // PersistentVolumeSource is similar to VolumeSource but meant for the
@@ -492,7 +492,7 @@ type EmptyDirVolumeSource struct {
 	// Must be an empty string (default) or Memory.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
 	// +optional
-	Medium StorageMedium `json:"medium,omitempty" protobuf:"bytes,1,opt,name=medium,casttype=StorageMedium"` // want "optionalfields: field Medium should be a pointer."
+	Medium StorageMedium `json:"medium,omitempty" protobuf:"bytes,1,opt,name=medium,casttype=StorageMedium"` // want "optionalfields: field EmptyDirVolumeSource.Medium should be a pointer."
 	// sizeLimit is the total amount of local storage required for this EmptyDir volume.
 	// The size limit is also applicable for memory medium.
 	// The maximum usage on memory medium EmptyDir would be the minimum value between
@@ -517,7 +517,7 @@ type GlusterfsVolumeSource struct {
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field GlusterfsVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a Glusterfs mount that lasts the lifetime of a pod.
@@ -535,7 +535,7 @@ type GlusterfsPersistentVolumeSource struct {
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field GlusterfsPersistentVolumeSource.ReadOnly should be a pointer."
 
 	// endpointsNamespace is the namespace that contains Glusterfs endpoint.
 	// If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC.
@@ -560,25 +560,25 @@ type RBDVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field RBDVolumeSource.FSType should be a pointer."
 	// pool is the rados pool name.
 	// Default is rbd.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="rbd"
-	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"` // want "optionalfields: field RBDPool should be a pointer."
+	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"` // want "optionalfields: field RBDVolumeSource.RBDPool should be a pointer."
 	// user is the rados user name.
 	// Default is admin.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="admin"
-	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"` // want "optionalfields: field RadosUser should be a pointer."
+	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"` // want "optionalfields: field RBDVolumeSource.RadosUser should be a pointer."
 	// keyring is the path to key ring for RBDUser.
 	// Default is /etc/ceph/keyring.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="/etc/ceph/keyring"
-	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"` // want "optionalfields: field Keyring should be a pointer."
+	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"` // want "optionalfields: field RBDVolumeSource.Keyring should be a pointer."
 	// secretRef is name of the authentication secret for RBDUser. If provided
 	// overrides keyring.
 	// Default is nil.
@@ -589,7 +589,7 @@ type RBDVolumeSource struct {
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,8,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,8,opt,name=readOnly"` // want "optionalfields: field RBDVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a Rados Block Device mount that lasts the lifetime of a pod.
@@ -608,25 +608,25 @@ type RBDPersistentVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field RBDPersistentVolumeSource.FSType should be a pointer."
 	// pool is the rados pool name.
 	// Default is rbd.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="rbd"
-	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"` // want "optionalfields: field RBDPool should be a pointer."
+	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"` // want "optionalfields: field RBDPersistentVolumeSource.RBDPool should be a pointer."
 	// user is the rados user name.
 	// Default is admin.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="admin"
-	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"` // want "optionalfields: field RadosUser should be a pointer."
+	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"` // want "optionalfields: field RBDPersistentVolumeSource.RadosUser should be a pointer."
 	// keyring is the path to key ring for RBDUser.
 	// Default is /etc/ceph/keyring.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	// +default="/etc/ceph/keyring"
-	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"` // want "optionalfields: field Keyring should be a pointer."
+	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"` // want "optionalfields: field RBDPersistentVolumeSource.Keyring should be a pointer."
 	// secretRef is name of the authentication secret for RBDUser. If provided
 	// overrides keyring.
 	// Default is nil.
@@ -637,7 +637,7 @@ type RBDPersistentVolumeSource struct {
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,8,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,8,opt,name=readOnly"` // want "optionalfields: field RBDPersistentVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a cinder volume resource in Openstack.
@@ -653,12 +653,12 @@ type CinderVolumeSource struct {
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field CinderVolumeSource.FSType should be a pointer."
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field CinderVolumeSource.ReadOnly should be a pointer."
 	// secretRef is optional: points to a secret object containing parameters used to connect
 	// to OpenStack.
 	// +optional
@@ -678,12 +678,12 @@ type CinderPersistentVolumeSource struct {
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field CinderPersistentVolumeSource.FSType should be a pointer."
 	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field CinderPersistentVolumeSource.ReadOnly should be a pointer."
 	// secretRef is Optional: points to a secret object containing parameters used to connect
 	// to OpenStack.
 	// +optional
@@ -699,15 +699,15 @@ type CephFSVolumeSource struct {
 	Monitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"` // want "optionalorrequired: field CephFSVolumeSource.Monitors must be marked as optional or required"
 	// path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
 	// +optional
-	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"` // want "optionalfields: field Path should be a pointer."
+	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"` // want "optionalfields: field CephFSVolumeSource.Path should be a pointer."
 	// user is optional: User is the rados user name, default is admin
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"` // want "optionalfields: field User should be a pointer."
+	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"` // want "optionalfields: field CephFSVolumeSource.User should be a pointer."
 	// secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"` // want "optionalfields: field SecretFile should be a pointer."
+	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"` // want "optionalfields: field CephFSVolumeSource.SecretFile should be a pointer."
 	// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
@@ -716,7 +716,7 @@ type CephFSVolumeSource struct {
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field CephFSVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a Ceph Filesystem mount that lasts the lifetime of a pod
@@ -728,15 +728,15 @@ type CephFSPersistentVolumeSource struct {
 	Monitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"` // want "optionalorrequired: field CephFSPersistentVolumeSource.Monitors must be marked as optional or required"
 	// path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
 	// +optional
-	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"` // want "optionalfields: field Path should be a pointer."
+	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"` // want "optionalfields: field CephFSPersistentVolumeSource.Path should be a pointer."
 	// user is Optional: User is the rados user name, default is admin
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"` // want "optionalfields: field User should be a pointer."
+	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"` // want "optionalfields: field CephFSPersistentVolumeSource.User should be a pointer."
 	// secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"` // want "optionalfields: field SecretFile should be a pointer."
+	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"` // want "optionalfields: field CephFSPersistentVolumeSource.SecretFile should be a pointer."
 	// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
@@ -745,7 +745,7 @@ type CephFSPersistentVolumeSource struct {
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field CephFSPersistentVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a Flocker volume mounted by the Flocker agent.
@@ -755,10 +755,10 @@ type FlockerVolumeSource struct {
 	// datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
 	// should be considered as deprecated
 	// +optional
-	DatasetName string `json:"datasetName,omitempty" protobuf:"bytes,1,opt,name=datasetName"` // want "optionalfields: field DatasetName should be a pointer."
+	DatasetName string `json:"datasetName,omitempty" protobuf:"bytes,1,opt,name=datasetName"` // want "optionalfields: field FlockerVolumeSource.DatasetName should be a pointer."
 	// datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
 	// +optional
-	DatasetUUID string `json:"datasetUUID,omitempty" protobuf:"bytes,2,opt,name=datasetUUID"` // want "optionalfields: field DatasetUUID should be a pointer."
+	DatasetUUID string `json:"datasetUUID,omitempty" protobuf:"bytes,2,opt,name=datasetUUID"` // want "optionalfields: field FlockerVolumeSource.DatasetUUID should be a pointer."
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.
@@ -787,19 +787,19 @@ type GCEPersistentDiskVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field GCEPersistentDiskVolumeSource.FSType should be a pointer."
 	// partition is the partition in the volume that you want to mount.
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// +optional
-	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"` // want "optionalfields: field Partition should be a pointer."
+	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"` // want "optionalfields: field GCEPersistentDiskVolumeSource.Partition should be a pointer."
 	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field GCEPersistentDiskVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a Quobyte mount that lasts the lifetime of a pod.
@@ -816,22 +816,22 @@ type QuobyteVolumeSource struct {
 	// readOnly here will force the Quobyte volume to be mounted with read-only permissions.
 	// Defaults to false.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field QuobyteVolumeSource.ReadOnly should be a pointer."
 
 	// user to map volume access to
 	// Defaults to serivceaccount user
 	// +optional
-	User string `json:"user,omitempty" protobuf:"bytes,4,opt,name=user"` // want "optionalfields: field User should be a pointer."
+	User string `json:"user,omitempty" protobuf:"bytes,4,opt,name=user"` // want "optionalfields: field QuobyteVolumeSource.User should be a pointer."
 
 	// group to map volume access to
 	// Default is no group
 	// +optional
-	Group string `json:"group,omitempty" protobuf:"bytes,5,opt,name=group"` // want "optionalfields: field Group should be a pointer."
+	Group string `json:"group,omitempty" protobuf:"bytes,5,opt,name=group"` // want "optionalfields: field QuobyteVolumeSource.Group should be a pointer."
 
 	// tenant owning the given Quobyte volume in the Backend
 	// Used with dynamically provisioned Quobyte volumes, value is set by the plugin
 	// +optional
-	Tenant string `json:"tenant,omitempty" protobuf:"bytes,6,opt,name=tenant"` // want "optionalfields: field Tenant should be a pointer."
+	Tenant string `json:"tenant,omitempty" protobuf:"bytes,6,opt,name=tenant"` // want "optionalfields: field QuobyteVolumeSource.Tenant should be a pointer."
 }
 
 // FlexPersistentVolumeSource represents a generic persistent volume resource that is
@@ -843,7 +843,7 @@ type FlexPersistentVolumeSource struct {
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FlexPersistentVolumeSource.FSType should be a pointer."
 	// secretRef is Optional: SecretRef is reference to the secret object containing
 	// sensitive information to pass to the plugin scripts. This may be
 	// empty if no secret object is specified. If the secret object
@@ -854,7 +854,7 @@ type FlexPersistentVolumeSource struct {
 	// readOnly is Optional: defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field FlexPersistentVolumeSource.ReadOnly should be a pointer."
 	// options is Optional: this field holds extra command options if any.
 	// +optional
 	Options map[string]string `json:"options,omitempty" protobuf:"bytes,5,rep,name=options"`
@@ -869,7 +869,7 @@ type FlexVolumeSource struct {
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FlexVolumeSource.FSType should be a pointer."
 	// secretRef is Optional: secretRef is reference to the secret object containing
 	// sensitive information to pass to the plugin scripts. This may be
 	// empty if no secret object is specified. If the secret object
@@ -880,7 +880,7 @@ type FlexVolumeSource struct {
 	// readOnly is Optional: defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field FlexVolumeSource.ReadOnly should be a pointer."
 	// options is Optional: this field holds extra command options if any.
 	// +optional
 	Options map[string]string `json:"options,omitempty" protobuf:"bytes,5,rep,name=options"`
@@ -902,17 +902,17 @@ type AWSElasticBlockStoreVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field AWSElasticBlockStoreVolumeSource.FSType should be a pointer."
 	// partition is the partition in the volume that you want to mount.
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
 	// +optional
-	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"` // want "optionalfields: field Partition should be a pointer."
+	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"` // want "optionalfields: field AWSElasticBlockStoreVolumeSource.Partition should be a pointer."
 	// readOnly value true will force the readOnly setting in VolumeMounts.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field AWSElasticBlockStoreVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a volume that is populated with the contents of a git repository.
@@ -927,13 +927,13 @@ type GitRepoVolumeSource struct {
 	Repository string `json:"repository" protobuf:"bytes,1,opt,name=repository"` // want "optionalorrequired: field GitRepoVolumeSource.Repository must be marked as optional or required"
 	// revision is the commit hash for the specified revision.
 	// +optional
-	Revision string `json:"revision,omitempty" protobuf:"bytes,2,opt,name=revision"` // want "optionalfields: field Revision should be a pointer."
+	Revision string `json:"revision,omitempty" protobuf:"bytes,2,opt,name=revision"` // want "optionalfields: field GitRepoVolumeSource.Revision should be a pointer."
 	// directory is the target directory name.
 	// Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
 	// git repository.  Otherwise, if specified, the volume will contain the git repository in
 	// the subdirectory with the given name.
 	// +optional
-	Directory string `json:"directory,omitempty" protobuf:"bytes,3,opt,name=directory"` // want "optionalfields: field Directory should be a pointer."
+	Directory string `json:"directory,omitempty" protobuf:"bytes,3,opt,name=directory"` // want "optionalfields: field GitRepoVolumeSource.Directory should be a pointer."
 }
 
 // Adapts a Secret into a volume.
@@ -945,7 +945,7 @@ type SecretVolumeSource struct {
 	// secretName is the name of the secret in the pod's namespace to use.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 	// +optional
-	SecretName string `json:"secretName,omitempty" protobuf:"bytes,1,opt,name=secretName"` // want "optionalfields: field SecretName should be a pointer."
+	SecretName string `json:"secretName,omitempty" protobuf:"bytes,1,opt,name=secretName"` // want "optionalfields: field SecretVolumeSource.SecretName should be a pointer."
 	// items If unspecified, each key-value pair in the Data field of the referenced
 	// Secret will be projected into the volume as a file whose name is the
 	// key and content is the value. If specified, the listed keys will be
@@ -1012,7 +1012,7 @@ type NFSVolumeSource struct {
 	// Defaults to false.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field NFSVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents an ISCSI disk.
@@ -1030,18 +1030,18 @@ type ISCSIVolumeSource struct {
 	// Defaults to 'default' (tcp).
 	// +optional
 	// +default="default"
-	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"` // want "optionalfields: field ISCSIInterface should be a pointer."
+	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"` // want "optionalfields: field ISCSIVolumeSource.ISCSIInterface should be a pointer."
 	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"` // want "optionalfields: field ISCSIVolumeSource.FSType should be a pointer."
 	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ISCSIVolumeSource.ReadOnly should be a pointer."
 	// portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	// +optional
@@ -1049,10 +1049,10 @@ type ISCSIVolumeSource struct {
 	Portals []string `json:"portals,omitempty" protobuf:"bytes,7,opt,name=portals"`
 	// chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
 	// +optional
-	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"` // want "optionalfields: field DiscoveryCHAPAuth should be a pointer."
+	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"` // want "optionalfields: field ISCSIVolumeSource.DiscoveryCHAPAuth should be a pointer."
 	// chapAuthSession defines whether support iSCSI Session CHAP authentication
 	// +optional
-	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"` // want "optionalfields: field SessionCHAPAuth should be a pointer."
+	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"` // want "optionalfields: field ISCSIVolumeSource.SessionCHAPAuth should be a pointer."
 	// secretRef is the CHAP Secret for iSCSI target and initiator authentication
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,10,opt,name=secretRef"`
@@ -1078,18 +1078,18 @@ type ISCSIPersistentVolumeSource struct {
 	// Defaults to 'default' (tcp).
 	// +optional
 	// +default="default"
-	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"` // want "optionalfields: field ISCSIInterface should be a pointer."
+	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"` // want "optionalfields: field ISCSIPersistentVolumeSource.ISCSIInterface should be a pointer."
 	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"` // want "optionalfields: field ISCSIPersistentVolumeSource.FSType should be a pointer."
 	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"` // want "optionalfields: field ISCSIPersistentVolumeSource.ReadOnly should be a pointer."
 	// portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	// +optional
@@ -1097,10 +1097,10 @@ type ISCSIPersistentVolumeSource struct {
 	Portals []string `json:"portals,omitempty" protobuf:"bytes,7,opt,name=portals"`
 	// chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
 	// +optional
-	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"` // want "optionalfields: field DiscoveryCHAPAuth should be a pointer."
+	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"` // want "optionalfields: field ISCSIPersistentVolumeSource.DiscoveryCHAPAuth should be a pointer."
 	// chapAuthSession defines whether support iSCSI Session CHAP authentication
 	// +optional
-	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"` // want "optionalfields: field SessionCHAPAuth should be a pointer."
+	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"` // want "optionalfields: field ISCSIPersistentVolumeSource.SessionCHAPAuth should be a pointer."
 	// secretRef is the CHAP Secret for iSCSI target and initiator authentication
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,10,opt,name=secretRef"`
@@ -1127,11 +1127,11 @@ type FCVolumeSource struct {
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FCVolumeSource.FSType should be a pointer."
 	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field FCVolumeSource.ReadOnly should be a pointer."
 	// wwids Optional: FC volume world wide identifiers (wwids)
 	// Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
 	// +optional
@@ -1148,7 +1148,7 @@ type AzureFileVolumeSource struct {
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field AzureFileVolumeSource.ReadOnly should be a pointer."
 }
 
 // AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
@@ -1160,11 +1160,11 @@ type AzureFilePersistentVolumeSource struct {
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field AzureFilePersistentVolumeSource.ReadOnly should be a pointer."
 	// secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key
 	// default is the same as the Pod
 	// +optional
-	SecretNamespace *string `json:"secretNamespace" protobuf:"bytes,4,opt,name=secretNamespace"` // want "optionalfields: field SecretNamespace should have the omitempty tag."
+	SecretNamespace *string `json:"secretNamespace" protobuf:"bytes,4,opt,name=secretNamespace"` // want "optionalfields: field AzureFilePersistentVolumeSource.SecretNamespace should have the omitempty tag."
 }
 
 // Represents a vSphere volume resource.
@@ -1175,13 +1175,13 @@ type VsphereVirtualDiskVolumeSource struct {
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"` // want "optionalfields: field VsphereVirtualDiskVolumeSource.FSType should be a pointer."
 	// storagePolicyName is the storage Policy Based Management (SPBM) profile name.
 	// +optional
-	StoragePolicyName string `json:"storagePolicyName,omitempty" protobuf:"bytes,3,opt,name=storagePolicyName"` // want "optionalfields: field StoragePolicyName should be a pointer."
+	StoragePolicyName string `json:"storagePolicyName,omitempty" protobuf:"bytes,3,opt,name=storagePolicyName"` // want "optionalfields: field VsphereVirtualDiskVolumeSource.StoragePolicyName should be a pointer."
 	// storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
 	// +optional
-	StoragePolicyID string `json:"storagePolicyID,omitempty" protobuf:"bytes,4,opt,name=storagePolicyID"` // want "optionalfields: field StoragePolicyID should be a pointer."
+	StoragePolicyID string `json:"storagePolicyID,omitempty" protobuf:"bytes,4,opt,name=storagePolicyID"` // want "optionalfields: field VsphereVirtualDiskVolumeSource.StoragePolicyID should be a pointer."
 }
 
 // Represents a Photon Controller persistent disk resource.
@@ -1247,7 +1247,7 @@ type PortworxVolumeSource struct {
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field PortworxVolumeSource.ReadOnly should be a pointer."
 }
 
 // ScaleIOVolumeSource represents a persistent ScaleIO volume
@@ -1261,18 +1261,18 @@ type ScaleIOVolumeSource struct {
 	SecretRef *LocalObjectReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"` // want "optionalorrequired: field ScaleIOVolumeSource.SecretRef must be marked as optional or required"
 	// sslEnabled Flag enable/disable SSL communication with Gateway, default false
 	// +optional
-	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"` // want "optionalfields: field SSLEnabled should be a pointer."
+	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"` // want "optionalfields: field ScaleIOVolumeSource.SSLEnabled should be a pointer."
 	// protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
 	// +optional
-	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"` // want "optionalfields: field ProtectionDomain should be a pointer."
+	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"` // want "optionalfields: field ScaleIOVolumeSource.ProtectionDomain should be a pointer."
 	// storagePool is the ScaleIO Storage Pool associated with the protection domain.
 	// +optional
-	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"` // want "optionalfields: field StoragePool should be a pointer."
+	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"` // want "optionalfields: field ScaleIOVolumeSource.StoragePool should be a pointer."
 	// storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
 	// Default is ThinProvisioned.
 	// +optional
 	// +default="ThinProvisioned"
-	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"` // want "optionalfields: field StorageMode should be a pointer."
+	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"` // want "optionalfields: field ScaleIOVolumeSource.StorageMode should be a pointer."
 	// volumeName is the name of a volume already created in the ScaleIO system
 	// that is associated with this volume source.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,8,opt,name=volumeName"` // want "optionalorrequired: field ScaleIOVolumeSource.VolumeName must be marked as optional or required"
@@ -1282,11 +1282,11 @@ type ScaleIOVolumeSource struct {
 	// Default is "xfs".
 	// +optional
 	// +default="xfs"
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"` // want "optionalfields: field ScaleIOVolumeSource.FSType should be a pointer."
 	// readOnly Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"` // want "optionalfields: field ScaleIOVolumeSource.ReadOnly should be a pointer."
 }
 
 // ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
@@ -1300,18 +1300,18 @@ type ScaleIOPersistentVolumeSource struct {
 	SecretRef *SecretReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"` // want "optionalorrequired: field ScaleIOPersistentVolumeSource.SecretRef must be marked as optional or required"
 	// sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
 	// +optional
-	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"` // want "optionalfields: field SSLEnabled should be a pointer."
+	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"` // want "optionalfields: field ScaleIOPersistentVolumeSource.SSLEnabled should be a pointer."
 	// protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
 	// +optional
-	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"` // want "optionalfields: field ProtectionDomain should be a pointer."
+	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"` // want "optionalfields: field ScaleIOPersistentVolumeSource.ProtectionDomain should be a pointer."
 	// storagePool is the ScaleIO Storage Pool associated with the protection domain.
 	// +optional
-	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"` // want "optionalfields: field StoragePool should be a pointer."
+	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"` // want "optionalfields: field ScaleIOPersistentVolumeSource.StoragePool should be a pointer."
 	// storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
 	// Default is ThinProvisioned.
 	// +optional
 	// +default="ThinProvisioned"
-	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"` // want "optionalfields: field StorageMode should be a pointer."
+	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"` // want "optionalfields: field ScaleIOPersistentVolumeSource.StorageMode should be a pointer."
 	// volumeName is the name of a volume already created in the ScaleIO system
 	// that is associated with this volume source.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,8,opt,name=volumeName"` // want "optionalorrequired: field ScaleIOPersistentVolumeSource.VolumeName must be marked as optional or required"
@@ -1321,11 +1321,11 @@ type ScaleIOPersistentVolumeSource struct {
 	// Default is "xfs"
 	// +optional
 	// +default="xfs"
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"` // want "optionalfields: field ScaleIOPersistentVolumeSource.FSType should be a pointer."
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"` // want "optionalfields: field ScaleIOPersistentVolumeSource.ReadOnly should be a pointer."
 }
 
 // Represents a StorageOS persistent volume resource.
@@ -1340,16 +1340,16 @@ type StorageOSVolumeSource struct {
 	// Set to "default" if you are not using namespaces within StorageOS.
 	// Namespaces that do not pre-exist within StorageOS will be created.
 	// +optional
-	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"` // want "optionalfields: field VolumeNamespace should be a pointer."
+	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"` // want "optionalfields: field StorageOSVolumeSource.VolumeNamespace should be a pointer."
 	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field StorageOSVolumeSource.FSType should be a pointer."
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field StorageOSVolumeSource.ReadOnly should be a pointer."
 	// secretRef specifies the secret to use for obtaining the StorageOS API
 	// credentials.  If not specified, default values will be attempted.
 	// +optional
@@ -1368,16 +1368,16 @@ type StorageOSPersistentVolumeSource struct {
 	// Set to "default" if you are not using namespaces within StorageOS.
 	// Namespaces that do not pre-exist within StorageOS will be created.
 	// +optional
-	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"` // want "optionalfields: field VolumeNamespace should be a pointer."
+	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"` // want "optionalfields: field StorageOSPersistentVolumeSource.VolumeNamespace should be a pointer."
 	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"` // want "optionalfields: field StorageOSPersistentVolumeSource.FSType should be a pointer."
 	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"` // want "optionalfields: field StorageOSPersistentVolumeSource.ReadOnly should be a pointer."
 	// secretRef specifies the secret to use for obtaining the StorageOS API
 	// credentials.  If not specified, default values will be attempted.
 	// +optional
@@ -1671,7 +1671,7 @@ type ServiceAccountTokenProjection struct {
 	// token, and otherwise should reject the token. The audience defaults to the
 	// identifier of the apiserver.
 	// +optional
-	Audience string `json:"audience,omitempty" protobuf:"bytes,1,rep,name=audience"` // want "optionalfields: field Audience should be a pointer."
+	Audience string `json:"audience,omitempty" protobuf:"bytes,1,rep,name=audience"` // want "optionalfields: field ServiceAccountTokenProjection.Audience should be a pointer."
 	// expirationSeconds is the requested duration of validity of the service
 	// account token. As the token approaches expiration, the kubelet volume
 	// plugin will proactively rotate the service account token. The kubelet will
@@ -1725,7 +1725,7 @@ type PodCertificateProjection struct {
 	// Kubelet's generated CSRs will be addressed to this signer. // want "commentstart: godoc for field PodCertificateProjection.SignerName should start with 'signerName ...'"
 	//
 	// +required
-	SignerName string `json:"signerName,omitempty" protobuf:"bytes,1,rep,name=signerName"` // want "requiredfields: field SignerName has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	SignerName string `json:"signerName,omitempty" protobuf:"bytes,1,rep,name=signerName"` // want "requiredfields: field PodCertificateProjection.SignerName has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// The type of keypair Kubelet will generate for the pod. // want "commentstart: godoc for field PodCertificateProjection.KeyType should start with 'keyType ...'"
 	//
@@ -1733,7 +1733,7 @@ type PodCertificateProjection struct {
 	// "ECDSAP521", and "ED25519".
 	//
 	// +required
-	KeyType string `json:"keyType,omitempty" protobuf:"bytes,2,rep,name=keyType"` // want "requiredfields: field KeyType has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+	KeyType string `json:"keyType,omitempty" protobuf:"bytes,2,rep,name=keyType"` // want "requiredfields: field PodCertificateProjection.KeyType has a valid zero value \\(\\\"\\\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
 	// maxExpirationSeconds is the maximum lifetime permitted for the
 	// certificate.
@@ -1769,7 +1769,7 @@ type PodCertificateProjection struct {
 	// additionally check that the leaf certificate was issued to the key.
 	//
 	// +optional
-	CredentialBundlePath string `json:"credentialBundlePath,omitempty" protobuf:"bytes,4,rep,name=credentialBundlePath"` // want "optionalfields: field CredentialBundlePath should be a pointer."
+	CredentialBundlePath string `json:"credentialBundlePath,omitempty" protobuf:"bytes,4,rep,name=credentialBundlePath"` // want "optionalfields: field PodCertificateProjection.CredentialBundlePath should be a pointer."
 
 	// Write the key at this path in the projected volume. // want "commentstart: godoc for field PodCertificateProjection.KeyPath should start with 'keyPath ...'"
 	//
@@ -1779,7 +1779,7 @@ type PodCertificateProjection struct {
 	// files mid-rotation.
 	//
 	// +optional
-	KeyPath string `json:"keyPath,omitempty" protobuf:"bytes,5,rep,name=keyPath"` // want "optionalfields: field KeyPath should be a pointer."
+	KeyPath string `json:"keyPath,omitempty" protobuf:"bytes,5,rep,name=keyPath"` // want "optionalfields: field PodCertificateProjection.KeyPath should be a pointer."
 
 	// Write the certificate chain at this path in the projected volume. // want "commentstart: godoc for field PodCertificateProjection.CertificateChainPath should start with 'certificateChainPath ...'"
 	//
@@ -1789,7 +1789,7 @@ type PodCertificateProjection struct {
 	// files mid-rotation.
 	//
 	// +optional
-	CertificateChainPath string `json:"certificateChainPath,omitempty" protobuf:"bytes,6,rep,name=certificateChainPath"` // want "optionalfields: field CertificateChainPath should be a pointer."
+	CertificateChainPath string `json:"certificateChainPath,omitempty" protobuf:"bytes,6,rep,name=certificateChainPath"` // want "optionalfields: field PodCertificateProjection.CertificateChainPath should be a pointer."
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
@@ -1810,10 +1810,10 @@ type PersistentVolumeClaimSpec struct {
 	// status field of the claim.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
 	// +optional
-	Resources VolumeResourceRequirements `json:"resources,omitempty" protobuf:"bytes,2,opt,name=resources"` // want "optionalfields: field Resources should be a pointer."
+	Resources VolumeResourceRequirements `json:"resources,omitempty" protobuf:"bytes,2,opt,name=resources"` // want "optionalfields: field PersistentVolumeClaimSpec.Resources should be a pointer."
 	// volumeName is the binding reference to the PersistentVolume backing this claim.
 	// +optional
-	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,3,opt,name=volumeName"` // want "optionalfields: field VolumeName should be a pointer."
+	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,3,opt,name=volumeName"` // want "optionalfields: field PersistentVolumeClaimSpec.VolumeName should be a pointer."
 	// storageClassName is the name of the StorageClass required by the claim.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
 	// +optional
@@ -1948,12 +1948,12 @@ type CSIPersistentVolumeSource struct {
 	// readOnly value to pass to ControllerPublishVolumeRequest.
 	// Defaults to false (read/write).
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field ReadOnly should be a pointer."
+	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"` // want "optionalfields: field CSIPersistentVolumeSource.ReadOnly should be a pointer."
 
 	// fsType to mount. Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs".
 	// +optional
-	FSType string `json:"fsType,omitempty" protobuf:"bytes,4,opt,name=fsType"` // want "optionalfields: field FSType should be a pointer."
+	FSType string `json:"fsType,omitempty" protobuf:"bytes,4,opt,name=fsType"` // want "optionalfields: field CSIPersistentVolumeSource.FSType should be a pointer."
 
 	// volumeAttributes of the volume to publish.
 	// +optional


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kube-api-linter/issues/158
Previous work for other linters: https://github.com/kubernetes-sigs/kube-api-linter/pull/174