### PR TITLE
chore: fix typos in comments

### DIFF
--- a/pkg/analysis/conditions/doc.go
+++ b/pkg/analysis/conditions/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 /*
 conditions is a linter that verifies that the conditions field within the struct is correctly defined.
 
-conditions fields in Kuberenetes API types are expected to be a slice of metav1.Condition.
+conditions fields in Kubernetes API types are expected to be a slice of metav1.Condition.
 This linter verifies that the field is a slice of metav1.Condition and that it is correctly annotated with the required markers,
 and tags.
 

--- a/pkg/analysis/defaults/config.go
+++ b/pkg/analysis/defaults/config.go
@@ -18,7 +18,7 @@ package defaults
 // OmitEmptyPolicy is the policy for omitempty.
 // SuggestFix will suggest a fix for the field to add omitempty.
 // Warn will warn about the field to add omitempty.
-// Ignore will ignore the the absence of omitempty.
+// Ignore will ignore the absence of omitempty.
 type OmitEmptyPolicy string
 
 const (
@@ -84,7 +84,7 @@ type DefaultsOmitZero struct {
 	// Valid values are "SuggestFix", "Warn" and "Forbid".
 	// When set to "SuggestFix", the linter will suggest adding the `omitzero` tag when a struct field with default does not have it.
 	// When set to "Warn", the linter will emit a warning if the field does not have the `omitzero` tag.
-	// When set to "Forbid", 'omitzero' tags wont be considered.
+	// When set to "Forbid", 'omitzero' tags will not be considered.
 	// Note, when set to "Forbid", and a field have the `omitzero` tag, the linter will not suggest adding it.
 	// Note, `omitzero` tag is supported in go version starting from go 1.24.
 	// Note, Configure omitzero policy to 'Forbid', if using with go version less than go 1.24.

--- a/pkg/analysis/forbiddenmarkers/analyzer_test.go
+++ b/pkg/analysis/forbiddenmarkers/analyzer_test.go
@@ -98,7 +98,7 @@ func TestWithConfiguration(t *testing.T) {
 				},
 			},
 			{
-				// No blue or green apples, but any othe apples allowed
+				// No blue or green apples, but any other apples allowed
 				// No red, blue, or green oranges, but any other oranges allowed
 				// No bananas allowed
 				Identifier: "custom:MultiRuleSet",

--- a/pkg/analysis/helpers/doc.go
+++ b/pkg/analysis/helpers/doc.go
@@ -22,7 +22,7 @@ The available helpers are:
   - [extractjsontags]: Extracts JSON tags from struct fields and returns the information in a structured format.
   - [markers]: Extracts marker information from types and returns the information in a structured format.
 
-Helpers should expose an *analysis.Analyzer as a globabl variable.
+Helpers should expose an *analysis.Analyzer as a global variable.
 Other linters will use the `Requires` configuration to ensure that the helper is run before the linter.
 The linter `Requires` relies on matching pointers to Analyzers, and therefore the helper cannot be dynamically created.
 */

--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -858,7 +858,7 @@ type Marker struct {
 	// Pos is the starting position in the file for the comment line containing the marker.
 	Pos token.Pos
 
-	// End is the ending position in the file for the coment line containing the marker.
+	// End is the ending position in the file for the comment line containing the marker.
 	End token.Pos
 }
 

--- a/pkg/analysis/initializer/initializer.go
+++ b/pkg/analysis/initializer/initializer.go
@@ -37,7 +37,7 @@ type AnalyzerInitializer interface {
 	// It will be passed the complete LintersConfig and is expected to rely only on its own configuration.
 	Init(any) (*analysis.Analyzer, error)
 
-	// Default determines whether the inializer intializes an analyzer that should be
+	// Default determines whether the initializer initializes an analyzer that should be
 	// on by default, or not.
 	Default() bool
 }
@@ -64,7 +64,7 @@ func NewInitializer(name string, analyzer *analysis.Analyzer, isDefault bool) An
 	}
 }
 
-// NewConfigurableInitializer constructs a new initializer for intializing a
+// NewConfigurableInitializer constructs a new initializer for initializing a
 // configurable Analyzer.
 func NewConfigurableInitializer[T any](name string, initFunc InitializerFunc[T], isDefault bool, validateFunc ValidateFunc[T]) ConfigurableAnalyzerInitializer {
 	return configurableInitializer[T]{
@@ -88,7 +88,7 @@ func (i initializer[T]) Name() string {
 	return i.name
 }
 
-// Init returns a newly initializr analyzer.
+// Init returns a newly initialized analyzer.
 func (i initializer[T]) Init(_ any) (*analysis.Analyzer, error) {
 	var cfg *T
 

--- a/pkg/analysis/integers/doc.go
+++ b/pkg/analysis/integers/doc.go
@@ -25,7 +25,7 @@ values larger than int32.
 It also states that unsigned integers should be replaced with signed integers, and then numeric
 lower bounds added to prevent negative integers.
 
-Succinctly this anaylzer checks for int, int8, int16, uint, uint8, uint16, uint32 and uint64 types
+Succinctly this analyzer checks for int, int8, int16, uint, uint8, uint16, uint32 and uint64 types
 and highlights that they should not be used.
 */
 package integers

--- a/pkg/analysis/nobools/doc.go
+++ b/pkg/analysis/nobools/doc.go
@@ -25,7 +25,7 @@ This is confusing and error-prone.
 It is recommended instead to use a string type with a set of constants to represent the different states,
 creating an enum.
 
-By using an enum, not only can you provide meaningul names for the various states of the API,
+By using an enum, not only can you provide meaningful names for the various states of the API,
 but you can also add additional states in the future without breaking the API.
 */
 package nobools

--- a/pkg/analysis/nomaps/initializer.go
+++ b/pkg/analysis/nomaps/initializer.go
@@ -39,7 +39,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	)
 }
 
-// Init returns the intialized Analyzer.
+// Init returns the initialized Analyzer.
 func initAnalyzer(nmc *NoMapsConfig) (*analysis.Analyzer, error) {
 	return newAnalyzer(nmc), nil
 }

--- a/pkg/analysis/optionalfields/config.go
+++ b/pkg/analysis/optionalfields/config.go
@@ -40,7 +40,7 @@ type OptionalFieldsPointers struct {
 	// Valid values are "Always" and "WhenRequired".
 	// When set to "Always", the linter will prefer pointers for all optional fields.
 	// When set to "WhenRequired", the linter will prefer pointers for optional fields where validation or serialization requires a pointer.
-	// The "WhenRequired" option requires bounds on strings and numerical values to be able to acurately determine the correct pointer vs non-pointer decision.
+	// The "WhenRequired" option requires bounds on strings and numerical values to be able to accurately determine the correct pointer vs non-pointer decision.
 	// When otherwise not specified, the default value is "Always".
 	Preference OptionalFieldsPointerPreference `json:"preference"`
 	// policy is the policy for the pointer preferences for optional fields.

--- a/pkg/analysis/optionalfields/doc.go
+++ b/pkg/analysis/optionalfields/doc.go
@@ -23,7 +23,7 @@ However, where the zero value for a field is not a valid value (e.g. the empty s
 In this case, the field may not need to be a pointer, and, with the WhenRequired preference, the linter will point out where the fields do not need to be pointers.
 
 Structs are also inspected to determine if they require a pointer.
-If a struct has any required fields, or a minimum numebr of properties, then fields leveraging the struct should be pointers.
+If a struct has any required fields, or a minimum number of properties, then fields leveraging the struct should be pointers.
 
 Optional structs do not always need to be pointers, but may be marshalled as `{}` because the JSON marshaller in Go cannot determine whether a struct is empty or not.
 */

--- a/pkg/analysis/optionalfields/initializer.go
+++ b/pkg/analysis/optionalfields/initializer.go
@@ -39,7 +39,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	)
 }
 
-// Init returns the intialized Analyzer.
+// Init returns the initialized Analyzer.
 func initAnalyzer(ofc *OptionalFieldsConfig) (*analysis.Analyzer, error) {
 	return newAnalyzer(ofc), nil
 }

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go
@@ -533,7 +533,7 @@ type E struct {
 	// B is a struct with optional fields.
 	B B `json:"b"`
 
-	// ByteArry is a byte array field.
+	// ByteArray is a byte array field.
 	// +optional
 	ByteArray []byte `json:"byteArray"`
 }

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
@@ -533,7 +533,7 @@ type E struct {
 	// B is a struct with optional fields.
 	B B `json:"b"`
 
-	// ByteArry is a byte array field.
+	// ByteArray is a byte array field.
 	// +optional
 	ByteArray []byte `json:"byteArray"`
 }

--- a/pkg/analysis/requiredfields/config.go
+++ b/pkg/analysis/requiredfields/config.go
@@ -65,7 +65,7 @@ type RequiredFieldsOmitZero struct {
 	// Valid values are "SuggestFix", "Warn" and "Forbid".
 	// When set to "SuggestFix", the linter will suggest adding the `omitzero` tag when an required field does not have it.
 	// When set to "Warn", the linter will emit a warning if the field does not have the `omitzero` tag.
-	// When set to "Forbid", 'omitzero' tags wont be considered.
+	// When set to "Forbid", 'omitzero' tags will not be considered.
 	// Note, when set to "Forbid", and a field have the `omitzero` tag, the linter will suggest to remove the `omitzero` tag.
 	// Note, `omitzero` tag is supported in go version starting from go 1.24.
 	// Note, Configure omitzero policy to 'Forbid', if using with go version less than go 1.24.

--- a/pkg/analysis/ssatags/initializer.go
+++ b/pkg/analysis/ssatags/initializer.go
@@ -41,7 +41,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	)
 }
 
-// Init returns the intialized Analyzer.
+// Init returns the initialized Analyzer.
 func initAnalyzer(stc *SSATagsConfig) (*analysis.Analyzer, error) {
 	return newAnalyzer(stc), nil
 }

--- a/pkg/analysis/uniquemarkers/initializer.go
+++ b/pkg/analysis/uniquemarkers/initializer.go
@@ -38,7 +38,7 @@ func Initializer() initializer.AnalyzerInitializer {
 	)
 }
 
-// Init returns the intialized Analyzer.
+// Init returns the initialized Analyzer.
 func initAnalyzer(umc *UniqueMarkersConfig) (*analysis.Analyzer, error) {
 	return newAnalyzer(umc), nil
 }

--- a/pkg/analysis/utils/serialization/config.go
+++ b/pkg/analysis/utils/serialization/config.go
@@ -45,7 +45,7 @@ const (
 // OmitEmptyPolicy is the policy for omitempty.
 // SuggestFix will suggest a fix for the field to add omitempty.
 // Warn will warn about the field to add omitempty.
-// Ignore will ignore the the absence of omitempty.
+// Ignore will ignore the absence of omitempty.
 type OmitEmptyPolicy string
 
 const (

--- a/pkg/plugin/base/base.go
+++ b/pkg/plugin/base/base.go
@@ -43,7 +43,7 @@ func New(settings any) (register.LinterPlugin, error) {
 // GolangCIPlugin constructs a new plugin for the golangci-lint
 // plugin pattern.
 // This allows golangci-lint to build a version of itself, containing
-// all of the anaylzers included in KAL.
+// all of the analyzers included in KAL.
 type GolangCIPlugin struct {
 	config config.GolangCIConfig
 }


### PR DESCRIPTION
This PR corrects grammar mistakes in the Go comments.