### PR TITLE
Turn statusoptional off by default

### DIFF
--- a/pkg/analysis/statusoptional/initializer.go
+++ b/pkg/analysis/statusoptional/initializer.go
@@ -35,7 +35,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewConfigurableInitializer(
 		name,
 		initAnalyzer,
-		true,
+		false,
 		validateConfig,
 	)
 }


### PR DESCRIPTION
Having discussed this with upstream API reviewers, the tendency to set fields as optional in the status just came from the tooling we had. Newer APIs where we use status subresources do not need to have optional status fields, and in fact, it would be preferable to validate that status writers are writing the expected information.

This should be off by default, tbh, I think it should be deprecated, but I'll leave it in in case folks want to enforce this old convention.