### PR TITLE
fix(jsontags): enforce camelCase field-name to json-tag match

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -445,6 +445,8 @@ The `jsontags` linter checks that all fields in the API types have a `json` tag,
 The `json` tag for a field within a Kubernetes API type should use a camel case version of the field name.
 
 The `jsontags` linter checks the tag name against the regex `"^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$"` which allows consecutive upper case characters, to allow for acronyms, e.g. `requestTTL`.
+Optionally, the linter can also validate that the `json` tag name matches the camelCase version of the Go field name.
+This matching check uses identifier word-splitting heuristics and can be disabled when a project intentionally uses different casing.
 
 ### Configuration
 
@@ -452,6 +454,7 @@ The `jsontags` linter checks the tag name against the regex `"^[a-z][a-z0-9]*(?:
 lintersConfig:
   jsontags:
     jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # Provide a custom regex, which the json tag must match.
+    fieldNameMatch: SuggestFix | Warn | Ignore # Check whether json tag names must match camelCase field names. Defaults to Ignore.
 ```
 
 ## MaxLength

--- a/pkg/analysis/jsontags/analyzer.go
+++ b/pkg/analysis/jsontags/analyzer.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"go/ast"
 	"regexp"
+	"slices"
+	"strings"
+	"unicode"
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
@@ -35,7 +38,8 @@ const (
 )
 
 type analyzer struct {
-	jsonTagRegex *regexp.Regexp
+	jsonTagRegex   *regexp.Regexp
+	fieldNameMatch FieldNameMatchPolicy
 }
 
 // newAnalyzer creates a new analyzer with the given json tag regex.
@@ -52,7 +56,8 @@ func newAnalyzer(cfg *JSONTagsConfig) (*analysis.Analyzer, error) {
 	}
 
 	a := &analyzer{
-		jsonTagRegex: jsonTagRegex,
+		jsonTagRegex:   jsonTagRegex,
+		fieldNameMatch: cfg.FieldNameMatch,
 	}
 
 	return &analysis.Analyzer{
@@ -98,9 +103,50 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, tagInfo ext
 		return
 	}
 
-	matched := a.jsonTagRegex.Match([]byte(tagInfo.Name))
-	if !matched {
+	if !a.jsonTagRegex.MatchString(tagInfo.Name) {
 		pass.Reportf(field.Pos(), "%s json tag does not match pattern %q: %s", prefix, a.jsonTagRegex.String(), tagInfo.Name)
+	}
+
+	a.checkFieldNameMatch(pass, field, tagInfo, prefix)
+}
+
+func (a *analyzer) checkFieldNameMatch(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo, prefix string) {
+	if len(field.Names) == 0 || field.Names[0] == nil {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+	if jsonTagMatchesFieldName(fieldName, tagInfo.Name) {
+		return
+	}
+
+	expectedTagName := expectedJSONTagName(fieldName)
+	message := fmt.Sprintf("%s json tag should match the camelCase field name %q: got %q", prefix, expectedTagName, tagInfo.Name)
+
+	switch a.fieldNameMatch {
+	case FieldNameMatchPolicyIgnore:
+		return
+	case FieldNameMatchPolicyWarn:
+		pass.Reportf(field.Pos(), "%s", message)
+	case FieldNameMatchPolicySuggestFix:
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			Message: message,
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: fmt.Sprintf("replace json tag name with %q", expectedTagName),
+					TextEdits: []analysis.TextEdit{
+						{
+							Pos:     tagInfo.Pos,
+							End:     tagInfo.End,
+							NewText: []byte(strings.Replace(tagInfo.RawValue, tagInfo.Name, expectedTagName, 1)),
+						},
+					},
+				},
+			},
+		})
+	default:
+		panic(fmt.Sprintf("unknown field name match policy: %s", a.fieldNameMatch))
 	}
 }
 
@@ -108,4 +154,88 @@ func defaultConfig(cfg *JSONTagsConfig) {
 	if cfg.JSONTagRegex == "" {
 		cfg.JSONTagRegex = camelCaseRegex
 	}
+
+	if cfg.FieldNameMatch == "" {
+		cfg.FieldNameMatch = FieldNameMatchPolicyIgnore
+	}
+}
+
+func expectedJSONTagName(fieldName string) string {
+	words := splitIdentifierWords(fieldName)
+	if len(words) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	b.WriteString(words[0])
+	for _, word := range words[1:] {
+		r := []rune(word)
+		if len(r) == 0 {
+			continue
+		}
+
+		r[0] = unicode.ToUpper(r[0])
+		b.WriteString(string(r))
+	}
+
+	return b.String()
+}
+
+func jsonTagMatchesFieldName(fieldName, jsonTagName string) bool {
+	return slices.Equal(splitIdentifierWords(fieldName), splitIdentifierWords(jsonTagName))
+}
+
+func splitIdentifierWords(in string) []string {
+	if in == "" {
+		return nil
+	}
+
+	runes := []rune(in)
+	words := []string{}
+	start := 0
+
+	appendWord := func(end int) {
+		if end <= start {
+			return
+		}
+
+		words = append(words, strings.ToLower(string(runes[start:end])))
+	}
+
+	for i := 1; i < len(runes); i++ {
+		prev := runes[i-1]
+		curr := runes[i]
+
+		var next rune
+		hasNext := i+1 < len(runes)
+		if hasNext {
+			next = runes[i+1]
+		}
+
+		boundary := false
+		switch {
+		case unicode.IsLower(prev) && unicode.IsUpper(curr):
+			boundary = true
+		case unicode.IsLetter(prev) && unicode.IsDigit(curr):
+			boundary = true
+		case unicode.IsDigit(prev) && unicode.IsUpper(curr):
+			boundary = true
+		case unicode.IsUpper(prev) && unicode.IsUpper(curr) && hasNext && unicode.IsLower(next) && i-start > 1:
+			// Keep pluralized acronyms together: WWIDs -> wwids, WWIDsBad -> wwidsBad, URLs -> urls.
+			pluralizedAcronym := next == 's' && (i+2 == len(runes) || unicode.IsUpper(runes[i+2]))
+			boundary = !pluralizedAcronym
+		}
+
+		if !boundary {
+			continue
+		}
+
+		appendWord(i)
+		start = i
+	}
+
+	appendWord(len(runes))
+
+	return words
 }

--- a/pkg/analysis/jsontags/analyzer_test.go
+++ b/pkg/analysis/jsontags/analyzer_test.go
@@ -30,7 +30,7 @@ func TestDefaultConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	analysistest.Run(t, testdata, a, "a")
+	analysistest.Run(t, testdata, a, "a", "c")
 }
 
 func TestAlternativeRegex(t *testing.T) {
@@ -44,4 +44,43 @@ func TestAlternativeRegex(t *testing.T) {
 	}
 
 	analysistest.Run(t, testdata, a, "b")
+}
+
+func TestFieldNameMatchIgnored(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := jsontags.Initializer().Init(&jsontags.JSONTagsConfig{
+		FieldNameMatch: jsontags.FieldNameMatchPolicyIgnore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.Run(t, testdata, a, "c")
+}
+
+func TestFieldNameMatchWarn(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := jsontags.Initializer().Init(&jsontags.JSONTagsConfig{
+		FieldNameMatch: jsontags.FieldNameMatchPolicyWarn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.Run(t, testdata, a, "d", "e")
+}
+
+func TestFieldNameMatchSuggestFixSuggestedFixes(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := jsontags.Initializer().Init(&jsontags.JSONTagsConfig{
+		FieldNameMatch: jsontags.FieldNameMatchPolicySuggestFix,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, a, "d")
 }

--- a/pkg/analysis/jsontags/config.go
+++ b/pkg/analysis/jsontags/config.go
@@ -15,10 +15,36 @@ limitations under the License.
 */
 package jsontags
 
+// FieldNameMatchPolicy controls whether json tag names must match the camelCase field name.
+type FieldNameMatchPolicy string
+
+const (
+	// FieldNameMatchPolicySuggestFix emits diagnostics and suggests fixes when a json
+	// tag name does not match the expected camelCase version of the Go field name.
+	FieldNameMatchPolicySuggestFix FieldNameMatchPolicy = "SuggestFix"
+
+	// FieldNameMatchPolicyWarn emits diagnostics when a json tag name does not match
+	// the expected camelCase version of the Go field name.
+	FieldNameMatchPolicyWarn FieldNameMatchPolicy = "Warn"
+
+	// FieldNameMatchPolicyIgnore disables the field-name matching check.
+	FieldNameMatchPolicyIgnore FieldNameMatchPolicy = "Ignore"
+)
+
 // JSONTagsConfig contains configuration for the jsontags linter.
 type JSONTagsConfig struct {
 	// jsonTagRegex is the regular expression used to validate that json tags are in a particular format.
 	// By default, the regex used is "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" and is used to check for
 	// camel case like string.
 	JSONTagRegex string `json:"jsonTagRegex"`
+
+	// fieldNameMatch controls whether json tag names must match the camelCase
+	// version of their Go field name.
+	// The check uses word-splitting heuristics to preserve common acronyms and initialisms.
+	// Valid values are "SuggestFix", "Warn" and "Ignore".
+	// When set to "SuggestFix", diagnostics are emitted for mismatches and a fix is suggested.
+	// When set to "Warn", diagnostics are emitted for mismatches.
+	// When set to "Ignore", this check is disabled.
+	// When otherwise not specified, the default value is "Ignore".
+	FieldNameMatch FieldNameMatchPolicy `json:"fieldNameMatch"`
 }

--- a/pkg/analysis/jsontags/doc.go
+++ b/pkg/analysis/jsontags/doc.go
@@ -27,5 +27,10 @@ to allow, for example, for fields like `requestTTLSeconds`.
 
 To disallow consecutive capital letters, the regex can be set to `^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]+)*$`.
 The regex can be configured with the JSONTagRegex field in the JSONTagsConfig struct.
+
+The linter can also check that the json tag name matches the camelCase version of
+the Go field name by setting the FieldNameMatch field to "SuggestFix" or "Warn".
+This check uses identifier word-splitting heuristics and can be disabled by
+setting FieldNameMatch to "Ignore".
 */
 package jsontags

--- a/pkg/analysis/jsontags/initializer.go
+++ b/pkg/analysis/jsontags/initializer.go
@@ -58,5 +58,15 @@ func validateConfig(jtc *JSONTagsConfig, fldPath *field.Path) field.ErrorList {
 		}
 	}
 
+	switch jtc.FieldNameMatch {
+	case "", FieldNameMatchPolicySuggestFix, FieldNameMatchPolicyWarn, FieldNameMatchPolicyIgnore:
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(
+			fldPath.Child("fieldNameMatch"),
+			jtc.FieldNameMatch,
+			fmt.Sprintf("invalid value, must be one of %q, %q, %q or omitted", FieldNameMatchPolicySuggestFix, FieldNameMatchPolicyWarn, FieldNameMatchPolicyIgnore),
+		))
+	}
+
 	return fieldErrors
 }

--- a/pkg/analysis/jsontags/initializer_test.go
+++ b/pkg/analysis/jsontags/initializer_test.go
@@ -50,6 +50,24 @@ var _ = Describe("jsontags initializer", func() {
 				},
 				expectedErr: "",
 			}),
+			Entry("With a valid JSONTagsConfig FieldNameMatch", testCase{
+				config: jsontags.JSONTagsConfig{
+					FieldNameMatch: jsontags.FieldNameMatchPolicyWarn,
+				},
+				expectedErr: "",
+			}),
+			Entry("With a valid JSONTagsConfig FieldNameMatch SuggestFix", testCase{
+				config: jsontags.JSONTagsConfig{
+					FieldNameMatch: jsontags.FieldNameMatchPolicySuggestFix,
+				},
+				expectedErr: "",
+			}),
+			Entry("With an invalid JSONTagsConfig FieldNameMatch", testCase{
+				config: jsontags.JSONTagsConfig{
+					FieldNameMatch: "Invalid",
+				},
+				expectedErr: "jsontags.fieldNameMatch: Invalid value: \"Invalid\": invalid value, must be one of \"SuggestFix\", \"Warn\", \"Ignore\" or omitted",
+			}),
 			Entry("With an invalid JSONTagsConfig JSONTagRegex", testCase{
 				config: jsontags.JSONTagsConfig{
 					JSONTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*",

--- a/pkg/analysis/jsontags/testdata/src/c/c.go
+++ b/pkg/analysis/jsontags/testdata/src/c/c.go
@@ -1,0 +1,6 @@
+package c
+
+type JSONTagMismatchAllowed struct {
+	ID     string `json:"vmID,omitempty"`
+	IPAddr string `json:"vmIp,omitempty"`
+}

--- a/pkg/analysis/jsontags/testdata/src/d/d.go
+++ b/pkg/analysis/jsontags/testdata/src/d/d.go
@@ -1,0 +1,12 @@
+package d
+
+type JSONTagMismatch struct {
+	ID             string   `json:"vmID,omitempty"` // want "field JSONTagMismatch.ID json tag should match the camelCase field name \"id\": got \"vmID\""
+	IPAddr         string   `json:"vmIp,omitempty"` // want "field JSONTagMismatch.IPAddr json tag should match the camelCase field name \"ipAddr\": got \"vmIp\""
+	IPv6Address    string   `json:"ipv6Address,omitempty"`
+	IPv6AddressBad string   `json:"ipv6addressBad,omitempty"` // want "field JSONTagMismatch.IPv6AddressBad json tag should match the camelCase field name \"ipv6AddressBad\": got \"ipv6addressBad\""
+	WWIDs          []string `json:"wwids,omitempty"`
+	WWIDsBad       []string `json:"wwiDs,omitempty"` // want "field JSONTagMismatch.WWIDsBad json tag should match the camelCase field name \"wwidsBad\": got \"wwiDs\""
+	URLs           []string `json:"urls,omitempty"`
+	URLsBad        []string `json:"urLs,omitempty"` // want "field JSONTagMismatch.URLsBad json tag should match the camelCase field name \"urlsBad\": got \"urLs\""
+}

--- a/pkg/analysis/jsontags/testdata/src/d/d.go.golden
+++ b/pkg/analysis/jsontags/testdata/src/d/d.go.golden
@@ -1,0 +1,12 @@
+package d
+
+type JSONTagMismatch struct {
+	ID             string   `json:"id,omitempty"`     // want "field JSONTagMismatch.ID json tag should match the camelCase field name \"id\": got \"vmID\""
+	IPAddr         string   `json:"ipAddr,omitempty"` // want "field JSONTagMismatch.IPAddr json tag should match the camelCase field name \"ipAddr\": got \"vmIp\""
+	IPv6Address    string   `json:"ipv6Address,omitempty"`
+	IPv6AddressBad string   `json:"ipv6AddressBad,omitempty"` // want "field JSONTagMismatch.IPv6AddressBad json tag should match the camelCase field name \"ipv6AddressBad\": got \"ipv6addressBad\""
+	WWIDs          []string `json:"wwids,omitempty"`
+	WWIDsBad       []string `json:"wwidsBad,omitempty"` // want "field JSONTagMismatch.WWIDsBad json tag should match the camelCase field name \"wwidsBad\": got \"wwiDs\""
+	URLs           []string `json:"urls,omitempty"`
+	URLsBad        []string `json:"urlsBad,omitempty"` // want "field JSONTagMismatch.URLsBad json tag should match the camelCase field name \"urlsBad\": got \"urLs\""
+}

--- a/pkg/analysis/jsontags/testdata/src/e/e.go
+++ b/pkg/analysis/jsontags/testdata/src/e/e.go
@@ -1,0 +1,5 @@
+package e
+
+type JSONTagRegexAndFieldNameMismatch struct {
+	FieldName string `json:"field_name,omitempty"` // want "json tag does not match pattern" "field JSONTagRegexAndFieldNameMismatch.FieldName json tag should match the camelCase field name \"fieldName\": got \"field_name\""
+}


### PR DESCRIPTION
## What this PR does

Fixes `jsontags` so it validates that the `json` tag name matches the camelCase form of the Go field name (not just regex format).

Fixes: https://github.com/kubernetes-sigs/kube-api-linter/issues/214

## Changes

- Added field-name/tag matching in `jsontags` analyzer.
- Added config option:
  - `lintersConfig.jsontags.fieldNameMatch: Warn | Ignore`
  - default is `Warn`.
- Added config validation for `fieldNameMatch`.
- Updated docs for `jsontags`.
- Added/updated test coverage for:
  - default behavior (`Warn`)
  - opt-out behavior (`Ignore`)
  - acronym/initialism-safe matching behavior.
