### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go build -o ./bin ./cmd/golangci-lint-kube-api-linter
 ```
 
 The binary builds a custom version of `golangci-lint` with Kube API Linter included as a module.
-See [Golangci-lint Moduule](#golangci-lint-module) for details on configuration of the module
+See [Golangci-lint Module](#golangci-lint-module) for details on configuration of the module
 under `settings`.
 
 ### Golangci-lint Module

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -282,7 +282,7 @@ The `forbiddenmarkers` linter ensures that types and fields do not contain any m
 
 By default, `forbiddenmarkers` is not enabled.
 
-### Configuation
+### Configuration
 
 It can be configured with a list of marker identifiers and optionally their attributes and values that are forbidden.
 
@@ -433,7 +433,7 @@ For strings, this means they have a `+kubebuilder:validation:MaxLength` marker.
 For arrays, this means they have a `+kubebuilder:validation:MaxItems` marker.
 
 For arrays of strings, the array element should also have a `+kubebuilder:validation:MaxLength` marker if the array element is a type alias,
-or `+kubebuilder:validation:items:MaxLenth` if the array is an element of the built-in string type.
+or `+kubebuilder:validation:items:MaxLength` if the array is an element of the built-in string type.
 
 Adding maximum lengths to strings and arrays not only ensures that the API is not abused (used to store overly large data, reduces DDOS etc.),
 but also allows CEL validation cost estimations to be kept within reasonable bounds.

--- a/docs/new-linter.md
+++ b/docs/new-linter.md
@@ -21,7 +21,7 @@ Once you are within the `inspect.Preorder`, you can then implement the business 
 
 ## Registry
 
-The registry in the analysis package co-ordinates the initialization of all linters.
+The registry in the analysis package coordinates the initialization of all linters.
 Where linters have configuration, or are enabled/disabled by higher level configuration, the registry takes on making sure the linters are initialized correctly.
 
 To enable the registry, each linter package must create an `Initializer` function that returns an `initializer.AnalyzerInitializer` interface (from `pkg/analysis/initializer`).
@@ -73,7 +73,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	)
 }
 
-// initAnalyzer returns the intialized Analyzer.
+// initAnalyzer returns the initialized Analyzer.
 func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
 	return newAnalyzer(cfg), nil
 }


### PR DESCRIPTION
The PR corrects grammar mistakes in the Markdown files.