### PR TITLE
wip: Add declarative validation tag support to minlength linter

### DIFF
--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -935,6 +935,37 @@ func (ms MarkerSet) HasWithArgumentsAndPayload(identifier string, arguments map[
 	return false
 }
 
+type PayloadFunc func(Payload) bool
+
+func (ms MarkerSet) HasWithPayloadFunc(identifier string, payloadFunc PayloadFunc) bool {
+	markers, ok := ms[identifier]
+	if !ok {
+		return false
+	}
+
+	for _, marker := range markers {
+		if payloadFunc(marker.Payload) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func WithMarkerIdentifier(identifier string) PayloadFunc {
+	return func(p Payload) bool {
+		if p.Marker == nil {
+			return false
+		}
+
+		if p.Marker.Identifier == identifier {
+			return true
+		}
+
+		return false
+	}
+}
+
 // Get returns the markers associated with the given identifier.
 // If no markers are found, an empty slice is returned.
 // The returned slice may contain multiple markers with the same identifier.

--- a/pkg/analysis/helpers/markers/analyzer_test.go
+++ b/pkg/analysis/helpers/markers/analyzer_test.go
@@ -371,6 +371,27 @@ func TestExtractMarker(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "simple declarative validation marker with chained marker",
+			comment: &ast.Comment{
+				Text: "// +k8s:eachVal=+k8s:minLength=1",
+			},
+			expected: Marker{
+				Type:       MarkerTypeDeclarativeValidation,
+				Identifier: "k8s:eachVal",
+				Arguments:  make(map[string]string),
+				Payload: Payload{
+					Marker: &Marker{
+						Type: MarkerTypeDeclarativeValidation,
+						Identifier: "k8s:minLength",
+						Arguments: make(map[string]string),
+						Payload: Payload{
+							Value: "1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/analysis/minlength/analyzer.go
+++ b/pkg/analysis/minlength/analyzer.go
@@ -32,37 +32,97 @@ const (
 	name = "minlength"
 )
 
-// Analyzer is the analyzer for the minlength package.
-// It checks that strings and arrays have minimum lengths and minimum items respectively.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "Checks that all strings formatted fields are marked with a minimum length, and that arrays are marked with min items, maps are marked with min properties, and structs that do not have required fields are marked with min properties",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspector.Analyzer},
+// NewAnalyzer creates a new analysis.Analyzer for the minlength
+// linter based on the provided MinLengthConfig
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		preferredSuggestionMarkerType: cfg.PreferredSuggestionMarkerType,
+	}
+
+	analyzer := &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that all strings formatted fields are marked with a minimum length, and that arrays are marked with min items, maps are marked with min properties, and structs that do not have required fields are marked with min properties",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+
+	return analyzer
 }
 
-func run(pass *analysis.Pass) (any, error) {
+func defaultConfig(cfg *Config) {
+	if cfg.PreferredSuggestionMarkerType == "" {
+		cfg.PreferredSuggestionMarkerType = PreferredSuggestionMarkerTypeKubebuilder
+	}
+}
+
+type analyzer struct {
+	preferredSuggestionMarkerType PreferredSuggestionMarkerType
+}
+
+type markerPreferences struct {
+	MinLengthMarker      string
+	MinPropertiesMarker  string
+	MinItemsMarker       string
+	ItemsMinLengthMarker string
+}
+
+func markerPreferencesForConfigType(markerType PreferredSuggestionMarkerType) markerPreferences {
+	switch markerType {
+	case PreferredSuggestionMarkerTypeKubebuilder:
+		return markerPreferences{
+			MinLengthMarker:      markers.KubebuilderMinLengthMarker,
+			MinPropertiesMarker:  markers.KubebuilderMinPropertiesMarker,
+			MinItemsMarker:       markers.KubebuilderMinItemsMarker,
+			ItemsMinLengthMarker: markers.KubebuilderItemsMinLengthMarker,
+		}
+	case PreferredSuggestionMarkerTypeDeclarativeValidation:
+		return markerPreferences{
+			MinLengthMarker: markers.K8sMinLengthMarker,
+			// TODO: This marker needs to be added to DV marker set
+			MinPropertiesMarker: markers.K8sMinPropertiesMarker,
+			// TODO: This marker needs to be added to DV marker set
+			MinItemsMarker:       markers.K8sMinItemsMarker,
+			ItemsMinLengthMarker: fmt.Sprintf("%s=+%s", markers.K8sEachValMarker, markers.K8sMinLengthMarker),
+		}
+	default:
+		// default to Kubebuilder markers for backwards compatibility
+		return markerPreferences{
+			MinLengthMarker:      markers.KubebuilderMinLengthMarker,
+			MinPropertiesMarker:  markers.KubebuilderMinPropertiesMarker,
+			MinItemsMarker:       markers.KubebuilderMinItemsMarker,
+			ItemsMinLengthMarker: markers.KubebuilderItemsMinLengthMarker,
+		}
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
 	if !ok {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
+		checkField(pass, field, markersAccess, qualifiedFieldName, markerPreferencesForConfigType(a.preferredSuggestionMarkerType))
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string, markerPreference markerPreferences) {
 	prefix := fmt.Sprintf("field %s", qualifiedFieldName)
 
-	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markers.KubebuilderMinLengthMarker, needsStringMinLength)
+	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markerPreference, needsStringMinLength)
 }
 
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences, needsMinLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		checkString(pass, ident, node, aliases, markersAccess, prefix, markerPreference.MinLengthMarker, needsMinLength)
 
 		return
 	}
@@ -72,7 +132,7 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 		return
 	}
 
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markerPreference, needsMinLength)
 }
 
 func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMinLength func(markershelper.MarkerSet) bool) {
@@ -87,7 +147,7 @@ func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases [
 	}
 }
 
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMinLength func(markershelper.MarkerSet) bool) {
+func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences, needsMinLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
 	}
@@ -95,53 +155,54 @@ func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, alia
 	typeName := tSpec.Name.Name
 	prefix = fmt.Sprintf("%s %s", prefix, typeName)
 
-	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMinLength)
+	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, markerPreference, needsMinLength)
 }
 
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMinLength func(markershelper.MarkerSet) bool) {
+func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences, needsMinLength func(markershelper.MarkerSet) bool) {
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
-		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMinLength)
+		checkIdent(pass, typ, node, aliases, markersAccess, prefix, markerPreference, needsMinLength)
 	case *ast.StarExpr:
-		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMinLength)
+		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, markerPreference, needsMinLength)
 	case *ast.ArrayType:
-		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+		checkArrayType(pass, typ, node, aliases, markersAccess, prefix, markerPreference)
 	case *ast.MapType:
-		checkMapType(pass, node, aliases, markersAccess, prefix)
+		checkMapType(pass, node, aliases, markersAccess, prefix, markerPreference)
 	case *ast.StructType:
-		checkStructType(pass, typ, node, aliases, markersAccess, prefix)
+		checkStructType(pass, typ, node, aliases, markersAccess, prefix, markerPreference)
 	}
 }
 
-func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
 			if ident.Name == "byte" {
 				// byte slices are a special case as they are treated as strings.
 				// Pretend the ident is a string so that checkString can process it as expected.
+				// TODO: is this true of DV validations?
 				i := &ast.Ident{
 					NamePos: ident.NamePos,
 					Name:    "string",
 				}
-				checkString(pass, i, node, aliases, markersAccess, prefix, markers.KubebuilderMinLengthMarker, needsStringMinLength)
+				checkString(pass, i, node, aliases, markersAccess, prefix, markerPreference.MinLengthMarker, needsStringMinLength)
 
 				return
 			}
 
-			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix), markerPreference)
 		}
 	}
 
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markerSet.Has(markers.KubebuilderMinItemsMarker) {
-		pass.Reportf(node.Pos(), "%s must have a minimum items, add %s marker", prefix, markers.KubebuilderMinItemsMarker)
+	if !markerSet.Has(markers.KubebuilderMinItemsMarker) && !markerSet.Has(markers.K8sMinItemsMarker) {
+		pass.Reportf(node.Pos(), "%s must have a minimum items, add %s marker", prefix, markerPreference.MinItemsMarker)
 	}
 }
 
-func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences) {
 	if ident.Obj == nil { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMinLengthMarker, needsItemsMinLength)
+		checkString(pass, ident, node, aliases, markersAccess, prefix, markerPreference.ItemsMinLengthMarker, needsItemsMinLength)
 
 		return
 	}
@@ -153,20 +214,20 @@ func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node
 
 	// If the array element wasn't directly a string, allow a string alias to be used
 	// with either the items style markers or the on alias style markers.
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMinLengthMarker, func(ms markershelper.MarkerSet) bool {
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markerPreference, func(ms markershelper.MarkerSet) bool {
 		return needsStringMinLength(ms) && needsItemsMinLength(ms)
 	})
 }
 
-func checkMapType(pass *analysis.Pass, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func checkMapType(pass *analysis.Pass, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences) {
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markerSet.Has(markers.KubebuilderMinPropertiesMarker) {
-		pass.Reportf(node.Pos(), "%s must have a minimum properties, add %s marker", prefix, markers.KubebuilderMinPropertiesMarker)
+	if !markerSet.Has(markers.KubebuilderMinPropertiesMarker) && !markerSet.Has(markers.K8sMinPropertiesMarker) {
+		pass.Reportf(node.Pos(), "%s must have a minimum properties, add %s marker", prefix, markerPreference.MinPropertiesMarker)
 	}
 }
 
-func checkStructType(pass *analysis.Pass, structType *ast.StructType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func checkStructType(pass *analysis.Pass, structType *ast.StructType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string, markerPreference markerPreferences) {
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
 	minProperties, err := utils.GetMinProperties(markerSet)
@@ -196,7 +257,7 @@ func checkStructType(pass *analysis.Pass, structType *ast.StructType, node ast.N
 	}
 
 	// The field does not have a min properties, and does not have any required fields.
-	pass.Reportf(node.Pos(), "%s must have a minimum properties, add %s marker", prefix, markers.KubebuilderMinPropertiesMarker)
+	pass.Reportf(node.Pos(), "%s must have a minimum properties, add %s marker", prefix, markerPreference.MinPropertiesMarker)
 }
 
 func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
@@ -222,31 +283,74 @@ func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelpe
 
 // needsMinLength returns true if the field needs a minimum length.
 // Fields do not need a minimum length if they are already marked with a minimum length,
-// or if they are an enum, or if they are a date, date-time or duration.
+// or if they are an enum, or if they are a format that already enforces a minimum length.
 func needsStringMinLength(markerSet markershelper.MarkerSet) bool {
-	switch {
-	case markerSet.Has(markers.KubebuilderMinLengthMarker),
-		markerSet.Has(markers.KubebuilderEnumMarker),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
-		return false
-	}
-
-	return true
+	return !hasKubebuilderMinLengthOrEquivalentMarker(markerSet) &&
+		!hasDeclarativeValidationMinLengthOrEquivalentMarker(markerSet)
 }
 
 func needsItemsMinLength(markerSet markershelper.MarkerSet) bool {
-	switch {
-	case markerSet.Has(markers.KubebuilderItemsMinLengthMarker),
-		markerSet.Has(markers.KubebuilderItemsEnumMarker),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
-		return false
+	return !hasKubebuilderItemsMinLengthOrEquivalentMarker(markerSet) &&
+		!hasDeclarativeEachValMinLengthOrEquivalentMarker(markerSet)
+}
+
+func hasKubebuilderMinLengthOrEquivalentMarker(markerSet markershelper.MarkerSet) bool {
+	if markerSet.Has(markers.KubebuilderMinLengthMarker) || markerSet.Has(markers.KubebuilderEnumMarker) {
+		return true
 	}
 
-	return true
+	for _, value := range knownKubebuilderMinimumLengthConstrainedFormats {
+		if markerSet.HasWithValue(kubebuilderFormatWithValue(value)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasKubebuilderItemsMinLengthOrEquivalentMarker(markerSet markershelper.MarkerSet) bool {
+	if markerSet.Has(markers.KubebuilderItemsMinLengthMarker) || markerSet.Has(markers.KubebuilderItemsEnumMarker) {
+		return true
+	}
+
+	for _, value := range knownKubebuilderMinimumLengthConstrainedFormats {
+		if markerSet.HasWithValue(kubebuilderItemsFormatWithValue(value)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasDeclarativeValidationMinLengthOrEquivalentMarker(markerSet markershelper.MarkerSet) bool {
+	if markerSet.Has(markers.K8sMinLengthMarker) || markerSet.Has(markers.K8sEnumMarker) {
+		return true
+	}
+
+	for _, value := range knownDeclarativeValidationMinimumLengthConstrainedFormats {
+		if markerSet.HasWithValue(fmt.Sprintf("%s=%s", markers.K8sFormatMarker, value)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasDeclarativeEachValMinLengthOrEquivalentMarker(markerSet markershelper.MarkerSet) bool {
+	if markerSet.HasWithPayloadFunc(markers.K8sEachValMarker, markershelper.WithMarkerIdentifier(markers.K8sMinLengthMarker)) ||
+		markerSet.HasWithPayloadFunc(markers.K8sEachValMarker, markershelper.WithMarkerIdentifier(markers.K8sEnumMarker)) {
+		return true
+	}
+
+	for _, value := range knownKubebuilderMinimumLengthConstrainedFormats {
+		formatMarker := fmt.Sprintf("%s=%s", markers.K8sFormatMarker, value)
+		if markerSet.HasWithValue(fmt.Sprintf("%s=+%s", markers.K8sEachValMarker, formatMarker)) {
+		
+			return true
+		}
+	}
+
+	return false
 }
 
 func kubebuilderFormatWithValue(value string) string {
@@ -255,4 +359,275 @@ func kubebuilderFormatWithValue(value string) string {
 
 func kubebuilderItemsFormatWithValue(value string) string {
 	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+}
+
+// knownKubebuilderMinimumLengthConstrainedFormats is a slice of the known
+// formats that have minimum length constraints associated
+// with them, specifically the formats supported by
+// https://github.com/kubernetes/kube-openapi/tree/master/pkg/validation/strfmt
+var knownKubebuilderMinimumLengthConstrainedFormats = []string{
+	// date is an RFC3339 date format and is processed by
+	// https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/date.go#L30
+	// An inherent minimum length is enforced by this format.
+	"date",
+
+	// date-time is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/time.go#L67
+	// which ensures an input adheres to one of RFC3339 micro, RFC3339 millis, RFC3339, RFC3339 nano, or ISO8601 local time formats.
+	// An inherent minimum length is enforced by these formats.
+	"date-time",
+
+	// duration is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/duration.go#L59
+	// which ensures that an input adheres to the format '{digits}{unit}', inherently
+	// enforcing a minimum length of 2 (i.e '1s').
+	"duration",
+
+	// bsonobjectid is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/bson.go#L28
+	// which ensures that an input is a valid hex string that is exactly 12 characters in length.
+	"bsonobjectid",
+
+	// uri is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L149
+	// which uses Golang's net/url.ParseRequestURI function to validate the input.
+	// net/url.ParseRequestURI does not accept an empty string as a valid input, inherently enforcing a minimum length.
+	"uri",
+
+	// email is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L152
+	// which uses Golang's net/mail.ParseAddress function to validate the input.
+	// net/mail.ParseAddress does not accept an emptry string as a valid input, inherently enforcing a minimum length.
+	"email",
+
+	// hostname is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L155
+	// which enforces that the input is a valid representation of an internet hostname as defined by RFC1034 section 3.1.
+	// This format inherently enforces a minimum length.
+	"hostname",
+
+	// ipv4 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L158
+	// which inherently enforces a minimum length.
+	"ipv4",
+
+	// ipv6 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L161
+	// which inherently enforces a minimum length.
+	"ipv6",
+
+	// cidr is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L164
+	// which inherently enforces a minimum length by validating the input against CIDR notation formats
+	// as defined by RFC 4632 and RFC 4291.
+	"cidr",
+
+	// mac is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L167
+	// which inherently enforces a minimum length via Golang's net.ParseMAC function.
+	"mac",
+
+	// uuid is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L170
+	// which ensures that the input is a valid UUID, inherently enforcing a minimum length.
+	"uuid",
+
+	// uuid3 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L173
+	// which ensures that the input is a valid UUID3, inherently enforcing a minimum length.
+	"uuid3",
+
+	// uuid4 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L176
+	// which ensures that the input is a valid UUID4, inherently enforcing a minimum length.
+	"uuid4",
+
+	// uuid5 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L179
+	// which ensures that the input is a valid UUID5, inherently enforcing a minimum length.
+	"uuid5",
+
+	// isbn is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L182
+	// which ensures that the input is either a valid ISBN10 or ISBN13 value, inherently enforcing a minimum length.
+	"isbn",
+
+	// isbn10 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L185
+	// which ensures that the input is a valid ISBN10, inherently enforcing a minimum length.
+	"isbn10",
+
+	// isbn13 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L188
+	// which ensures that the input is a valid ISBN13, inherently enforcing a minimum length.
+	"isbn13",
+
+	// creditcard is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L191
+	// which ensures that the input is a valid credit card number, inherently enforcing a minimum length.
+	"creditcard",
+
+	// ssn is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L194
+	// which ensures that the input is a valid social security number, inherently enforcing a minimum length.
+	"ssn",
+
+	// hexcolor is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L197
+	// which ensures that the input is a valid hexcolor, inherently enforcing a minimum length.
+	"hexcolor",
+
+	// rgbcolor is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L200
+	// which ensures that the input is a valid rgbcolor, inherently enforcing a minimum length.
+	"rgbcolor",
+
+	// byte is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L203
+	// which ensures that the input is a valid base64 string, inherently enforcing a minimum length.
+	"byte",
+
+	// k8s-short-name is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/kubernetes-extensions.go#L83
+	// which ensures that the input is a valid Kubernetes short name. This is a variant of RFC1123 DNS Label names with the exception that only
+	// lowercase letters are allowed.
+	// This inherently enforces a minimum length.
+	"k8s-short-name",
+
+	// k8s-long-name is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/kubernetes-extensions.go#L140
+	// which ensures that the input is a valid Kubernetes long name. This is a variant of RFC1123 DNS Subdomain names with the exception that only
+	// lowercase letters are allowed and there is no 63 character limit for each of the dot-separated DNS labels.
+	// This inherently enforces a minimum length.
+	"k8s-long-name",
+}
+
+// knownDeclarativeValidationMinimumLengthConstrainedFormats is a slice of the known
+// formats that have minimum length constraints associated
+// with them, specifically the formats supported by
+// https://github.com/kubernetes/kube-openapi/tree/master/pkg/validation/strfmt
+// For Kubernetes native types, they may or may not
+// have use cases for validating known OpenAPI spec formats.
+// For future usage as a replacement of the `kubebuilder:validation:Format` marker,
+// and supporting native types, this is a superset of knownKubebuilderMinimumLengthConstrainedFormats.
+var knownDeclarativeValidationMinimumLengthConstrainedFormats = []string{
+	// OpenAPI-available formats
+	// ---
+
+	// date is an RFC3339 date format and is processed by
+	// https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/date.go#L30
+	// An inherent minimum length is enforced by this format.
+	"date",
+
+	// date-time is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/time.go#L67
+	// which ensures an input adheres to one of RFC3339 micro, RFC3339 millis, RFC3339, RFC3339 nano, or ISO8601 local time formats.
+	// An inherent minimum length is enforced by these formats.
+	"date-time",
+
+	// duration is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/duration.go#L59
+	// which ensures that an input adheres to the format '{digits}{unit}', inherently
+	// enforcing a minimum length of 2 (i.e '1s').
+	"duration",
+
+	// bsonobjectid is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/bson.go#L28
+	// which ensures that an input is a valid hex string that is exactly 12 characters in length.
+	"bsonobjectid",
+
+	// uri is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L149
+	// which uses Golang's net/url.ParseRequestURI function to validate the input.
+	// net/url.ParseRequestURI does not accept an empty string as a valid input, inherently enforcing a minimum length.
+	"uri",
+
+	// email is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L152
+	// which uses Golang's net/mail.ParseAddress function to validate the input.
+	// net/mail.ParseAddress does not accept an emptry string as a valid input, inherently enforcing a minimum length.
+	"email",
+
+	// hostname is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L155
+	// which enforces that the input is a valid representation of an internet hostname as defined by RFC1034 section 3.1.
+	// This format inherently enforces a minimum length.
+	"hostname",
+
+	// ipv4 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L158
+	// which inherently enforces a minimum length.
+	"ipv4",
+
+	// ipv6 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L161
+	// which inherently enforces a minimum length.
+	"ipv6",
+
+	// cidr is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L164
+	// which inherently enforces a minimum length by validating the input against CIDR notation formats
+	// as defined by RFC 4632 and RFC 4291.
+	"cidr",
+
+	// mac is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L167
+	// which inherently enforces a minimum length via Golang's net.ParseMAC function.
+	"mac",
+
+	// uuid is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L170
+	// which ensures that the input is a valid UUID, inherently enforcing a minimum length.
+	"uuid",
+
+	// uuid3 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L173
+	// which ensures that the input is a valid UUID3, inherently enforcing a minimum length.
+	"uuid3",
+
+	// uuid4 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L176
+	// which ensures that the input is a valid UUID4, inherently enforcing a minimum length.
+	"uuid4",
+
+	// uuid5 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L179
+	// which ensures that the input is a valid UUID5, inherently enforcing a minimum length.
+	"uuid5",
+
+	// isbn is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L182
+	// which ensures that the input is either a valid ISBN10 or ISBN13 value, inherently enforcing a minimum length.
+	"isbn",
+
+	// isbn10 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L185
+	// which ensures that the input is a valid ISBN10, inherently enforcing a minimum length.
+	"isbn10",
+
+	// isbn13 is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L188
+	// which ensures that the input is a valid ISBN13, inherently enforcing a minimum length.
+	"isbn13",
+
+	// creditcard is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L191
+	// which ensures that the input is a valid credit card number, inherently enforcing a minimum length.
+	"creditcard",
+
+	// ssn is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L194
+	// which ensures that the input is a valid social security number, inherently enforcing a minimum length.
+	"ssn",
+
+	// hexcolor is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L197
+	// which ensures that the input is a valid hexcolor, inherently enforcing a minimum length.
+	"hexcolor",
+
+	// rgbcolor is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L200
+	// which ensures that the input is a valid rgbcolor, inherently enforcing a minimum length.
+	"rgbcolor",
+
+	// byte is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/default.go#L203
+	// which ensures that the input is a valid base64 string, inherently enforcing a minimum length.
+	"byte",
+
+	// k8s-short-name is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/kubernetes-extensions.go#L83
+	// which ensures that the input is a valid Kubernetes short name. This is a variant of RFC1123 DNS Label names with the exception that only
+	// lowercase letters are allowed.
+	// This inherently enforces a minimum length.
+	"k8s-short-name",
+
+	// k8s-long-name is processed by https://github.com/kubernetes/kube-openapi/blob/a19766b6e2d458320f2b3d4d14a6533a870fcaba/pkg/validation/strfmt/kubernetes-extensions.go#L140
+	// which ensures that the input is a valid Kubernetes long name. This is a variant of RFC1123 DNS Subdomain names with the exception that only
+	// lowercase letters are allowed and there is no 63 character limit for each of the dot-separated DNS labels.
+	// This inherently enforces a minimum length.
+	"k8s-long-name",
+
+	// Declarative Validation only formats
+	// ---
+
+	// k8s-extended-resource-name is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L216
+	// which ensures that the input is a valid Kubernetes extended resource name, inherently enforcing a minimum length.
+	"k8s-extended-resource-name",
+
+	// k8s-label-key is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L89
+	// which ensures that the input is a valid Kubernetes label key, inherently enforcing a minimum length.
+	"k8s-label-key",
+
+	// k8s-long-name-caseless is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L109
+	// which ensures that the input is a valid Kubernetes long name with case insensitivity, inherently enforcing a minimum length.
+	// Even though this format is deprecated, there may be existing native types that use this and we
+	// shouldn't require an explicit minimum length here if it is already enforced.
+	"k8s-long-name-caseless",
+
+	// k8s-resource-fully-qualified-name is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L285
+	// which ensures that the input is a fully qualified Kubernetes resource name, inherently enforcing a minimum length because it
+	// does not accept an empty value.
+	"k8s-resource-fully-qualified-name",
+
+	// k8s-resource-pool-name is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L184
+	// which ensures that the input is a fully qualified Kubernetes resource name, inherently enforcing a minimum length.
+	"k8s-resource-pool-name",
+
+	// k8s-uuid is processed by https://github.com/kubernetes/kubernetes/blob/23ea1ec286387f45f52e1189089bacc0702a00aa/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go#L157
+	// which ensures that the input is a valid Kubernetes UUID - which follows the 8-4-4-4-12 format, inherently enfrocing a minimum length of 36.
+	"k8s-uuid",
 }

--- a/pkg/analysis/minlength/analyzer_test.go
+++ b/pkg/analysis/minlength/analyzer_test.go
@@ -25,5 +25,23 @@ import (
 func TestMinLength(t *testing.T) {
 	testdata := analysistest.TestData()
 
-	analysistest.Run(t, testdata, minlength.Analyzer, "a")
+	analyzer, err := minlength.Initializer().Init(&minlength.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error initializing minlength linter: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "a")
+}
+
+func TestMinLengthDeclarativeValidation(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := minlength.Initializer().Init(&minlength.Config{
+		PreferredSuggestionMarkerType: minlength.PreferredSuggestionMarkerTypeDeclarativeValidation,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error initializing minlength linter: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "b")
 }

--- a/pkg/analysis/minlength/config.go
+++ b/pkg/analysis/minlength/config.go
@@ -1,0 +1,40 @@
+package minlength
+
+// Config is the set of configuration options
+// for the minlength linting rule.
+type Config struct {
+	// preferredSuggestionMarkerType is an optional
+	// field used to specify the marker style you prefer
+	// from suggestions made by the minlength linter.
+	//
+	// Allowed values are Kubebuilder, DeclarativeValidation and omitted.
+	//
+	// When set to Kubebuilder, the minlength linter will suggest the
+	// use of Kubebuilder-style minimum constraint markers in its suggestions.
+	// For example, `kubebuilder:validation:Minimum`.
+	//
+	// When set to DeclarativeValidation, the minlength linter will
+	// suggest the use of Declarative Validation-style minimum constraint markers
+	// in its suggestions.
+	// For example, `k8s:minimum`.
+	//
+	// When omitted, this defaults to Kubebuilder.
+	PreferredSuggestionMarkerType PreferredSuggestionMarkerType `json:"preferredSuggestionMarkerType,omitempty"`
+}
+
+// PreferredSuggestionMarkerType is a representation of the different
+// marker types that can be returned as part of the suggestions
+// for markers to add to a field/type.
+type PreferredSuggestionMarkerType string
+
+const (
+	// PreferredSuggestionMarkerTypeKubebuilder is used to tell
+	// the minlength linter that Kubebuilder-style markers are preferred
+	// for enforcing minimum constraints and should be used in suggestions.
+	PreferredSuggestionMarkerTypeKubebuilder PreferredSuggestionMarkerType = "Kubebuilder"
+
+	// PreferredSuggestionMarkerTypeDeclarativeValidation is used to tell
+	// the minlength linter that Declarative Validation-style markers are preferred
+	// for enforcing minimum constraints and should be used in suggestions.
+	PreferredSuggestionMarkerTypeDeclarativeValidation PreferredSuggestionMarkerType = "DeclarativeValidation"
+)

--- a/pkg/analysis/minlength/doc.go
+++ b/pkg/analysis/minlength/doc.go
@@ -45,5 +45,15 @@ For structs, the minimum number of fields can be set using the `kubebuilder:vali
 For arrays of strings, the minimum length of each string can be set using the `kubebuilder:validation:items:MinLength` tag,
 on the array field itself.
 Or, if the array uses a string type alias, the `kubebuilder:validation:MinLength` tag can be used on the alias.
+
+This linter suggests fixes and can be configured to prefer either Kubebuilder or Declarative Validation style
+markers in the suggestions that it makes. By default, this linter prefers Kubebuilder style validations.
+
+Configuration options:
+```yaml
+linterConfig:
+  minlength:
+    preferredSuggestionMarkerType: Kubebuilder || DeclarativeValidation
+```
 */
 package minlength

--- a/pkg/analysis/minlength/initializer.go
+++ b/pkg/analysis/minlength/initializer.go
@@ -16,6 +16,10 @@ limitations under the License.
 package minlength
 
 import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
 )
@@ -27,9 +31,30 @@ func init() {
 // Initializer returns the AnalyzerInitializer for this
 // Analyzer so that it can be added to the registry.
 func Initializer() initializer.AnalyzerInitializer {
-	return initializer.NewInitializer(
+	return initializer.NewConfigurableInitializer(
 		name,
-		Analyzer,
-		false, // For now, CRD only, and so not on by default.
+		initAnalyzer,
+		false, // No longer CRD only, but keeping as disabled-by-default for backwards compatibility because the default behavior is for CRD-based suggestions
+		validateConfig,
 	)
+}
+
+func initAnalyzer(c *Config) (*analysis.Analyzer, error) {
+	return newAnalyzer(c), nil
+}
+
+func validateConfig(c *Config, fldPath *field.Path) field.ErrorList {
+	if c == nil {
+		return field.ErrorList{}
+	}
+
+	errs := field.ErrorList{}
+
+	switch c.PreferredSuggestionMarkerType {
+	case "", PreferredSuggestionMarkerTypeKubebuilder, PreferredSuggestionMarkerTypeDeclarativeValidation:
+	default:
+		errs = append(errs, field.Invalid(fldPath.Child("preferredSuggestionMarkerType"), c.PreferredSuggestionMarkerType, fmt.Sprintf("must be one of %s, %s or omitted.", PreferredSuggestionMarkerTypeKubebuilder, PreferredSuggestionMarkerTypeDeclarativeValidation)))
+	}
+
+	return errs
 }

--- a/pkg/analysis/minlength/testdata/src/a/a.go
+++ b/pkg/analysis/minlength/testdata/src/a/a.go
@@ -110,7 +110,7 @@ type MinLength struct {
 
 	StructWithARequiredField StructWithARequiredField `json:"structWithARequiredField"`
 
-	StructWithExactlyOneOf StructWithARequiredField `json:"structWithExactlyOneOf"`
+	StructWithExactlyOneOf StructWithExactlyOneOf `json:"structWithExactlyOneOf"`
 
 	StructWithAtLeastOneOf StructWithAtLeastOneOf `json:"structWithAtLeastOneOf"`
 

--- a/pkg/analysis/minlength/testdata/src/b/a.go
+++ b/pkg/analysis/minlength/testdata/src/b/a.go
@@ -1,0 +1,169 @@
+package b
+
+type MinLength struct {
+	// +k8s:minLength=256
+	StringWithMinLength string
+
+	// +k8s:minLength=256
+	StringPointerWithMinLength *string
+
+	// +k8s:minLength=128
+	StringAliasWithMinLengthOnField StringAlias
+
+	StringAliasWithMinLengthOnAlias StringAliasWithMinLength
+
+	StringAliasFromAnotherFile StringAliasB // want "field MinLength.StringAliasFromAnotherFile type StringAliasB must have a minimum length, add k8s:minLength marker"
+
+	// +k8s:minLength=128
+	StringAliasFromAnotherFileWithMinLengthOnField StringAliasB
+
+	StringAliasWithMinLengthFromAnotherFile StringAliasWithMinLengthB
+
+	StringWithoutMinLength string // want "field MinLength.StringWithoutMinLength must have a minimum length, add k8s:minLength marker"
+
+	StringPointerWithoutMinLength *string // want "field MinLength.StringPointerWithoutMinLength must have a minimum length, add k8s:minLength marker"
+
+	StringAliasWithoutMinLength StringAlias // want "field MinLength.StringAliasWithoutMinLength type StringAlias must have a minimum length, add k8s:minLength marker"
+
+	// +k8s:enum
+	EnumString string
+
+	// +k8s:enum
+	EnumStringPointer *string
+
+	EnumStringAlias EnumStringAlias
+
+	// +k8s:format=duration
+	DurationFormat string
+
+	// +k8s:format=date-time
+	DateTimeFormat string
+
+	// +k8s:format=date
+	DateFormat string
+
+	// +k8s:minItems=256
+	ArrayWithMinItems []int
+
+	ArrayWithoutMinItems []int // want "field MinLength.ArrayWithoutMinItems must have a minimum items, add k8s:minItems marker"
+
+	ByteSlice []byte // want "field MinLength.ByteSlice must have a minimum length, add k8s:minLength marker"
+
+	// +k8s:minLength=512
+	ByteSliceWithMinLength []byte
+
+	ByteSliceAlias ByteSliceAlias // want "field MinLength.ByteSliceAlias type ByteSliceAlias must have a minimum length, add k8s:minLength marker"
+
+	// +k8s:minLength=512
+	ByteSliceAliasWithMinLength ByteSliceAlias
+
+	ByteSliceAliasWithMinLengthOnAlias ByteSliceAliasWithMinLength
+
+	// +k8s:minItems=128
+	StringArrayWithMinItemsWithoutMinElementLength []string // want "field MinLength.StringArrayWithMinItemsWithoutMinElementLength array element must have a minimum length, add k8s:eachVal=\\+k8s:minLength marker"
+
+	StringArrayWithoutMinItemsWithoutMinElementLength []string // want "field MinLength.StringArrayWithoutMinItemsWithoutMinElementLength must have a minimum items, add k8s:minItems marker" "field MinLength.StringArrayWithoutMinItemsWithoutMinElementLength array element must have a minimum length, add k8s:eachVal=\\+k8s:minLength marker"
+
+	// +k8s:minItems=64
+	// +k8s:eachVal=+k8s:minLength=64
+	StringArrayWithMinItemsAndMinElementLength []string
+
+	// +k8s:eachVal=+k8s:minLength=512
+	StringArrayWithoutMinItemsWithMinElementLength []string // want  "field MinLength.StringArrayWithoutMinItemsWithMinElementLength must have a minimum items, add k8s:minItems marker"
+
+	// +k8s:minItems=128
+	StringAliasArrayWithMinItemsWithoutMinElementLength []StringAlias // want "field MinLength.StringAliasArrayWithMinItemsWithoutMinElementLength array element type StringAlias must have a minimum length, add k8s:minLength marker"
+
+	StringAliasArrayWithoutMinItemsWithoutMinElementLength []StringAlias // want "field MinLength.StringAliasArrayWithoutMinItemsWithoutMinElementLength must have a minimum items, add k8s:minItems marker" "field MinLength.StringAliasArrayWithoutMinItemsWithoutMinElementLength array element type StringAlias must have a minimum length, add k8s:minLength marker"
+
+	// +k8s:minItems=64
+	// +k8s:eachVal=+k8s:minLength=64
+	StringAliasArrayWithMinItemsAndMinElementLength []StringAlias
+
+	// +k8s:eachVal=+k8s:minLength=512
+	StringAliasArrayWithoutMinItemsWithMinElementLength []StringAlias // want  "field MinLength.StringAliasArrayWithoutMinItemsWithMinElementLength must have a minimum items, add k8s:minItems marker"
+
+	// +k8s:minItems=64
+	StringAliasArrayWithMinItemsAndMinElementLengthOnAlias []StringAliasWithMinLength
+
+	StringAliasArrayWithoutMinItemsWithMinElementLengthOnAlias []StringAliasWithMinLength // want  "field MinLength.StringAliasArrayWithoutMinItemsWithMinElementLengthOnAlias must have a minimum items, add k8s:minItems marker"
+
+	InlineStruct struct { // want "field MinLength.InlineStruct must have a minimum properties, add k8s:minProperties marker"
+		// +k8s:minLength=256
+		StringWithMinLength string
+
+		StringWithoutMinLength string // want "field StringWithoutMinLength must have a minimum length, add k8s:minLength marker"
+	} `json:"inlineStruct"`
+
+	// +k8s:minProperties=1
+	InlineStructWithMinProperties struct{} `json:"inlineStructWithMinProperties"`
+
+	InlineStructWithARequiredField struct {
+		// +k8s:minLength=256
+		// +required
+		StringWithMinLength string
+	} `json:"inlineStructWithARequiredField`
+
+	StructWithoutMinProperties StructWithoutMinProperties `json:"structWithoutMinProperties` // want "field MinLength.StructWithoutMinProperties type StructWithoutMinProperties must have a minimum properties, add k8s:minProperties marker"
+
+	StructWithMinProperties StructWithMinProperties `json:"structWithMinProperties`
+
+	StructWithARequiredField StructWithARequiredField `json:"structWithARequiredField"`
+
+	StructWithExactlyOneOf StructWithARequiredField `json:"structWithExactlyOneOf"`
+
+	StructWithMalformedMinProperties StructWithMalformedMinProperties `json:"structWithMalformedMinProperties` // want "could not get min properties for struct: invalid format for minimum properties marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"abc\\\": invalid syntax"
+
+	// +k8s:minItems=1
+	StructArrayWithMinProperties []StructWithMinProperties `json:"structArrayWithMinProperties"`
+
+	// +k8s:minItems=1
+	StructArrayWithARequiredField []StructWithARequiredField `json:"structArrayWithARequiredField"`
+
+	// +k8s:minItems=1
+	StructArrayWithMalformedMinProperties []StructWithMalformedMinProperties `json:"structArrayWithMalformedMinProperties` // want "could not get min properties for struct: invalid format for minimum properties marker: error getting marker value: error converting value to number: strconv.ParseFloat: parsing \\\"abc\\\": invalid syntax"
+
+	// +k8s:minItems=1
+	StructArrayWithoutMinProperties []StructWithoutMinProperties `json:"structArrayWithoutMinProperties` // want "field MinLength.StructArrayWithoutMinProperties array element type StructWithoutMinProperties must have a minimum properties, add k8s:minProperties marker"
+}
+
+// StringAlias is a string without a MinLength.
+type StringAlias string
+
+// StringAliasWithMinLength is a string with a MinLength.
+// +k8s:minLength=512
+type StringAliasWithMinLength string
+
+// EnumStringAlias is a string alias that is an enum.
+// +k8s:enum
+type EnumStringAlias string
+
+// ByteSliceAlias is a byte slice without a MinLength.
+type ByteSliceAlias []byte
+
+// ByteSliceAliasWithMinLength is a byte slice with a MinLength.
+// +k8s:minLength=512
+type ByteSliceAliasWithMinLength []byte
+
+type StructWithoutMinProperties struct {
+	// +k8s:minLength=256
+	StringWithMinLength string
+}
+
+// +k8s:minProperties=1
+type StructWithMinProperties struct {
+	// +k8s:minLength=256
+	StringWithMinLength string
+}
+
+type StructWithARequiredField struct {
+	// +k8s:minLength=256
+	// +required
+	StringWithMinLength string
+}
+
+// +k8s:minProperties=abc
+type StructWithMalformedMinProperties struct {
+	// +k8s:minLength=256
+	StringWithMinLength string
+}

--- a/pkg/analysis/minlength/testdata/src/b/b.go
+++ b/pkg/analysis/minlength/testdata/src/b/b.go
@@ -1,0 +1,8 @@
+package b
+
+// StringAliasB is a string without a MinLength.
+type StringAliasB string
+
+// StringAliasWithMinLengthB is a string with a MinLength.
+// +k8s:minLength=512
+type StringAliasWithMinLengthB string

--- a/pkg/analysis/minlength/testdata/src/b/maps.go
+++ b/pkg/analysis/minlength/testdata/src/b/maps.go
@@ -1,0 +1,25 @@
+package b
+
+type Maps struct {
+	// +k8s:minProperties=1
+	InlineMapWithMinProperties map[string]string `json:"inlineMapWithMinProperties"`
+
+	InlineMapWithoutMinProperties map[string]string `json:"inlineMapWithoutMinProperties"` // want "field Maps.InlineMapWithoutMinProperties must have a minimum properties, add k8s:minProperties marker"
+
+	// +k8s:minProperties=0
+	InlineMapWithMinPropertiesZero map[string]string `json:"inlineMapWithMinPropertiesZero"`
+
+	MapWithMinProperties MapWithMinProperties `json:"mapWithMinProperties"`
+
+	MapWithoutMinProperties MapWithoutMinProperties `json:"mapWithoutMinProperties"` // want "field Maps.MapWithoutMinProperties type MapWithoutMinProperties must have a minimum properties, add k8s:minProperties marker"
+
+	MapWithMinPropertiesZero MapWithMinPropertiesZero `json:"mapWithMinPropertiesZero"`
+}
+
+// +k8s:minProperties=0
+type MapWithMinProperties map[string]string
+
+type MapWithoutMinProperties map[string]string
+
+// +k8s:minProperties=0
+type MapWithMinPropertiesZero map[string]string

--- a/pkg/analysis/utils/utils.go
+++ b/pkg/analysis/utils/utils.go
@@ -462,9 +462,25 @@ func isTypeBasic(t types.Type) bool {
 // It returns a nil value when the marker is not present, and an error
 // when the marker is present, but malformed.
 func GetMinProperties(markerSet markershelper.MarkerSet) (*int, error) {
-	minProperties, err := getMarkerNumericValueByName[int](markerSet, markers.KubebuilderMinPropertiesMarker)
-	if err != nil && !errors.Is(err, errMarkerMissingValue) {
-		return nil, fmt.Errorf("invalid format for minimum properties marker: %w", err)
+	minPropertyMarkers := []string{
+		markers.K8sMinPropertiesMarker,
+		markers.KubebuilderMinPropertiesMarker,
+	}
+
+	var minProperties *int
+	for _, marker := range minPropertyMarkers {
+		minProps, err := getMarkerNumericValueByName[int](markerSet, marker)
+		if err != nil && errors.Is(err, errMarkerNotFound) {
+			// try the next minProperties marker
+			continue
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("invalid format for minimum properties marker: %w", err)
+		}
+
+		minProperties = minProps
+		break
 	}
 
 	return minProperties, nil

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -33,6 +33,7 @@ import (
 
 var (
 	errMarkerMissingValue = errors.New("marker does not have a value")
+	errMarkerNotFound     = errors.New("marker not found in marker set")
 )
 
 // IsZeroValueValid determines whether the zero value of the field is valid per the validation markers.
@@ -130,7 +131,7 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 		zeroValueValid = false
 	}
 
-	var completeStructValidation = true
+	completeStructValidation := true
 	if minProperties == nil && nonOmittedFields == 0 {
 		// If the struct has no non-omitted fields, then the zero value of the struct is `{}`.
 		// This generally means that the validation is incomplete as the difference between omitting the field and not omitting is not clear.
@@ -310,7 +311,7 @@ func isNumericZeroValueValid[N number](pass *analysis.Pass, field *ast.Field, ma
 func getMarkerNumericValueByName[N number](marker markershelper.MarkerSet, markerName string) (*N, error) {
 	markerList := marker.Get(markerName)
 	if len(markerList) == 0 {
-		return nil, errMarkerMissingValue
+		return nil, errMarkerNotFound
 	}
 
 	markerValue, err := getMarkerNumericValue[N](markerList[0])

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -188,6 +188,9 @@ const (
 	// K8sMaxItemsMarker is the marker that indicates that a field has a maximum number of items in k8s declarative validation.
 	K8sMaxItemsMarker = "k8s:maxItems"
 
+	// K8sMinPropertiesMarker is the marker that indicates that a field has a minimum number of properties in k8s declarative validation.
+	K8sMinPropertiesMarker = "k8s:minProperties"
+
 	// K8sEnumMarker is the marker that indicates that a field has an enum in k8s declarative validation.
 	K8sEnumMarker = "k8s:enum"
 
@@ -211,4 +214,7 @@ const (
 
 	// K8sDefaultMarker is the marker that indicates the default value for a field in k8s declarative validation.
 	K8sDefaultMarker = "k8s:default"
+
+	// K8sEachValMarker is the marker that indicates a validation for each entry in a map (specifically values, not keys) or list.
+	K8sEachValMarker = "k8s:eachVal"
 )


### PR DESCRIPTION
## Description

Adds declarative validation tag support to the `minlength` linter, making it usable in kubernetes/kubernetes

In order to support changing the suggestion messages output by this linter, a new configuration knob was added that can be used to select preference of suggested marker types.

Keeping as a WIP/Draft as there have been some markers that I've identified as needing to be added to DV to support the use cases handled by this linter still and some additional work to get this PR mergeable (some of the changes here broke other things that I haven't had time yet to fix).

Fixes #225  