### PR TITLE
WIP: Fix requiredfields linter to respect OmitEmpty Ignore policy

### DIFF
--- a/pkg/analysis/requiredfields/analyzer_test.go
+++ b/pkg/analysis/requiredfields/analyzer_test.go
@@ -32,3 +32,18 @@ func TestDefaultConfiguration(t *testing.T) {
 
 	analysistest.RunWithSuggestedFixes(t, testdata, a, "a")
 }
+
+func TestOmitEmptyIgnorePolicy(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := requiredfields.Initializer().Init(&requiredfields.RequiredFieldsConfig{
+		OmitEmpty: requiredfields.RequiredFieldsOmitEmpty{
+			Policy: requiredfields.RequiredFieldsOmitEmptyPolicyIgnore,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "omitempty_ignore")
+}

--- a/pkg/analysis/requiredfields/testdata/src/omitempty_ignore/test.go
+++ b/pkg/analysis/requiredfields/testdata/src/omitempty_ignore/test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package omitempty_ignore
+
+// TestOmitEmptyIgnore tests that when omitempty policy is set to Ignore,
+// fields that don't allow the zero value still report diagnostics because
+// this is a correctness issue (the field must have omitempty to work correctly).
+type TestOmitEmptyIgnore struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// This field does not allow the zero value (empty string) and does not have omitempty.
+	// Even with Ignore policy, this must be reported as it's a correctness issue.
+	RequiredFieldWithoutOmitEmpty string `json:"requiredField"` // want "field TestOmitEmptyIgnore.RequiredFieldWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// This field has omitempty, so it should work normally.
+	RequiredFieldWithOmitEmpty string `json:"requiredFieldWithOmitEmpty,omitempty"`
+}

--- a/pkg/analysis/requiredfields/testdata/src/omitempty_ignore/test.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/omitempty_ignore/test.go.golden
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package omitempty_ignore
+
+// TestOmitEmptyIgnore tests that when omitempty policy is set to Ignore,
+// fields that don't allow the zero value still report diagnostics because
+// this is a correctness issue (the field must have omitempty to work correctly).
+type TestOmitEmptyIgnore struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// This field does not allow the zero value (empty string) and does not have omitempty.
+	// Even with Ignore policy, this must be reported as it's a correctness issue.
+	RequiredFieldWithoutOmitEmpty string `json:"requiredField,omitempty"` // want "field TestOmitEmptyIgnore.RequiredFieldWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
+
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// This field has omitempty, so it should work normally.
+	RequiredFieldWithOmitEmpty string `json:"requiredFieldWithOmitEmpty,omitempty"`
+}


### PR DESCRIPTION
When the requiredfields linter is configured with omitempty policy set to 'Ignore', violations for missing omitempty tags were still reported because checkFieldPropertiesWithoutOmitEmpty was ignoring the configured policy.

The fix ensures that when omitEmptyPolicy is Ignore, all checks for fields without omitempty are skipped, respecting the user's configuration choice.

Fixes https://github.com/kubernetes-sigs/kube-api-linter/issues/195