### PR TITLE
Add note to nonpointerstructs that it is not necessary for CRD types

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -523,6 +523,10 @@ Non-pointer structs that contain no required fields are marked as optional.
 This linter is important for types validated in Go as there is no way to validate the optionality of the fields at runtime,
 aside from checking the fields within them.
 
+This linter is NOT intended to be used to check for CRD types.
+The advice of this linter may be applied to CRD types, but it is not necessary for CRD types due to optionality being validated by openapi and no native Go code.
+For CRD types, the optionalfields and requiredfields linters should be used instead.
+
 If a struct is marked required, this can only be validated by having a required field within it.
 If there are no required fields, the struct is implicitly optional and must be marked as so.
 

--- a/pkg/analysis/nonpointerstructs/doc.go
+++ b/pkg/analysis/nonpointerstructs/doc.go
@@ -21,6 +21,10 @@ Non-pointer structs that contain no required fields are marked as optional.
 This linter is important for types validated in Go as there is no way to validate the optionality of the fields at runtime,
 aside from checking the fields within them.
 
+This linter is NOT intended to be used to check for CRD types.
+The advice of this linter may be applied to CRD types, but it is not necessary for CRD types due to optionality being validated by openapi and no native Go code.
+For CRD types, the optionalfields and requiredfields linters should be used instead.
+
 If a struct is marked required, this can only be validated by having a required field within it.
 If there are no required fields, the struct is implicitly optional and must be marked as so.
 


### PR DESCRIPTION
See #197 

The advice of nonpointerstructs is important for native types that are validated in Go, but can be ignored if you prefer for CRD types.

This is an attempt to try to make that clearer in the docs.

CC @pmalek 