### PR TITLE
Rename dependenttags 'dependents' to 'dependsOn'

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -105,7 +105,7 @@ When `usePatchStrategy` is set to `Forbid`, the linter will suggest to remove th
 
 The `dependenttags` linter enforces dependencies between markers. This prevents API inconsistencies where one marker requires the presence of another.
 
-The linter is configured with a main tag and a list of required dependent tags. If the main tag is present on a field, the linter checks for the presence of the dependent tags based on the `type` field:
+The linter is configured with an identifier marker and a list of required dependsOn markers. If the identifier marker is present on a field, the linter checks for the presence of the dependsOn markers based on the `type` field:
 - `All`: Ensures that **all** of the dependent tags are present.
 - `Any`: Ensures that **at least one** of the dependent tags is present.
 
@@ -117,15 +117,15 @@ lintersConfig:
     rules:
       - identifier: "k8s:unionMember"
         type: "All"
-        dependents:
+        dependsOn:
           - "k8s:optional"
       - identifier: "listType"
         type: "All"
-        dependents:
+        dependsOn:
           - "k8s:listType"
       - identifier: "example:any"
         type: "Any"
-        dependents:
+        dependsOn:
           - "dep1"
           - "dep2"
 ```

--- a/pkg/analysis/dependenttags/analyzer.go
+++ b/pkg/analysis/dependenttags/analyzer.go
@@ -41,7 +41,7 @@ func newAnalyzer(cfg Config) *analysis.Analyzer {
 	for _, rule := range cfg.Rules {
 		markers.DefaultRegistry().Register(rule.Identifier)
 
-		for _, dep := range rule.Dependents {
+		for _, dep := range rule.DependsOn {
 			markers.DefaultRegistry().Register(dep)
 		}
 	}
@@ -89,9 +89,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	return nil, nil //nolint:nilnil
 }
 func handleAll(pass *analysis.Pass, field *ast.Field, rule Rule, fieldMarkers markers.MarkerSet, qualifiedFieldName string) {
-	missing := make([]string, 0, len(rule.Dependents))
+	missing := make([]string, 0, len(rule.DependsOn))
 
-	for _, dependent := range rule.Dependents {
+	for _, dependent := range rule.DependsOn {
 		if _, depOk := fieldMarkers[dependent]; !depOk {
 			missing = append(missing, fmt.Sprintf("+%s", dependent))
 		}
@@ -105,7 +105,7 @@ func handleAll(pass *analysis.Pass, field *ast.Field, rule Rule, fieldMarkers ma
 func handleAny(pass *analysis.Pass, field *ast.Field, rule Rule, fieldMarkers markers.MarkerSet, qualifiedFieldName string) {
 	found := false
 
-	for _, dependent := range rule.Dependents {
+	for _, dependent := range rule.DependsOn {
 		if _, depOk := fieldMarkers[dependent]; depOk {
 			found = true
 			break
@@ -113,11 +113,11 @@ func handleAny(pass *analysis.Pass, field *ast.Field, rule Rule, fieldMarkers ma
 	}
 
 	if !found {
-		dependents := make([]string, len(rule.Dependents))
-		for i, d := range rule.Dependents {
-			dependents[i] = fmt.Sprintf("+%s", d)
+		dependsOn := make([]string, len(rule.DependsOn))
+		for i, d := range rule.DependsOn {
+			dependsOn[i] = fmt.Sprintf("+%s", d)
 		}
 
-		pass.Reportf(field.Pos(), "field %s with marker +%s requires at least one of the following markers, but none were found: %s", qualifiedFieldName, rule.Identifier, strings.Join(dependents, ", "))
+		pass.Reportf(field.Pos(), "field %s with marker +%s requires at least one of the following markers, but none were found: %s", qualifiedFieldName, rule.Identifier, strings.Join(dependsOn, ", "))
 	}
 }

--- a/pkg/analysis/dependenttags/analyzer_test.go
+++ b/pkg/analysis/dependenttags/analyzer_test.go
@@ -30,22 +30,22 @@ func TestAnalyzer(t *testing.T) {
 			{
 				Identifier: "k8s:unionMember",
 				Type:       dependenttags.DependencyTypeAll,
-				Dependents: []string{"k8s:optional"},
+				DependsOn:  []string{"k8s:optional"},
 			},
 			{
 				Identifier: "listType",
 				Type:       dependenttags.DependencyTypeAll,
-				Dependents: []string{"k8s:listType"},
+				DependsOn:  []string{"k8s:listType"},
 			},
 			{
 				Identifier: "example:any",
 				Type:       dependenttags.DependencyTypeAny,
-				Dependents: []string{"dep1", "dep2"},
+				DependsOn:  []string{"dep1", "dep2"},
 			},
 			{
 				Identifier: "listType=map",
 				Type:       dependenttags.DependencyTypeAll,
-				Dependents: []string{"listMapKey"},
+				DependsOn:  []string{"listMapKey"},
 			},
 		},
 	}

--- a/pkg/analysis/dependenttags/config.go
+++ b/pkg/analysis/dependenttags/config.go
@@ -32,14 +32,14 @@ type Config struct {
 	Rules []Rule `mapstructure:"rules"`
 }
 
-// Rule defines a dependency rule where a main marker requires a set of dependent markers.
+// Rule defines a dependency rule where a specific marker requires a set of other markers.
 type Rule struct {
 	// Identifier is the marker that requires other markers.
 	Identifier string `mapstructure:"identifier"`
-	// Dependents are the markers that are required by Main.
-	Dependents []string `mapstructure:"dependents"`
-	// Type defines how to interpret the dependents list.
+	// DependsOn are the markers that are required when the identifier is present.
+	DependsOn []string `mapstructure:"dependsOn"`
+	// Type defines how to interpret the dependsOn list.
 	// When set to All, every dependent in the list must be present when the identifier is present on a field or type.
-	// When set to Any, at least one of the listed dependents must be present when the identifier is present on a field or type.
+	// When set to Any, at least one of the listed dependsOn must be present when the identifier is present on a field or type.
 	Type DependencyType `mapstructure:"type,omitempty"`
 }

--- a/pkg/analysis/dependenttags/doc.go
+++ b/pkg/analysis/dependenttags/doc.go
@@ -26,7 +26,7 @@ limitations under the License.
 // # Configuration
 //
 // The linter is configured with a list of rules. Each rule specifies an identifier marker and a list of
-// dependent markers. The `type` field is required and specifies how to interpret the dependents list:
+// dependent markers. The `type` field is required and specifies how to interpret the dependsOn list:
 // - `All`: all dependent markers are required.
 // - `Any`: at least one of the dependent markers is required.
 //
@@ -37,15 +37,15 @@ limitations under the License.
 //	    rules:
 //	    - identifier: "k8s:unionMember"
 //	      type: "All"
-//	      dependents:
+//	      dependsOn:
 //	      - "k8s:optional"
 //	    - identifier: "listType"
 //	      type: "All"
-//	      dependents:
+//	      dependsOn:
 //	      - "k8s:listType"
 //	    - identifier: "example:any"
 //	      type: "Any"
-//	      dependents:
+//	      dependsOn:
 //	      - "dep1"
 //	      - "dep2"
 package dependenttags

--- a/pkg/analysis/dependenttags/initializer.go
+++ b/pkg/analysis/dependenttags/initializer.go
@@ -70,8 +70,8 @@ func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
 			errs = append(errs, field.Invalid(rulesPath.Index(i).Child("identifier"), rule.Identifier, "identifier marker cannot be empty"))
 		}
 
-		if len(rule.Dependents) == 0 {
-			errs = append(errs, field.Invalid(rulesPath.Index(i).Child("dependents"), rule.Dependents, "dependents list cannot be empty"))
+		if len(rule.DependsOn) == 0 {
+			errs = append(errs, field.Invalid(rulesPath.Index(i).Child("dependsOn"), rule.DependsOn, "dependsOn list cannot be empty"))
 		}
 
 		if rule.Type == "" {

--- a/pkg/analysis/dependenttags/initializer_test.go
+++ b/pkg/analysis/dependenttags/initializer_test.go
@@ -48,7 +48,7 @@ var _ = Describe("dependenttags initializer", func() {
 						{
 							Identifier: "k8s:unionMember",
 							Type:       dependenttags.DependencyTypeAll,
-							Dependents: []string{"k8s:optional"},
+							DependsOn:  []string{"k8s:optional"},
 						},
 					},
 				},
@@ -59,7 +59,7 @@ var _ = Describe("dependenttags initializer", func() {
 					Rules: []dependenttags.Rule{
 						{
 							Identifier: "k8s:unionMember",
-							Dependents: []string{"k8s:optional"},
+							DependsOn:  []string{"k8s:optional"},
 						},
 					},
 				},
@@ -75,14 +75,14 @@ var _ = Describe("dependenttags initializer", func() {
 				config: dependenttags.Config{
 					Rules: []dependenttags.Rule{
 						{
-							Type:       dependenttags.DependencyTypeAll,
-							Dependents: []string{"k8s:optional"},
+							Type:      dependenttags.DependencyTypeAll,
+							DependsOn: []string{"k8s:optional"},
 						},
 					},
 				},
 				expectedErr: "dependenttags.rules[0].identifier: Invalid value: \"\": identifier marker cannot be empty",
 			}),
-			Entry("with missing dependents", testCase{
+			Entry("with missing dependsOn", testCase{
 				config: dependenttags.Config{
 					Rules: []dependenttags.Rule{
 						{
@@ -91,7 +91,7 @@ var _ = Describe("dependenttags initializer", func() {
 						},
 					},
 				},
-				expectedErr: "dependenttags.rules[0].dependents: Invalid value: []string(nil): dependents list cannot be empty",
+				expectedErr: "dependenttags.rules[0].dependsOn: Invalid value: []string(nil): dependsOn list cannot be empty",
 			}),
 			Entry("with invalid type", testCase{
 				config: dependenttags.Config{
@@ -99,11 +99,11 @@ var _ = Describe("dependenttags initializer", func() {
 						{
 							Identifier: "k8s:unionMember",
 							Type:       "invalid",
-							Dependents: []string{"k8s:optional"},
+							DependsOn:  []string{"k8s:optional"},
 						},
 					},
 				},
-				expectedErr: fmt.Sprintf(`dependenttags.rules[0].type: Invalid value: "invalid": type must be '%s' or '%s'`, dependenttags.DependencyTypeAll, dependenttags.DependencyTypeAny),
+				expectedErr: fmt.Sprintf("dependenttags.rules[0].type: Invalid value: \"invalid\": type must be '%s' or '%s'", dependenttags.DependencyTypeAll, dependenttags.DependencyTypeAny),
 			}),
 		)
 	})


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/136184#discussion_r2684470082

This PR rename dependenttags configuration field 'dependents' to 'dependsOn'.