### PR TITLE
Automate linter registration to prevent unknown linter errors

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Verify registration
+        run: make verify-validate-linter-registration
       - name: Build
         run: make build
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ unit: ## Run unit tests.
 build: ## Build the golangci-lint custom plugin binary.
 	go build -o ./bin ./cmd/golangci-lint-kube-api-linter 
 
+.PHONY: validate-linter-registration
+validate-linter-registration: ## Validate registration linters.
+	hack/validate-linter-registration.sh
+
 .PHONY: verify-%
 verify-%:
 	make $*

--- a/hack/validate-linter-registration.sh
+++ b/hack/validate-linter-registration.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+linters=$(go list -json ./pkg/analysis/... | jq -rs '.[] | select((.GoFiles | index("initializer.go")) and (.GoFiles | index("analyzer.go"))) | .ImportPath')
+registered=$(go list -json ./pkg/registration | jq -r '.Imports | .[]')
+
+if [[ "${linters[*]}" != "${registered[*]}" ]]; then
+    echo "Linter registration mismatch detected:"
+    echo "  - Lines starting with '-' exist in pkg/registration but not in pkg/analysis"
+    echo "  - Lines starting with '+' exist in pkg/analysis but not in pkg/registration"
+    echo ""
+    diff -Naup --label "pkg/registration/doc.go" --label "pkg/analysis/**/analyzer.go" <(echo "${registered}") <(echo "${linters}")
+fi
+

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 /*
 This package is used as an internal registration of linters.
 
@@ -34,6 +35,8 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/integers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/jsontags"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/maxlength"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/minlength"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/namingconventions"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nobools"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nodurations"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nofloats"


### PR DESCRIPTION
Add a script to automatically generate pkg/registration/doc.go from linter packages under pkg/analysis/. This prevents the common issue where adding a new linter but forgetting to register it causes "unknown linter" errors.

I noticed that `namingconvention` linter was also missed.

Close #203 