### PR TITLE
extend maxlength linter to support the declarative validation markers

### DIFF
--- a/pkg/analysis/doc.go
+++ b/pkg/analysis/doc.go
@@ -46,6 +46,10 @@ Example:
 				PreferredOptionalMarker: optionalorrequired.OptionalMarker,
 				PreferredRequiredMarker: optionalorrequired.RequiredMarker,
 			},
+			MaxLength: config.MaxLengthConfig{
+				PreferredMaxLengthMarker: markers.KubebuilderMaxLengthMarker,
+				PreferredMaxItemsMarker:  markers.KubebuilderMaxItemsMarker,
+			},
 		},
 	)
 
@@ -55,6 +59,7 @@ or as part of a custom analysis pipeline, eg via the golangci-lint plugin system
 Linters provided by KAL:
   - [commentstart]: Linter to ensure that comments start with the serialized version of the field name.
   - [jsontags]: Linter to ensure that JSON tags are present on struct fields, and that they match a given regex.
+  - [maxlength]: Linter to ensure that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.
   - [optionalorrequired]: Linter to ensure that all fields are marked as either optional or required.
 
 When adding new linters, ensure that they are added to the registry in the `NewRegistry` function.

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -16,40 +16,51 @@ limitations under the License.
 package maxlength
 
 import (
-"fmt"
-"go/ast"
+	"fmt"
+	"go/ast"
 
-"golang.org/x/tools/go/analysis"
-kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
-"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
-"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
-"sigs.k8s.io/kube-api-linter/pkg/markers"
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func init() {
 	markershelper.DefaultRegistry().Register(
-markers.KubebuilderMaxLengthMarker,
-markers.KubebuilderMaxItemsMarker,
-markers.KubebuilderItemsMaxLengthMarker,
-markers.KubebuilderEnumMarker,
-markers.KubebuilderItemsEnumMarker,
-markers.KubebuilderFormatMarker,
-markers.KubebuilderItemsFormatMarker,
-markers.K8sMaxLengthMarker,
-markers.K8sMaxItemsMarker,
-markers.K8sEnumMarker,
-)
+		markers.KubebuilderMaxLengthMarker,
+		markers.KubebuilderMaxItemsMarker,
+		markers.KubebuilderItemsMaxLengthMarker,
+		markers.KubebuilderEnumMarker,
+		markers.KubebuilderItemsEnumMarker,
+		markers.KubebuilderFormatMarker,
+		markers.KubebuilderItemsFormatMarker,
+		markers.KubebuilderMaxPropertiesMarker,
+		markers.KubebuilderMaximumMarker,
+		markers.K8sMaxLengthMarker,
+		markers.K8sMaxItemsMarker,
+		markers.K8sEnumMarker,
+		markers.K8sMinLengthMarker,
+		markers.K8sMinItemsMarker,
+		markers.K8sMinimumMarker,
+		markers.K8sMaxPropertiesMarker,
+		markers.K8sMinPropertiesMarker,
+		markers.K8sMaximumMarker,
+		markers.K8sMaxBytesMarker,
+	)
 }
 
 const (
-name = "maxlength"
+	name = "maxlength"
 )
 
 type analyzer struct {
-	preferredMaxLengthMarker string
-	preferredMaxItemsMarker  string
+	preferredMaxLengthMarker     string
+	preferredMaxItemsMarker      string
+	preferredMaxPropertiesMarker string
+	preferredMaximumMarker       string
 }
 
 // newAnalyzer creates a new analyzer with the given configuration.
@@ -61,8 +72,10 @@ func newAnalyzer(cfg *MaxLengthConfig) *analysis.Analyzer {
 	defaultConfig(cfg)
 
 	a := &analyzer{
-		preferredMaxLengthMarker: cfg.PreferredMaxLengthMarker,
-		preferredMaxItemsMarker:  cfg.PreferredMaxItemsMarker,
+		preferredMaxLengthMarker:     cfg.PreferredMaxLengthMarker,
+		preferredMaxItemsMarker:      cfg.PreferredMaxItemsMarker,
+		preferredMaxPropertiesMarker: cfg.PreferredMaxPropertiesMarker,
+		preferredMaximumMarker:       cfg.PreferredMaximumMarker,
 	}
 
 	return &analysis.Analyzer{
@@ -73,16 +86,6 @@ func newAnalyzer(cfg *MaxLengthConfig) *analysis.Analyzer {
 	}
 }
 
-func defaultConfig(cfg *MaxLengthConfig) {
-	if cfg.PreferredMaxLengthMarker == "" {
-		cfg.PreferredMaxLengthMarker = markers.KubebuilderMaxLengthMarker
-	}
-
-	if cfg.PreferredMaxItemsMarker == "" {
-		cfg.PreferredMaxItemsMarker = markers.KubebuilderMaxItemsMarker
-	}
-}
-
 func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
 	if !ok {
@@ -90,8 +93,8 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	}
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-a.checkField(pass, field, markersAccess, qualifiedFieldName)
-})
+		a.checkField(pass, field, markersAccess, qualifiedFieldName)
+	})
 
 	return nil, nil //nolint:nilnil
 }
@@ -104,7 +107,11 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAcce
 
 func (a *analyzer) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
-		a.checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		if ident.Name == "string" {
+			a.checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		} else if isNumericType(ident.Name) {
+			a.checkNumeric(pass, ident, node, aliases, markersAccess, prefix)
+		}
 
 		return
 	}
@@ -129,6 +136,14 @@ func (a *analyzer) checkString(pass *analysis.Pass, ident *ast.Ident, node ast.N
 	}
 }
 
+func (a *analyzer) checkNumeric(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
+
+	if needsMaximum(markerSet) {
+		pass.Reportf(node.Pos(), "%s must have a maximum value, add %s marker", prefix, a.preferredMaximumMarker)
+	}
+}
+
 func (a *analyzer) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
@@ -148,6 +163,8 @@ func (a *analyzer) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node as
 		a.checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.ArrayType:
 		a.checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+	case *ast.MapType:
+		a.checkMapType(pass, typ, node, aliases, markersAccess, prefix)
 	}
 }
 
@@ -177,6 +194,14 @@ func (a *analyzer) checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType,
 	}
 }
 
+func (a *analyzer) checkMapType(pass *analysis.Pass, mapType *ast.MapType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
+
+	if needsMaxProperties(markerSet) {
+		pass.Reportf(node.Pos(), "%s must have a maximum number of properties, add %s marker", prefix, a.preferredMaxPropertiesMarker)
+	}
+}
+
 func (a *analyzer) checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
 		a.checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
@@ -190,68 +215,100 @@ func (a *analyzer) checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident,
 	}
 
 	// If the array element wasn't directly a string, allow a string alias to be used
-// with either the items style markers or the on alias style markers.
-a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), a.preferredMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
-return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
-})
+	// with either the items style markers or the on alias style markers.
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), a.preferredMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
+		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+	})
 }
 
 func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
-base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
+	base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
 
-for _, a := range aliases {
-base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
-}
+	for _, a := range aliases {
+		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+	}
 
-return base
+	return base
 }
 
 func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelper.MarkerSet {
-switch t := node.(type) {
-case *ast.Field:
-return markersAccess.FieldMarkers(t)
-case *ast.TypeSpec:
-return markersAccess.TypeMarkers(t)
+	switch t := node.(type) {
+	case *ast.Field:
+		return markersAccess.FieldMarkers(t)
+	case *ast.TypeSpec:
+		return markersAccess.TypeMarkers(t)
+	}
+
+	return nil
 }
 
-return nil
-}
-
-// needsMaxLength returns true if the field needs a maximum length.
+// needsStringMaxLength returns true if the field needs a maximum length.
 // Fields do not need a maximum length if they are already marked with a maximum length,
 // or if they are an enum, or if they are a date, date-time or duration.
 func needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
-switch {
-case markerSet.Has(markers.KubebuilderMaxLengthMarker),
-markerSet.Has(markers.K8sMaxLengthMarker),
-markerSet.Has(markers.KubebuilderEnumMarker),
-markerSet.Has(markers.K8sEnumMarker),
-markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
-markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
-markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
-return false
-}
+	switch {
+	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxBytesMarker),
+		markerSet.Has(markers.KubebuilderEnumMarker),
+		markerSet.Has(markers.K8sEnumMarker),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+		return false
+	}
 
-return true
+	return true
 }
 
 func needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
-switch {
-case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
-markerSet.Has(markers.KubebuilderItemsEnumMarker),
-markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
-markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
-markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
-return false
+	switch {
+	case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
+		markerSet.Has(markers.KubebuilderItemsEnumMarker),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
+		return false
+	}
+
+	return true
 }
 
-return true
+func needsMaxProperties(markerSet markershelper.MarkerSet) bool {
+	switch {
+	case markerSet.Has(markers.KubebuilderMaxPropertiesMarker),
+		markerSet.Has(markers.K8sMaxPropertiesMarker):
+		return false
+	}
+
+	return true
+}
+
+func needsMaximum(markerSet markershelper.MarkerSet) bool {
+	switch {
+	case markerSet.Has(markers.KubebuilderMaximumMarker),
+		markerSet.Has(markers.K8sMaximumMarker):
+		return false
+	}
+
+	return true
 }
 
 func kubebuilderFormatWithValue(value string) string {
-return fmt.Sprintf("%s:=%s", markers.KubebuilderFormatMarker, value)
+	return fmt.Sprintf("%s:=%s", markers.KubebuilderFormatMarker, value)
 }
 
 func kubebuilderItemsFormatWithValue(value string) string {
-return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+}
+
+func isNumericType(name string) bool {
+	switch name {
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
+		"float32", "float64":
+		return true
+	}
+
+	return false
 }

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -16,68 +16,95 @@ limitations under the License.
 package maxlength
 
 import (
-	"fmt"
-	"go/ast"
+"fmt"
+"go/ast"
 
-	"golang.org/x/tools/go/analysis"
-	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
-	"sigs.k8s.io/kube-api-linter/pkg/markers"
+"golang.org/x/tools/go/analysis"
+kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func init() {
 	markershelper.DefaultRegistry().Register(
-		markers.KubebuilderMaxLengthMarker,
-		markers.KubebuilderMaxItemsMarker,
-		markers.KubebuilderItemsMaxLengthMarker,
-		markers.KubebuilderEnumMarker,
-		markers.KubebuilderItemsEnumMarker,
-		markers.KubebuilderFormatMarker,
-		markers.KubebuilderItemsFormatMarker,
-		markers.K8sMaxLengthMarker,
-		markers.K8sMaxItemsMarker,
-		markers.K8sEnumMarker,
-	)
+markers.KubebuilderMaxLengthMarker,
+markers.KubebuilderMaxItemsMarker,
+markers.KubebuilderItemsMaxLengthMarker,
+markers.KubebuilderEnumMarker,
+markers.KubebuilderItemsEnumMarker,
+markers.KubebuilderFormatMarker,
+markers.KubebuilderItemsFormatMarker,
+markers.K8sMaxLengthMarker,
+markers.K8sMaxItemsMarker,
+markers.K8sEnumMarker,
+)
 }
 
 const (
-	name = "maxlength"
+name = "maxlength"
 )
 
-// Analyzer is the analyzer for the maxlength package.
-// It checks that strings and arrays have maximum lengths and maximum items respectively.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspector.Analyzer},
+type analyzer struct {
+	preferredMaxLengthMarker string
+	preferredMaxItemsMarker  string
 }
 
-func run(pass *analysis.Pass) (any, error) {
+// newAnalyzer creates a new analyzer with the given configuration.
+func newAnalyzer(cfg *MaxLengthConfig) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &MaxLengthConfig{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		preferredMaxLengthMarker: cfg.PreferredMaxLengthMarker,
+		preferredMaxItemsMarker:  cfg.PreferredMaxItemsMarker,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+}
+
+func defaultConfig(cfg *MaxLengthConfig) {
+	if cfg.PreferredMaxLengthMarker == "" {
+		cfg.PreferredMaxLengthMarker = markers.KubebuilderMaxLengthMarker
+	}
+
+	if cfg.PreferredMaxItemsMarker == "" {
+		cfg.PreferredMaxItemsMarker = markers.KubebuilderMaxItemsMarker
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
 	if !ok {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+a.checkField(pass, field, markersAccess, qualifiedFieldName)
+})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	prefix := fmt.Sprintf("field %s", qualifiedFieldName)
 
-	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+	a.checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, a.preferredMaxLengthMarker, needsStringMaxLength)
 }
 
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 
 		return
 	}
@@ -87,10 +114,10 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 		return
 	}
 
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
 }
 
-func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if ident.Name != "string" {
 		return
 	}
@@ -102,7 +129,7 @@ func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases [
 	}
 }
 
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
 	}
@@ -110,21 +137,21 @@ func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, alia
 	typeName := tSpec.Name.Name
 	prefix = fmt.Sprintf("%s %s", prefix, typeName)
 
-	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	a.checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 }
 
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
-		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.StarExpr:
-		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.ArrayType:
-		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+		a.checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
 	}
 }
 
-func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func (a *analyzer) checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
 			if ident.Name == "byte" {
@@ -134,25 +161,25 @@ func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node
 					NamePos: ident.NamePos,
 					Name:    "string",
 				}
-				checkString(pass, i, node, aliases, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+				a.checkString(pass, i, node, aliases, markersAccess, prefix, a.preferredMaxLengthMarker, needsStringMaxLength)
 
 				return
 			}
 
-			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+			a.checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
 		}
 	}
 
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) {
-		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, markers.KubebuilderMaxItemsMarker)
+	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) && !markerSet.Has(markers.K8sMaxItemsMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, a.preferredMaxItemsMarker)
 	}
 }
 
-func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func (a *analyzer) checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
+		a.checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
 
 		return
 	}
@@ -163,66 +190,68 @@ func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node
 	}
 
 	// If the array element wasn't directly a string, allow a string alias to be used
-	// with either the items style markers or the on alias style markers.
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
-		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
-	})
+// with either the items style markers or the on alias style markers.
+a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), a.preferredMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
+return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+})
 }
 
 func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
-	base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
+base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
 
-	for _, a := range aliases {
-		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
-	}
+for _, a := range aliases {
+base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+}
 
-	return base
+return base
 }
 
 func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelper.MarkerSet {
-	switch t := node.(type) {
-	case *ast.Field:
-		return markersAccess.FieldMarkers(t)
-	case *ast.TypeSpec:
-		return markersAccess.TypeMarkers(t)
-	}
+switch t := node.(type) {
+case *ast.Field:
+return markersAccess.FieldMarkers(t)
+case *ast.TypeSpec:
+return markersAccess.TypeMarkers(t)
+}
 
-	return nil
+return nil
 }
 
 // needsMaxLength returns true if the field needs a maximum length.
 // Fields do not need a maximum length if they are already marked with a maximum length,
 // or if they are an enum, or if they are a date, date-time or duration.
 func needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
-	switch {
-	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
-		markerSet.Has(markers.KubebuilderEnumMarker),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
-		return false
-	}
+switch {
+case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+markerSet.Has(markers.K8sMaxLengthMarker),
+markerSet.Has(markers.KubebuilderEnumMarker),
+markerSet.Has(markers.K8sEnumMarker),
+markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+return false
+}
 
-	return true
+return true
 }
 
 func needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
-	switch {
-	case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
-		markerSet.Has(markers.KubebuilderItemsEnumMarker),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
-		return false
-	}
+switch {
+case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
+markerSet.Has(markers.KubebuilderItemsEnumMarker),
+markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
+markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
+markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
+return false
+}
 
-	return true
+return true
 }
 
 func kubebuilderFormatWithValue(value string) string {
-	return fmt.Sprintf("%s:=%s", markers.KubebuilderFormatMarker, value)
+return fmt.Sprintf("%s:=%s", markers.KubebuilderFormatMarker, value)
 }
 
 func kubebuilderItemsFormatWithValue(value string) string {
-	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
 }

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -28,6 +28,21 @@ import (
 	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
+func init() {
+	markershelper.DefaultRegistry().Register(
+		markers.KubebuilderMaxLengthMarker,
+		markers.KubebuilderMaxItemsMarker,
+		markers.KubebuilderItemsMaxLengthMarker,
+		markers.KubebuilderEnumMarker,
+		markers.KubebuilderItemsEnumMarker,
+		markers.KubebuilderFormatMarker,
+		markers.KubebuilderItemsFormatMarker,
+		markers.K8sMaxLengthMarker,
+		markers.K8sMaxItemsMarker,
+		markers.K8sEnumMarker,
+	)
+}
+
 const (
 	name = "maxlength"
 )

--- a/pkg/analysis/maxlength/analyzer_test.go
+++ b/pkg/analysis/maxlength/analyzer_test.go
@@ -20,10 +20,30 @@ import (
 
 	"golang.org/x/tools/go/analysis/analysistest"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/maxlength"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
-func TestMaxLength(t *testing.T) {
+func TestDefaultConfiguration(t *testing.T) {
 	testdata := analysistest.TestData()
 
-	analysistest.Run(t, testdata, maxlength.Analyzer, "a")
+	a, err := maxlength.Initializer().Init(&maxlength.MaxLengthConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.Run(t, testdata, a, "a")
+}
+
+func TestK8sMarkerConfiguration(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := maxlength.Initializer().Init(&maxlength.MaxLengthConfig{
+		PreferredMaxLengthMarker: markers.K8sMaxLengthMarker,
+		PreferredMaxItemsMarker:  markers.K8sMaxItemsMarker,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.Run(t, testdata, a, "b")
 }

--- a/pkg/analysis/maxlength/config.go
+++ b/pkg/analysis/maxlength/config.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package maxlength
+
+// MaxLengthConfig contains configuration for the maxlength linter.
+type MaxLengthConfig struct {
+	// PreferredMaxLengthMarker is the preferred marker identifier to use for maximum length on strings.
+	// If this field is not set, the default value is "kubebuilder:validation:MaxLength".
+	// Valid values are "kubebuilder:validation:MaxLength" and "k8s:maxLength".
+	PreferredMaxLengthMarker string `json:"preferredMaxLengthMarker"`
+
+	// PreferredMaxItemsMarker is the preferred marker identifier to use for maximum items on arrays.
+	// If this field is not set, the default value is "kubebuilder:validation:MaxItems".
+	// Valid values are "kubebuilder:validation:MaxItems" and "k8s:maxItems".
+	PreferredMaxItemsMarker string `json:"preferredMaxItemsMarker"`
+}

--- a/pkg/analysis/maxlength/config.go
+++ b/pkg/analysis/maxlength/config.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package maxlength
 
+import "sigs.k8s.io/kube-api-linter/pkg/markers"
+
 // MaxLengthConfig contains configuration for the maxlength linter.
 type MaxLengthConfig struct {
 	// PreferredMaxLengthMarker is the preferred marker identifier to use for maximum length on strings.
@@ -26,4 +28,32 @@ type MaxLengthConfig struct {
 	// If this field is not set, the default value is "kubebuilder:validation:MaxItems".
 	// Valid values are "kubebuilder:validation:MaxItems" and "k8s:maxItems".
 	PreferredMaxItemsMarker string `json:"preferredMaxItemsMarker"`
+
+	// PreferredMaxPropertiesMarker is the preferred marker identifier to use for maximum properties on maps.
+	// If this field is not set, the default value is "kubebuilder:validation:MaxProperties".
+	// Valid values are "kubebuilder:validation:MaxProperties" and "k8s:maxProperties".
+	PreferredMaxPropertiesMarker string `json:"preferredMaxPropertiesMarker"`
+
+	// PreferredMaximumMarker is the preferred marker identifier to use for maximum value on numbers.
+	// If this field is not set, the default value is "kubebuilder:validation:Maximum".
+	// Valid values are "kubebuilder:validation:Maximum" and "k8s:maximum".
+	PreferredMaximumMarker string `json:"preferredMaximumMarker"`
+}
+
+func defaultConfig(cfg *MaxLengthConfig) {
+	if cfg.PreferredMaxLengthMarker == "" {
+		cfg.PreferredMaxLengthMarker = markers.KubebuilderMaxLengthMarker
+	}
+
+	if cfg.PreferredMaxItemsMarker == "" {
+		cfg.PreferredMaxItemsMarker = markers.KubebuilderMaxItemsMarker
+	}
+
+	if cfg.PreferredMaxPropertiesMarker == "" {
+		cfg.PreferredMaxPropertiesMarker = markers.KubebuilderMaxPropertiesMarker
+	}
+
+	if cfg.PreferredMaximumMarker == "" {
+		cfg.PreferredMaximumMarker = markers.KubebuilderMaximumMarker
+	}
 }

--- a/pkg/analysis/maxlength/initializer.go
+++ b/pkg/analysis/maxlength/initializer.go
@@ -16,8 +16,13 @@ limitations under the License.
 package maxlength
 
 import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func init() {
@@ -27,9 +32,37 @@ func init() {
 // Initializer returns the AnalyzerInitializer for this
 // Analyzer so that it can be added to the registry.
 func Initializer() initializer.AnalyzerInitializer {
-	return initializer.NewInitializer(
+	return initializer.NewConfigurableInitializer(
 		name,
-		Analyzer,
+		initAnalyzer,
 		false, // For now, CRD only, and so not on by default.
+		validateConfig,
 	)
+}
+
+func initAnalyzer(config *MaxLengthConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(config), nil
+}
+
+// validateConfig is used to validate the configuration in the config.MaxLengthConfig struct.
+func validateConfig(config *MaxLengthConfig, fldPath *field.Path) field.ErrorList {
+	if config == nil {
+		return field.ErrorList{}
+	}
+
+	fieldErrors := field.ErrorList{}
+
+	switch config.PreferredMaxLengthMarker {
+	case "", markers.KubebuilderMaxLengthMarker, markers.K8sMaxLengthMarker:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredMaxLengthMarker"), config.PreferredMaxLengthMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.KubebuilderMaxLengthMarker, markers.K8sMaxLengthMarker)))
+	}
+
+	switch config.PreferredMaxItemsMarker {
+	case "", markers.KubebuilderMaxItemsMarker, markers.K8sMaxItemsMarker:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredMaxItemsMarker"), config.PreferredMaxItemsMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.KubebuilderMaxItemsMarker, markers.K8sMaxItemsMarker)))
+	}
+
+	return fieldErrors
 }

--- a/pkg/analysis/maxlength/initializer.go
+++ b/pkg/analysis/maxlength/initializer.go
@@ -64,5 +64,17 @@ func validateConfig(config *MaxLengthConfig, fldPath *field.Path) field.ErrorLis
 		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredMaxItemsMarker"), config.PreferredMaxItemsMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.KubebuilderMaxItemsMarker, markers.K8sMaxItemsMarker)))
 	}
 
+	switch config.PreferredMaxPropertiesMarker {
+	case "", markers.KubebuilderMaxPropertiesMarker, markers.K8sMaxPropertiesMarker:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredMaxPropertiesMarker"), config.PreferredMaxPropertiesMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.KubebuilderMaxPropertiesMarker, markers.K8sMaxPropertiesMarker)))
+	}
+
+	switch config.PreferredMaximumMarker {
+	case "", markers.KubebuilderMaximumMarker, markers.K8sMaximumMarker:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredMaximumMarker"), config.PreferredMaximumMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.KubebuilderMaximumMarker, markers.K8sMaximumMarker)))
+	}
+
 	return fieldErrors
 }

--- a/pkg/analysis/maxlength/testdata/src/a/limits.go
+++ b/pkg/analysis/maxlength/testdata/src/a/limits.go
@@ -1,0 +1,30 @@
+package a
+
+type Limits struct {
+	// +k8s:maxLength=256
+	StringWithK8sMaxLength string
+
+	// +k8s:maxBytes=512
+	StringWithK8sMaxBytes string
+
+	// +k8s:maxItems=128
+	ArrayWithK8sMaxItems []int
+
+	// +k8s:maxProperties=64
+	MapWithK8sMaxProperties map[string]string
+
+	// +k8s:maximum=100
+	IntWithK8sMaximum int32
+
+	// +kubebuilder:validation:MaxProperties=32
+	MapWithKubebuilderMaxProperties map[string]int
+
+	// +kubebuilder:validation:Maximum=50
+	IntWithKubebuilderMaximum int64
+
+	// Missing limits
+	StringWithoutLimit string // want "field Limits.StringWithoutLimit must have a maximum length, add kubebuilder:validation:MaxLength marker"
+	ArrayWithoutLimit  []int  // want "field Limits.ArrayWithoutLimit must have a maximum items, add kubebuilder:validation:MaxItems marker"
+	MapWithoutLimit    map[string]string // want "field Limits.MapWithoutLimit must have a maximum number of properties, add kubebuilder:validation:MaxProperties marker"
+	IntWithoutLimit    int32 // want "field Limits.IntWithoutLimit must have a maximum value, add kubebuilder:validation:Maximum marker"
+}

--- a/pkg/analysis/maxlength/testdata/src/b/b.go
+++ b/pkg/analysis/maxlength/testdata/src/b/b.go
@@ -1,0 +1,18 @@
+package b
+
+type MaxLength struct {
+	// +k8s:maxLength=256
+	StringWithMaxLength string
+
+	StringWithoutMaxLength string // want "field MaxLength.StringWithoutMaxLength must have a maximum length, add k8s:maxLength marker"
+
+	// +k8s:maxItems=256
+	ArrayWithMaxItems []int
+
+	ArrayWithoutMaxItems []int // want "field MaxLength.ArrayWithoutMaxItems must have a maximum items, add k8s:maxItems marker"
+
+	// +k8s:maxLength=512
+	ByteSliceWithMaxLength []byte
+
+	ByteSliceWithoutMaxLength []byte // want "field MaxLength.ByteSliceWithoutMaxLength must have a maximum length, add k8s:maxLength marker"
+}

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -211,4 +211,13 @@ const (
 
 	// K8sDefaultMarker is the marker that indicates the default value for a field in k8s declarative validation.
 	K8sDefaultMarker = "k8s:default"
+
+	// K8sMinPropertiesMarker is the marker that indicates that a field has a minimum number of properties in k8s declarative validation.
+	K8sMinPropertiesMarker = "k8s:minProperties"
+
+	// K8sMaxPropertiesMarker is the marker that indicates that a field has a maximum number of properties in k8s declarative validation.
+	K8sMaxPropertiesMarker = "k8s:maxProperties"
+
+	// K8sMaxBytesMarker is the marker that indicates that a field has a maximum number of bytes in k8s declarative validation.
+	K8sMaxBytesMarker = "k8s:maxBytes"
 )


### PR DESCRIPTION
**What This PR does ?**

This PR extends the `maxlength` linter to support k8s declarative validation markers. 

The following markers are recognized-
- `+k8s:maxlength` - on string fields .
- `+k8s:maxItems` - on slice fields.
- `+k8s:enum`- fields and types marked with this are correctly exempted from max length checks.