### PR TITLE
Fix unnecessary omitempty with omitzero

### DIFF
--- a/pkg/analysis/requiredfields/analyzer_test.go
+++ b/pkg/analysis/requiredfields/analyzer_test.go
@@ -32,3 +32,21 @@ func TestDefaultConfiguration(t *testing.T) {
 
 	analysistest.RunWithSuggestedFixes(t, testdata, a, "a")
 }
+
+func TestWithOmitEmptyPolicyIgnore(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := requiredfields.Initializer().Init(&requiredfields.RequiredFieldsConfig{
+		OmitEmpty: requiredfields.RequiredFieldsOmitEmpty{
+			Policy: requiredfields.RequiredFieldsOmitEmptyPolicyIgnore,
+		},
+		OmitZero: requiredfields.RequiredFieldsOmitZero{
+			Policy: requiredfields.RequiredFieldsOmitZeroPolicySuggestFix,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "b")
+}

--- a/pkg/analysis/requiredfields/testdata/src/b/a.go
+++ b/pkg/analysis/requiredfields/testdata/src/b/a.go
@@ -1,39 +1,16 @@
-package a
+package c
 
-type A struct {
-	// optional field should not be picked up.
-	// +optional
-	OptionalField *string `json:"optionalField,omitempty"`
-
-	// requiredCorrectField should not be picked up.
+type Foo struct {
 	// +required
-	RequiredCorrectField string `json:"requiredCorrectField"`
+	RequiredStructWithRequiredFieldWithoutOmitZero StructWithRequiredField `json:"requiredStructWithRequiredFieldWithoutOmitZero"` // want "field Foo.RequiredStructWithRequiredFieldWithoutOmitZero does not allow the zero value. It must have the omitzero tag."
 
-	// requiredOmitEmptyField field should be picked up.
 	// +required
-	RequiredOmitEmptyField string `json:"requiredOmitEmptyField,omitempty"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+	RequiredStructWithRequiredFieldWithOmitZero StructWithRequiredField `json:"requiredStructWithRequiredFieldWithOmitZero,omitzero"`
+}
 
-	// requiredPointerField should be picked up.
+type StructWithRequiredField struct {
+	// Does not allow the zero value.
 	// +required
-	RequiredPointerField *string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
-
-	// requiredPointerOmitEmptyField should be picked up.
-	// +required
-	RequiredPointerOmitEmptyField *string `json:"requiredPointerOmitEmptyField,omitempty"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
-
-	// requiredKubebuilderMarkerField should not be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
-
-	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
-
-	// requiredKubebuilderMarkerPointerField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerPointerField *string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
-
-	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerPointerOmitEmptyField *string `json:"requiredKubebuilderMarkerPointerOmitEmptyField,omitempty"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+	// +kubebuilder:validation:Enum=A;B;C
+	EnumStringWithoutOmitEmpty string `json:"enumStringWithoutOmitEmpty"` // want "field StructWithRequiredField.EnumStringWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 }

--- a/pkg/analysis/requiredfields/testdata/src/b/a.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/b/a.go.golden
@@ -1,39 +1,16 @@
-package a
+package c
 
-type A struct {
-	// optional field should not be picked up.
-	// +optional
-	OptionalField *string `json:"optionalField,omitempty"`
-
-	// requiredCorrectField should not be picked up.
+type Foo struct {
 	// +required
-	RequiredCorrectField string `json:"requiredCorrectField"`
+	RequiredStructWithRequiredFieldWithoutOmitZero StructWithRequiredField `json:"requiredStructWithRequiredFieldWithoutOmitZero,omitzero"` // want "field Foo.RequiredStructWithRequiredFieldWithoutOmitZero does not allow the zero value. It must have the omitzero tag."
 
-	// requiredOmitEmptyField field should be picked up.
 	// +required
-	RequiredOmitEmptyField string `json:"requiredOmitEmptyField"` // want "field RequiredOmitEmptyField is marked as required, but has the omitempty tag"
+	RequiredStructWithRequiredFieldWithOmitZero StructWithRequiredField `json:"requiredStructWithRequiredFieldWithOmitZero,omitzero"`
+}
 
-	// requiredPointerField should be picked up.
+type StructWithRequiredField struct {
+	// Does not allow the zero value.
 	// +required
-	RequiredPointerField *string `json:"requiredPointerField"` // want "field RequiredPointerField is marked as required, should not be a pointer"
-
-	// requiredPointerOmitEmptyField should be picked up.
-	// +required
-	RequiredPointerOmitEmptyField *string `json:"requiredPointerOmitEmptyField"` // want "field RequiredPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredPointerOmitEmptyField is marked as required, should not be a pointer"
-
-	// requiredKubebuilderMarkerField should not be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerField string `json:"requiredKubebuilderMarkerField"`
-
-	// requiredKubebuilderMarkerOmitEmptyField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerOmitEmptyField string `json:"requiredKubebuilderMarkerOmitEmptyField"` // want "field RequiredKubebuilderMarkerOmitEmptyField is marked as required, but has the omitempty tag"
-
-	// requiredKubebuilderMarkerPointerField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerPointerField *string `json:"requiredKubebuilderMarkerPointerField"` // want "field RequiredKubebuilderMarkerPointerField is marked as required, should not be a pointer"
-
-	// requiredKubebuilderMarkerPointerOmitEmptyField should be picked up.
-	// +kubebuilder:validation:Required
-	RequiredKubebuilderMarkerPointerOmitEmptyField *string `json:"requiredKubebuilderMarkerPointerOmitEmptyField"` // want "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, but has the omitempty tag" "field RequiredKubebuilderMarkerPointerOmitEmptyField is marked as required, should not be a pointer"
+	// +kubebuilder:validation:Enum=A;B;C
+	EnumStringWithoutOmitEmpty string `json:"enumStringWithoutOmitEmpty,omitempty"` // want "field StructWithRequiredField.EnumStringWithoutOmitEmpty does not allow the zero value. It must have the omitempty tag."
 }

--- a/pkg/analysis/utils/serialization/serialization_check.go
+++ b/pkg/analysis/utils/serialization/serialization_check.go
@@ -181,10 +181,14 @@ func (s *serializationCheck) checkFieldPropertiesWithoutOmitEmpty(pass *analysis
 		// The field is not omitempty, and the zero value is valid, the field does not need to be a pointer.
 		s.handleFieldShouldNotBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "field %s does not have omitempty and allows the zero value. The field does not need to be a pointer.", qualifiedFieldName)
 	case !hasValidZeroValue:
-		// The zero value would not be accepted, so the field needs to have omitempty.
-		// Force the omitempty policy to suggest a fix. We can only get to this function when the policy is configured to Ignore.
-		// Since we absolutely have to add the omitempty tag, we can report it as a suggestion.
-		reportShouldAddOmitEmpty(pass, field, OmitEmptyPolicySuggestFix, qualifiedFieldName, "field %s does not allow the zero value. It must have the omitempty tag.", jsonTags)
+		if s.omitZeroPolicy == OmitZeroPolicyForbid || !isStruct {
+			// The zero value would not be accepted, so the field needs to have omitempty.
+			// Force the omitempty policy to suggest a fix. We can only get to this function when the policy is configured to Ignore.
+			// Since we absolutely have to add the omitempty tag, we can report it as a suggestion.
+			// If we are checking omitzero separately, and it's a struct, this wouldn't apply so we skip.
+			reportShouldAddOmitEmpty(pass, field, OmitEmptyPolicySuggestFix, qualifiedFieldName, "field %s does not allow the zero value. It must have the omitempty tag.", jsonTags)
+		}
+
 		// Once it has the omitempty tag, it will also need to be a pointer in some cases.
 		// Now handle it as if it had the omitempty already.
 		// We already handle the omitempty tag above, so force the `hasOmitEmpty` to true.

--- a/pkg/analysis/utils/serialization/serialization_check_test.go
+++ b/pkg/analysis/utils/serialization/serialization_check_test.go
@@ -80,6 +80,22 @@ func TestPointersWhenRequiredOmitEmptyIgnore(t *testing.T) {
 	}), "pointers_when_required_omit_empty_ignore")
 }
 
+func TestPointersWhenRequiredOmitEmptyIgnoreOmitZeroSuggestFix(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, testSerializationAnalyzer(&serialization.Config{
+		Pointers: serialization.PointersConfig{
+			Policy:     serialization.PointersPolicySuggestFix,
+			Preference: serialization.PointersPreferenceWhenRequired,
+		},
+		OmitEmpty: serialization.OmitEmptyConfig{
+			Policy: serialization.OmitEmptyPolicyIgnore,
+		},
+		OmitZero: serialization.OmitZeroConfig{
+			Policy: serialization.OmitZeroPolicySuggestFix,
+		},
+	}), "pointers_when_required_omit_empty_ignore_omit_zero_suggest_fix")
+}
+
 func TestPointersWhenRequiredOmitEmptySuggestFixOmitZeroSuggestFix(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.RunWithSuggestedFixes(t, testdata, testSerializationAnalyzer(&serialization.Config{

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore_omit_zero_suggest_fix/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore_omit_zero_suggest_fix/structs.go
@@ -1,0 +1,122 @@
+package a
+
+type TestStructs struct {
+	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
+
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"`
+
+	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
+
+	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
+
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithMinProperties *StructWithMinProperties `json:"structPtrWithMinProperties"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
+
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"`
+
+	StructWithNonOmittedFieldsWithOmitEmpty StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+
+	StructPtrWithNonOmittedFields *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
+
+	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
+
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"`
+
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+
+	StructPtrWithNonOmittedFieldsAndMinProperties *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
+
+	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
+
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithOneNonOmittedFieldAndMinProperties *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty *StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
+
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+}
+
+type StructWithAllOptionalFields struct {
+	// +optional
+	String string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	// +optional
+	StringPtr *string `json:"stringPtr,omitempty"`
+
+	// +optional
+	Int int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	// +optional
+	IntPtr *int `json:"intPtr,omitempty"`
+}
+
+// +kubebuilder:validation:MinProperties=1
+type StructWithMinProperties struct {
+	// +kubebuilder:validation:MinProperties=1
+	// +optional
+	Map map[string]string `json:"map,omitempty"`
+}
+
+type StructWithNonOmittedFields struct {
+	// +required
+	String string `json:"string"`
+
+	// +required
+	Int int32 `json:"int"`
+}
+
+// Struct with non-omitted fields and minProperties marker.
+// Because there is no omitempty, and the zero values are valid, the zero value here is `{"string:"", "int":0}`.
+// This means the MinProperties marker is satisfied even when the object is the zero value.
+// +kubebuilder:validation:MinProperties=2
+type StructWithNonOmittedFieldsAndMinProperties struct {
+	// +required
+	String string `json:"string"`
+
+	// +required
+	Int int32 `json:"int"`
+}
+
+// Struct with one non-omitted field, and one omitted field and minProperties marker.
+// The zero value of the struct is `{"string:""}` which is not valid because it does not satisfy the MinProperties marker.
+// +kubebuilder:validation:MinProperties=2
+type StructWithOneNonOmittedFieldAndMinProperties struct {
+	// +required
+	String string `json:"string"`
+
+	// +optional
+	Int int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// Struct with an omitted required field.
+// The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
+type StructWithOmittedRequiredField struct {
+	// +required
+	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore_omit_zero_suggest_fix/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_ignore_omit_zero_suggest_fix/structs.go.golden
@@ -1,0 +1,122 @@
+package a
+
+type TestStructs struct {
+	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
+
+	StructWithAllOptionalFields StructWithAllOptionalFields `json:"structWithAllOptionalFields"`
+
+	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	StructPtrWithAllOptionalFields StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
+
+	// StructWithMinProperties has a zero value of {}, which is not valid because the MinProperties marker is not satisfied.
+
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties,omitzero"` // want "field TestStructs.StructWithMinProperties does not allow the zero value. It must have the omitzero tag."
+
+	StructWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithMinProperties StructWithMinProperties `json:"structPtrWithMinProperties,omitzero"` // want "field TestStructs.StructPtrWithMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinProperties does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
+
+	StructWithNonOmittedFields StructWithNonOmittedFields `json:"structWithNonOmittedFields"`
+
+	StructWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structWithNonOmittedFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+
+	StructPtrWithNonOmittedFields StructWithNonOmittedFields `json:"structPtrWithNonOmittedFields"` // want "field TestStructs.StructPtrWithNonOmittedFields does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithNonOmittedFieldsWithOmitEmpty *StructWithNonOmittedFields `json:"structPtrWithNonOmittedFieldsWithOmitEmpty,omitempty"`
+
+	// StructWithNonOmittedFieldsAndMinProperties has a zero value of {"string":"", "int":0}, which is valid because the MinProperties marker is satisfied.
+
+	StructWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinProperties"`
+
+	StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitempty"` // want "field TestStructs.StructWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty has a valid zero value \\({\"string\": \"\", \"int\": 0}\\) and should be a pointer."
+
+	StructPtrWithNonOmittedFieldsAndMinProperties StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinProperties"` // want "field TestStructs.StructPtrWithNonOmittedFieldsAndMinProperties does not have omitempty and allows the zero value. The field does not need to be a pointer."
+
+	StructPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty *StructWithNonOmittedFieldsAndMinProperties `json:"structPtrWithNonOmittedFieldsAndMinPropertiesWithOmitEmpty,omitempty"`
+
+	// StructWithOneNonOmittedFieldAndMinProperties has a zero value of {"string":""}, which is not valid because the MinProperties marker is not satisfied.
+
+	StructWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag."
+
+	StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structWithOneNonOmittedFieldAndMinPropertiesAndOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithOneNonOmittedFieldAndMinProperties StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinProperties,omitzero"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinProperties does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty StructWithOneNonOmittedFieldAndMinProperties `json:"structPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOneNonOmittedFieldAndMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithOmittedRequiredField has a zero value of {}, which is not valid because the required marker is not satisfied.
+
+	StructWithOmittedRequiredField StructWithOmittedRequiredField `json:"structWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag."
+
+	StructWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
+
+	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+}
+
+type StructWithAllOptionalFields struct {
+	// +optional
+	String *string `json:"string,omitempty"` // want "field StructWithAllOptionalFields.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	// +optional
+	StringPtr *string `json:"stringPtr,omitempty"`
+
+	// +optional
+	Int *int `json:"int,omitempty"` // want "field StructWithAllOptionalFields.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+
+	// +optional
+	IntPtr *int `json:"intPtr,omitempty"`
+}
+
+// +kubebuilder:validation:MinProperties=1
+type StructWithMinProperties struct {
+	// +kubebuilder:validation:MinProperties=1
+	// +optional
+	Map map[string]string `json:"map,omitempty"`
+}
+
+type StructWithNonOmittedFields struct {
+	// +required
+	String string `json:"string"`
+
+	// +required
+	Int int32 `json:"int"`
+}
+
+// Struct with non-omitted fields and minProperties marker.
+// Because there is no omitempty, and the zero values are valid, the zero value here is `{"string:"", "int":0}`.
+// This means the MinProperties marker is satisfied even when the object is the zero value.
+// +kubebuilder:validation:MinProperties=2
+type StructWithNonOmittedFieldsAndMinProperties struct {
+	// +required
+	String string `json:"string"`
+
+	// +required
+	Int int32 `json:"int"`
+}
+
+// Struct with one non-omitted field, and one omitted field and minProperties marker.
+// The zero value of the struct is `{"string:""}` which is not valid because it does not satisfy the MinProperties marker.
+// +kubebuilder:validation:MinProperties=2
+type StructWithOneNonOmittedFieldAndMinProperties struct {
+	// +required
+	String string `json:"string"`
+
+	// +optional
+	Int *int32 `json:"int,omitempty"` // want "field StructWithOneNonOmittedFieldAndMinProperties.Int has a valid zero value \\(0\\), but the validation is not complete \\(e.g. minimum/maximum\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// Struct with an omitted required field.
+// The zero value of the struct is `{}` which is not valid because it does not satisfy the required marker on the string field.
+type StructWithOmittedRequiredField struct {
+	// +required
+	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}


### PR DESCRIPTION
When we are suggesting `omitzero` for a struct, we should not be suggesting that it has `omitempty` as well. In particular, with the `omitempty` configured to `Ignore`, we previously were suggesting `omitempty` as well, which is confusing.

This PR adjusts that logic and adds test cases to prove that we won't suggest omitempty for a struct we already suggested omitzero for.

CC @pmalek would you be able to see if this fixes your issue

Fixes #195 