### PR TITLE
Add discriminated unions structure linter

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -9,6 +9,7 @@
 | [DefaultOrRequired](#defaultorrequired) | Ensures fields marked as required do not have default values | True | Native, CRD |
 | [Defaults](#defaults) | Checks that fields with default markers are configured correctly | True | Native, CRD |
 | [DependentTags](#dependenttags) | Enforces dependencies between markers | False | Native, CRD |
+| [DiscriminatedUnions](#discriminatedunions) | Validates discriminated union marker structure | False | Native, CRD |
 | [DuplicateMarkers](#duplicatemarkers) | Checks for exact duplicates of markers | True | Native, CRD |
 | [ForbiddenMarkers](#forbiddenmarkers) | Checks that no forbidden markers are present on types/fields. | False | Native, CRD |
 | [Integers](#integers) | Validates usage of supported integer types | True | Native, CRD |
@@ -137,6 +138,33 @@ This linter only checks for the presence or absence of markers; it does not insp
 - **Values:** The linter does not care about the values of the `identifier` or `dependent` markers. It only verifies if the markers themselves are present.
 - **Fixes:** This linter does not provide automatic fixes. It only reports violations.
 - **Same/Different Values:** Whether you want the same or different values between dependent markers is outside the scope of this linter. You would need other validation mechanisms (e.g., CEL validation) to enforce value-based dependencies.
+
+## DiscriminatedUnions
+
+The `discriminatedunions` linter validates discriminated union definitions across legacy markers (`+union`, `+unionDiscriminator`, `+unionMember`) and declarative markers (`+k8s:unionDiscriminator`, `+k8s:unionMember`).
+Union detection is triggered when a struct has either:
+- A type-level `+union` marker.
+- One or more union field markers (`+unionDiscriminator`/`+unionMember` or `+k8s:unionDiscriminator`/`+k8s:unionMember`).
+
+The linter enforces:
+
+- Exactly one discriminator field.
+- A required discriminator field.
+- Optional member fields (including support for `+unionMember,optional`).
+- Optional forbidding of non-member fields.
+
+### Configuration
+
+```yaml
+lintersConfig:
+  discriminatedunions:
+    nonMemberFields: Forbid | Allow # Defaults to `Forbid`.
+```
+
+### Behavior
+
+- **Default:** Disabled by default; enable explicitly.
+- **Scope:** Structure-only validation in this linter implementation.
 
 ## CommentStart
 

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -9,6 +9,7 @@
 | [DefaultOrRequired](#defaultorrequired) | Ensures fields marked as required do not have default values | True | Native, CRD |
 | [Defaults](#defaults) | Checks that fields with default markers are configured correctly | True | Native, CRD |
 | [DependentTags](#dependenttags) | Enforces dependencies between markers | False | Native, CRD |
+| [DiscriminatedUnions](#discriminatedunions) | Validates discriminated union marker structure | False | Native, CRD |
 | [DuplicateMarkers](#duplicatemarkers) | Checks for exact duplicates of markers | True | Native, CRD |
 | [ForbiddenMarkers](#forbiddenmarkers) | Checks that no forbidden markers are present on types/fields. | False | Native, CRD |
 | [Integers](#integers) | Validates usage of supported integer types | True | Native, CRD |
@@ -137,6 +138,38 @@ This linter only checks for the presence or absence of markers; it does not insp
 - **Values:** The linter does not care about the values of the `identifier` or `dependent` markers. It only verifies if the markers themselves are present.
 - **Fixes:** This linter does not provide automatic fixes. It only reports violations.
 - **Same/Different Values:** Whether you want the same or different values between dependent markers is outside the scope of this linter. You would need other validation mechanisms (e.g., CEL validation) to enforce value-based dependencies.
+
+## DiscriminatedUnions
+
+The `discriminatedunions` linter validates discriminated union definitions across legacy markers (`+union`, `+unionDiscriminator`, `+unionMember`) and declarative markers (`+k8s:unionDiscriminator`, `+k8s:unionMember`).
+Union detection is triggered when a struct has either:
+- A type-level `+union` marker.
+- One or more union field markers (`+unionDiscriminator`/`+unionMember` or `+k8s:unionDiscriminator`/`+k8s:unionMember`).
+
+The linter enforces:
+
+- Exactly one discriminator field.
+- A required discriminator field.
+- Member fields marked optional.
+- Optional forbidding of non-member fields.
+
+The legacy `+unionMember,optional` marker is union membership metadata. It does not replace field optionality markers such as `+optional` or `+k8s:optional`.
+Diagnostics for missing optional markers recommend the configured `preferredOptionalMarker`.
+Declarative union markers do not have a type-level `+k8s:union` marker; declarative unions are detected from `+k8s:unionDiscriminator` and `+k8s:unionMember` field markers.
+
+### Configuration
+
+```yaml
+lintersConfig:
+  discriminatedunions:
+    nonMemberFields: Forbid | Allow # Defaults to `Forbid`.
+    preferredOptionalMarker: optional # optional | kubebuilder:validation:Optional | k8s:optional
+```
+
+### Behavior
+
+- **Default:** Disabled by default; enable explicitly.
+- **Scope:** Structure-only validation in this linter implementation.
 
 ## CommentStart
 

--- a/pkg/analysis/discriminatedunions/analyzer.go
+++ b/pkg/analysis/discriminatedunions/analyzer.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+import (
+	"go/ast"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	inspectorhelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	markersconsts "sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+const name = "discriminatedunions"
+
+func init() {
+	markershelper.DefaultRegistry().Register(
+		markersconsts.UnionMarker,
+		markersconsts.UnionDiscriminatorMarker,
+		markersconsts.UnionMemberMarker,
+		markersconsts.K8sUnionDiscriminatorMarker,
+		markersconsts.K8sUnionMemberMarker,
+		markersconsts.OptionalMarker,
+		markersconsts.KubebuilderOptionalMarker,
+		markersconsts.K8sOptionalMarker,
+		markersconsts.RequiredMarker,
+		markersconsts.KubebuilderRequiredMarker,
+		markersconsts.K8sRequiredMarker,
+	)
+}
+
+type analyzer struct {
+	nonMemberFields NonMemberFieldsPolicy
+}
+
+type unionType struct {
+	typeSpec *ast.TypeSpec
+	name     string
+
+	hasUnionMarker bool
+
+	discriminatorFields []*unionField
+	memberFields        []*unionField
+	nonMemberFields     []*unionField
+}
+
+type unionField struct {
+	field         *ast.Field
+	qualifiedName string
+
+	required bool
+	optional bool
+
+	isDiscriminator      bool
+	isMember             bool
+	memberOptionalMarker bool
+}
+
+type unionFieldClassification struct {
+	isDiscriminator  bool
+	isMember         bool
+	isMemberOptional bool
+}
+
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		nonMemberFields: cfg.NonMemberFields,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Validates discriminated-union marker structure.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspectorhelper.Analyzer},
+	}
+}
+
+func defaultConfig(cfg *Config) {
+	if cfg.NonMemberFields == "" {
+		cfg.NonMemberFields = NonMemberFieldsForbid
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspectorhelper.Analyzer].(inspectorhelper.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	fieldInfos := make(map[*ast.Field]*unionField)
+
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
+		fieldInfos[field] = buildUnionFieldInfo(field, markersAccess, qualifiedFieldName)
+	})
+
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
+		union := buildUnionType(typeSpec, markersAccess, fieldInfos)
+		if union == nil {
+			return
+		}
+
+		a.reportStructureViolations(pass, union)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func buildUnionType(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers, fieldInfos map[*ast.Field]*unionField) *unionType {
+	if typeSpec == nil || typeSpec.Name == nil {
+		return nil
+	}
+
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if !ok || structType.Fields == nil {
+		return nil
+	}
+
+	structMarkers := markersAccess.StructMarkers(structType)
+
+	union := &unionType{
+		typeSpec:       typeSpec,
+		name:           typeSpec.Name.Name,
+		hasUnionMarker: structMarkers.Has(markersconsts.UnionMarker),
+	}
+
+	for _, field := range structType.Fields.List {
+		unionFieldInfo, ok := fieldInfos[field]
+		if !ok {
+			continue
+		}
+
+		addUnionField(union, unionFieldInfo)
+	}
+
+	if !union.hasUnionMarker && len(union.discriminatorFields) == 0 && len(union.memberFields) == 0 {
+		return nil
+	}
+
+	return union
+}
+
+func (a *analyzer) reportStructureViolations(pass *analysis.Pass, union *unionType) {
+	if union == nil {
+		return
+	}
+
+	reportDiscriminatorViolations(pass, union)
+	reportMissingMemberViolations(pass, union)
+	reportMemberOptionalityViolations(pass, union)
+	a.reportNonMemberFieldViolations(pass, union)
+}
+
+func buildUnionFieldInfo(field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) *unionField {
+	if field == nil {
+		return nil
+	}
+
+	fieldMarkers := markersAccess.FieldMarkers(field)
+	classification := classifyUnionField(fieldMarkers)
+
+	return &unionField{
+		field:                field,
+		qualifiedName:        qualifiedFieldName,
+		required:             utils.IsFieldRequired(field, markersAccess),
+		optional:             utils.IsFieldOptional(field, markersAccess),
+		isDiscriminator:      classification.isDiscriminator,
+		isMember:             classification.isMember,
+		memberOptionalMarker: classification.isMemberOptional,
+	}
+}
+
+func addUnionField(union *unionType, field *unionField) {
+	if union == nil || field == nil {
+		return
+	}
+
+	if field.isDiscriminator {
+		union.discriminatorFields = append(union.discriminatorFields, field)
+	}
+
+	if field.isMember {
+		union.memberFields = append(union.memberFields, field)
+	}
+
+	if !field.isDiscriminator && !field.isMember {
+		union.nonMemberFields = append(union.nonMemberFields, field)
+	}
+}
+
+func reportDiscriminatorViolations(pass *analysis.Pass, union *unionType) {
+	switch len(union.discriminatorFields) {
+	case 0:
+		pass.Reportf(
+			union.typeSpec.Pos(),
+			"type %s is marked as a discriminated union but has no discriminator field; expected exactly one field with +%s or +%s",
+			union.name,
+			markersconsts.UnionDiscriminatorMarker,
+			markersconsts.K8sUnionDiscriminatorMarker,
+		)
+	case 1:
+		discriminator := union.discriminatorFields[0]
+		if !discriminator.required {
+			pass.Reportf(discriminator.field.Pos(), "discriminator field %s must be marked as required", discriminator.qualifiedName)
+		}
+	default:
+		discriminatorNames := make([]string, 0, len(union.discriminatorFields))
+		for _, field := range union.discriminatorFields {
+			discriminatorNames = append(discriminatorNames, field.qualifiedName)
+		}
+
+		pass.Reportf(
+			union.typeSpec.Pos(),
+			"type %s is marked as a discriminated union but has %d discriminator fields; expected exactly one: %s",
+			union.name,
+			len(union.discriminatorFields),
+			strings.Join(discriminatorNames, ", "),
+		)
+	}
+}
+
+func reportMissingMemberViolations(pass *analysis.Pass, union *unionType) {
+	if len(union.memberFields) == 0 {
+		pass.Reportf(union.typeSpec.Pos(), "type %s is marked as a discriminated union but has no union member fields", union.name)
+	}
+}
+
+func reportMemberOptionalityViolations(pass *analysis.Pass, union *unionType) {
+	for _, member := range union.memberFields {
+		if member.optional || member.memberOptionalMarker {
+			continue
+		}
+
+		pass.Reportf(
+			member.field.Pos(),
+			"union member field %s must be marked as optional (use +optional/+k8s:optional or +%s,optional)",
+			member.qualifiedName,
+			markersconsts.UnionMemberMarker,
+		)
+	}
+}
+
+func (a *analyzer) reportNonMemberFieldViolations(pass *analysis.Pass, union *unionType) {
+	if a.nonMemberFields != NonMemberFieldsForbid {
+		return
+	}
+
+	for _, field := range union.nonMemberFields {
+		pass.Reportf(
+			field.field.Pos(),
+			"field %s is not a union discriminator/member in union type %s (non-member fields are forbidden)",
+			field.qualifiedName,
+			union.name,
+		)
+	}
+}
+
+func classifyUnionField(fieldMarkers markershelper.MarkerSet) unionFieldClassification {
+	classification := unionFieldClassification{
+		isDiscriminator: fieldMarkers.Has(markersconsts.UnionDiscriminatorMarker) ||
+			fieldMarkers.Has(markersconsts.K8sUnionDiscriminatorMarker),
+		isMember: fieldMarkers.Has(markersconsts.UnionMemberMarker) || fieldMarkers.Has(markersconsts.K8sUnionMemberMarker),
+	}
+
+	if !classification.isMember {
+		return classification
+	}
+
+	classification.isMemberOptional = slices.ContainsFunc(fieldMarkers.Get(markersconsts.UnionMemberMarker), markerSpecifiesOptionalMember) ||
+		slices.ContainsFunc(fieldMarkers.Get(markersconsts.K8sUnionMemberMarker), markerSpecifiesOptionalMember)
+
+	return classification
+}
+
+func markerSpecifiesOptionalMember(marker markershelper.Marker) bool {
+	value, ok := marker.Arguments[markershelper.UnnamedArgument]
+	if !ok {
+		return false
+	}
+
+	return strings.TrimSpace(strings.Trim(value, `"'`)) == markersconsts.OptionalMarker
+}

--- a/pkg/analysis/discriminatedunions/analyzer.go
+++ b/pkg/analysis/discriminatedunions/analyzer.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+import (
+	"go/ast"
+	"slices"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	inspectorhelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	markersconsts "sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+const (
+	name = "discriminatedunions"
+
+	defaultUnionKey = ""
+	unionArgument   = "union"
+)
+
+func init() {
+	markershelper.DefaultRegistry().Register(
+		markersconsts.UnionMarker,
+		markersconsts.UnionDiscriminatorMarker,
+		markersconsts.UnionMemberMarker,
+		markersconsts.K8sUnionDiscriminatorMarker,
+		markersconsts.K8sUnionMemberMarker,
+		markersconsts.OptionalMarker,
+		markersconsts.KubebuilderOptionalMarker,
+		markersconsts.K8sOptionalMarker,
+		markersconsts.RequiredMarker,
+		markersconsts.KubebuilderRequiredMarker,
+		markersconsts.K8sRequiredMarker,
+	)
+}
+
+type analyzer struct {
+	nonMemberFields         NonMemberFieldsPolicy
+	preferredOptionalMarker string
+}
+
+type unionType struct {
+	typeSpec *ast.TypeSpec
+	name     string
+	key      string
+
+	hasUnionMarker bool
+
+	discriminatorFields []unionField
+	memberFields        []unionField
+	nonMemberFields     []unionField
+}
+
+type unionField struct {
+	field         *ast.Field
+	qualifiedName string
+
+	required bool
+	optional bool
+
+	discriminatorKeys []string
+	memberKeys        []string
+}
+
+type unionFieldClassification struct {
+	discriminatorKeys []string
+	memberKeys        []string
+}
+
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		nonMemberFields:         cfg.NonMemberFields,
+		preferredOptionalMarker: cfg.PreferredOptionalMarker,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Validates that discriminated unions have one required discriminator field, optional union member fields, and no non-member fields when configured to forbid them.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspectorhelper.Analyzer},
+	}
+}
+
+func defaultConfig(cfg *Config) {
+	if cfg.NonMemberFields == "" {
+		cfg.NonMemberFields = NonMemberFieldsForbid
+	}
+
+	if cfg.PreferredOptionalMarker == "" {
+		cfg.PreferredOptionalMarker = markersconsts.OptionalMarker
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspectorhelper.Analyzer].(inspectorhelper.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	fieldInfos := make(map[*ast.Field]unionField)
+
+	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
+		fieldInfos[field] = buildUnionFieldInfo(field, markersAccess, qualifiedFieldName)
+	})
+
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
+		unions := buildUnionTypes(typeSpec, markersAccess, fieldInfos)
+		if len(unions) == 0 {
+			return
+		}
+
+		for _, union := range unions {
+			a.reportStructureViolations(pass, &union)
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func buildUnionTypes(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers, fieldInfos map[*ast.Field]unionField) []unionType {
+	if typeSpec == nil || typeSpec.Name == nil {
+		return nil
+	}
+
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if !ok || structType.Fields == nil {
+		return nil
+	}
+
+	structMarkers := markersAccess.StructMarkers(structType)
+	hasUnionMarker := structMarkers.Has(markersconsts.UnionMarker)
+	unionsByKey, getUnion := newUnionTypeCollector(typeSpec, hasUnionMarker)
+	nonMemberFields := collectUnionFields(structType, fieldInfos, getUnion)
+
+	if !hasUnionMarker && len(unionsByKey) == 0 {
+		return nil
+	}
+
+	if len(unionsByKey) == 0 {
+		getUnion(defaultUnionKey)
+	}
+
+	return sortedUnionTypes(unionsByKey, nonMemberFields)
+}
+
+func newUnionTypeCollector(typeSpec *ast.TypeSpec, hasUnionMarker bool) (map[string]*unionType, func(string) *unionType) {
+	unionsByKey := map[string]*unionType{}
+
+	return unionsByKey, func(key string) *unionType {
+		if union, ok := unionsByKey[key]; ok {
+			return union
+		}
+
+		union := &unionType{
+			typeSpec:       typeSpec,
+			name:           typeSpec.Name.Name,
+			key:            key,
+			hasUnionMarker: hasUnionMarker,
+		}
+
+		unionsByKey[key] = union
+
+		return union
+	}
+}
+
+func collectUnionFields(structType *ast.StructType, fieldInfos map[*ast.Field]unionField, getUnion func(string) *unionType) []unionField {
+	nonMemberFields := []unionField{}
+
+	for _, field := range structType.Fields.List {
+		unionFieldInfo, ok := fieldInfos[field]
+		if !ok {
+			continue
+		}
+
+		addUnionField(getUnion, unionFieldInfo)
+
+		if !unionFieldInfo.hasUnionRole() {
+			nonMemberFields = append(nonMemberFields, unionFieldInfo)
+		}
+	}
+
+	return nonMemberFields
+}
+
+func sortedUnionTypes(unionsByKey map[string]*unionType, nonMemberFields []unionField) []unionType {
+	unionKeys := make([]string, 0, len(unionsByKey))
+	for key := range unionsByKey {
+		unionKeys = append(unionKeys, key)
+	}
+
+	slices.Sort(unionKeys)
+
+	unions := make([]unionType, 0, len(unionKeys))
+
+	for i, key := range unionKeys {
+		union := *unionsByKey[key]
+		if i == 0 {
+			union.nonMemberFields = nonMemberFields
+		}
+
+		unions = append(unions, union)
+	}
+
+	return unions
+}
+
+func (a *analyzer) reportStructureViolations(pass *analysis.Pass, union *unionType) {
+	if union == nil {
+		return
+	}
+
+	reportDiscriminatorViolations(pass, union)
+	a.reportMemberOptionalityViolations(pass, union)
+	a.reportNonMemberFieldViolations(pass, union)
+}
+
+func buildUnionFieldInfo(field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) unionField {
+	if field == nil {
+		return unionField{}
+	}
+
+	fieldMarkers := markersAccess.FieldMarkers(field)
+	classification := classifyUnionField(fieldMarkers)
+
+	return unionField{
+		field:             field,
+		qualifiedName:     qualifiedFieldName,
+		required:          utils.IsFieldRequired(field, markersAccess),
+		optional:          utils.IsFieldOptional(field, markersAccess),
+		discriminatorKeys: classification.discriminatorKeys,
+		memberKeys:        classification.memberKeys,
+	}
+}
+
+func addUnionField(getUnion func(string) *unionType, field unionField) {
+	if field.field == nil {
+		return
+	}
+
+	for _, key := range field.discriminatorKeys {
+		union := getUnion(key)
+		union.discriminatorFields = append(union.discriminatorFields, field)
+	}
+
+	for _, key := range field.memberKeys {
+		union := getUnion(key)
+		union.memberFields = append(union.memberFields, field)
+	}
+}
+
+func reportDiscriminatorViolations(pass *analysis.Pass, union *unionType) {
+	switch len(union.discriminatorFields) {
+	case 0:
+		pass.Reportf(
+			union.typeSpec.Pos(),
+			"%s is marked as a discriminated union but has no discriminator field; expected exactly one field with +%s or +%s",
+			describeUnion(union),
+			markersconsts.UnionDiscriminatorMarker,
+			markersconsts.K8sUnionDiscriminatorMarker,
+		)
+	case 1:
+		discriminator := union.discriminatorFields[0]
+		if !discriminator.required {
+			pass.Reportf(discriminator.field.Pos(), "discriminator field %s must be marked as required", discriminator.qualifiedName)
+		}
+	default:
+		discriminatorNames := make([]string, 0, len(union.discriminatorFields))
+		for _, field := range union.discriminatorFields {
+			discriminatorNames = append(discriminatorNames, field.qualifiedName)
+		}
+
+		pass.Reportf(
+			union.typeSpec.Pos(),
+			"%s is marked as a discriminated union but has %d discriminator fields; expected exactly one: %s",
+			describeUnion(union),
+			len(union.discriminatorFields),
+			strings.Join(discriminatorNames, ", "),
+		)
+	}
+}
+
+func (a *analyzer) reportMemberOptionalityViolations(pass *analysis.Pass, union *unionType) {
+	for _, member := range union.memberFields {
+		if member.optional {
+			continue
+		}
+
+		pass.Reportf(
+			member.field.Pos(),
+			"union member field %s must be marked as optional (use +%s)",
+			member.qualifiedName,
+			a.preferredOptionalMarker,
+		)
+	}
+}
+
+func (a *analyzer) reportNonMemberFieldViolations(pass *analysis.Pass, union *unionType) {
+	if a.nonMemberFields != NonMemberFieldsForbid {
+		return
+	}
+
+	for _, field := range union.nonMemberFields {
+		pass.Reportf(
+			field.field.Pos(),
+			"field %s is not a union discriminator/member in union type %s (non-member fields are forbidden)",
+			field.qualifiedName,
+			union.name,
+		)
+	}
+}
+
+func classifyUnionField(fieldMarkers markershelper.MarkerSet) unionFieldClassification {
+	classification := unionFieldClassification{}
+
+	if fieldMarkers.Has(markersconsts.UnionDiscriminatorMarker) {
+		classification.discriminatorKeys = append(classification.discriminatorKeys, defaultUnionKey)
+	}
+
+	for _, marker := range fieldMarkers.Get(markersconsts.K8sUnionDiscriminatorMarker) {
+		classification.discriminatorKeys = appendUnionKey(classification.discriminatorKeys, unionKey(marker))
+	}
+
+	if fieldMarkers.Has(markersconsts.UnionMemberMarker) {
+		classification.memberKeys = append(classification.memberKeys, defaultUnionKey)
+	}
+
+	for _, marker := range fieldMarkers.Get(markersconsts.K8sUnionMemberMarker) {
+		classification.memberKeys = appendUnionKey(classification.memberKeys, unionKey(marker))
+	}
+
+	return classification
+}
+
+func (f unionField) hasUnionRole() bool {
+	return len(f.discriminatorKeys) > 0 || len(f.memberKeys) > 0
+}
+
+func unionKey(marker markershelper.Marker) string {
+	return marker.Arguments[unionArgument]
+}
+
+func appendUnionKey(keys []string, key string) []string {
+	if slices.Contains(keys, key) {
+		return keys
+	}
+
+	return append(keys, key)
+}
+
+func describeUnion(union *unionType) string {
+	if union.key == defaultUnionKey {
+		return "type " + union.name
+	}
+
+	return "union " + strconv.Quote(union.key) + " in type " + union.name
+}

--- a/pkg/analysis/discriminatedunions/analyzer_test.go
+++ b/pkg/analysis/discriminatedunions/analyzer_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/discriminatedunions"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := discriminatedunions.Initializer().Init(&discriminatedunions.Config{})
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "a")
+}
+
+func TestAnalyzerAllowNonMemberFields(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := discriminatedunions.Initializer().Init(&discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsAllow})
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "b")
+}

--- a/pkg/analysis/discriminatedunions/analyzer_test.go
+++ b/pkg/analysis/discriminatedunions/analyzer_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/discriminatedunions"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := discriminatedunions.Initializer().Init(&discriminatedunions.Config{})
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "a")
+}
+
+func TestAnalyzerAllowNonMemberFields(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := discriminatedunions.Initializer().Init(&discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsAllow})
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "b")
+}
+
+func TestAnalyzerPreferredOptionalMarker(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	analyzer, err := discriminatedunions.Initializer().Init(&discriminatedunions.Config{PreferredOptionalMarker: markers.K8sOptionalMarker})
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer: %v", err)
+	}
+
+	analysistest.Run(t, testdata, analyzer, "c")
+}

--- a/pkg/analysis/discriminatedunions/config.go
+++ b/pkg/analysis/discriminatedunions/config.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+// NonMemberFieldsPolicy controls how non-member fields are handled on union types.
+type NonMemberFieldsPolicy string
+
+const (
+	// NonMemberFieldsForbid reports non-member fields on union types.
+	NonMemberFieldsForbid NonMemberFieldsPolicy = "Forbid"
+	// NonMemberFieldsAllow allows non-member fields on union types.
+	NonMemberFieldsAllow NonMemberFieldsPolicy = "Allow"
+)
+
+// Config contains the configuration for the discriminatedunions linter.
+type Config struct {
+	// NonMemberFields defines how fields that are neither discriminator nor member are handled.
+	NonMemberFields NonMemberFieldsPolicy `json:"nonMemberFields"`
+}

--- a/pkg/analysis/discriminatedunions/config.go
+++ b/pkg/analysis/discriminatedunions/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+// NonMemberFieldsPolicy controls how fields with no union marker are handled on union types.
+type NonMemberFieldsPolicy string
+
+const (
+	// NonMemberFieldsForbid reports fields that are not union discriminators or union members.
+	NonMemberFieldsForbid NonMemberFieldsPolicy = "Forbid"
+
+	// NonMemberFieldsAllow permits fields that are not union discriminators or union members.
+	NonMemberFieldsAllow NonMemberFieldsPolicy = "Allow"
+)
+
+// Config contains the configuration for the discriminatedunions linter.
+type Config struct {
+	// NonMemberFields defines how fields that are neither discriminator nor member are handled.
+	// Valid values are "Forbid" and "Allow".
+	// When set to "Forbid", the linter reports fields without union markers on union types.
+	// When set to "Allow", non-member fields are permitted.
+	// When otherwise not specified, the default value is "Forbid".
+	NonMemberFields NonMemberFieldsPolicy `json:"nonMemberFields"`
+
+	// PreferredOptionalMarker is the marker this linter recommends when union members are not marked optional.
+	// Valid values are "optional", "kubebuilder:validation:Optional", and "k8s:optional".
+	// When otherwise not specified, the default value is "optional".
+	PreferredOptionalMarker string `json:"preferredOptionalMarker"`
+}

--- a/pkg/analysis/discriminatedunions/discriminatedunions_suite_test.go
+++ b/pkg/analysis/discriminatedunions/discriminatedunions_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDiscriminatedUnions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DiscriminatedUnions Suite")
+}

--- a/pkg/analysis/discriminatedunions/doc.go
+++ b/pkg/analysis/discriminatedunions/doc.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package discriminatedunions validates discriminated-union marker usage.
+//
+// This linter detects union types using either legacy markers (`+union`,
+// `+unionDiscriminator`, `+unionMember`) or declarative markers
+// (`+k8s:unionDiscriminator`, `+k8s:unionMember`). Union detection is triggered
+// by either a type-level `+union` marker or union field markers on the struct.
+//
+// It enforces:
+//   - Exactly one discriminator field per union type.
+//   - Discriminator fields are required.
+//   - Member fields are marked optional (or use `+unionMember,optional`).
+//   - Optional forbidding of non-member fields on union types.
+package discriminatedunions

--- a/pkg/analysis/discriminatedunions/doc.go
+++ b/pkg/analysis/discriminatedunions/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package discriminatedunions validates discriminated-union marker usage.
+//
+// This linter detects union types using either legacy markers (`+union`,
+// `+unionDiscriminator`, `+unionMember`) or declarative markers
+// (`+k8s:unionDiscriminator`, `+k8s:unionMember`). Union detection is triggered
+// by either a type-level `+union` marker or union field markers on the struct.
+//
+// It enforces:
+//   - Exactly one discriminator field per union type.
+//   - Discriminator fields are required.
+//   - Member fields are marked optional with an optional marker.
+//   - Optional forbidding of non-member fields on union types.
+//
+// The legacy `+unionMember,optional` marker is treated as union membership
+// metadata and does not replace field optionality markers such as `+optional`
+// or `+k8s:optional`.
+package discriminatedunions

--- a/pkg/analysis/discriminatedunions/initializer.go
+++ b/pkg/analysis/discriminatedunions/initializer.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this Analyzer so it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewConfigurableInitializer(
+		name,
+		initAnalyzer,
+		false,
+		validateConfig,
+	)
+}
+
+func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{}
+	}
+
+	fieldErrors := field.ErrorList{}
+
+	switch cfg.NonMemberFields {
+	case "", NonMemberFieldsForbid, NonMemberFieldsAllow:
+		// valid
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(
+			fldPath.Child("nonMemberFields"),
+			cfg.NonMemberFields,
+			fmt.Sprintf("invalid value, must be one of %q, %q or omitted", NonMemberFieldsForbid, NonMemberFieldsAllow),
+		))
+	}
+
+	return fieldErrors
+}

--- a/pkg/analysis/discriminatedunions/initializer.go
+++ b/pkg/analysis/discriminatedunions/initializer.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this Analyzer so it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewConfigurableInitializer(
+		name,
+		initAnalyzer,
+		false,
+		validateConfig,
+	)
+}
+
+func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{}
+	}
+
+	fieldErrors := field.ErrorList{}
+
+	switch cfg.NonMemberFields {
+	case "", NonMemberFieldsForbid, NonMemberFieldsAllow:
+		// valid
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(
+			fldPath.Child("nonMemberFields"),
+			cfg.NonMemberFields,
+			fmt.Sprintf("invalid value, must be one of %q, %q or omitted", NonMemberFieldsForbid, NonMemberFieldsAllow),
+		))
+	}
+
+	switch cfg.PreferredOptionalMarker {
+	case "", markers.OptionalMarker, markers.KubebuilderOptionalMarker, markers.K8sOptionalMarker:
+		// valid
+	default:
+		fieldErrors = append(fieldErrors, field.Invalid(
+			fldPath.Child("preferredOptionalMarker"),
+			cfg.PreferredOptionalMarker,
+			fmt.Sprintf("invalid value, must be one of %q, %q, %q or omitted", markers.OptionalMarker, markers.KubebuilderOptionalMarker, markers.K8sOptionalMarker),
+		))
+	}
+
+	return fieldErrors
+}

--- a/pkg/analysis/discriminatedunions/initializer_test.go
+++ b/pkg/analysis/discriminatedunions/initializer_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/discriminatedunions"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+)
+
+var _ = Describe("discriminatedunions initializer", func() {
+	Context("config validation", func() {
+		type testCase struct {
+			config      discriminatedunions.Config
+			expectedErr string
+		}
+
+		DescribeTable("should validate the provided config", func(in testCase) {
+			ci, ok := discriminatedunions.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+			Expect(ok).To(BeTrue())
+
+			errs := ci.ValidateConfig(&in.config, field.NewPath("discriminatedunions"))
+
+			if len(in.expectedErr) > 0 {
+				Expect(errs.ToAggregate()).To(MatchError(in.expectedErr))
+			} else {
+				Expect(errs).To(HaveLen(0), "No errors were expected")
+			}
+		},
+			Entry("with default config", testCase{
+				config:      discriminatedunions.Config{},
+				expectedErr: "",
+			}),
+			Entry("with explicit Forbid", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsForbid},
+				expectedErr: "",
+			}),
+			Entry("with explicit Allow", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsAllow},
+				expectedErr: "",
+			}),
+			Entry("with invalid policy", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: "invalid"},
+				expectedErr: "discriminatedunions.nonMemberFields: Invalid value: \"invalid\": invalid value, must be one of \"Forbid\", \"Allow\" or omitted",
+			}),
+		)
+	})
+})

--- a/pkg/analysis/discriminatedunions/initializer_test.go
+++ b/pkg/analysis/discriminatedunions/initializer_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discriminatedunions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/discriminatedunions"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+var _ = Describe("discriminatedunions initializer", func() {
+	Context("config validation", func() {
+		type testCase struct {
+			config      discriminatedunions.Config
+			expectedErr string
+		}
+
+		DescribeTable("should validate the provided config", func(in testCase) {
+			ci, ok := discriminatedunions.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+			Expect(ok).To(BeTrue())
+
+			errs := ci.ValidateConfig(&in.config, field.NewPath("discriminatedunions"))
+
+			if len(in.expectedErr) > 0 {
+				Expect(errs.ToAggregate()).To(MatchError(in.expectedErr))
+			} else {
+				Expect(errs).To(HaveLen(0), "No errors were expected")
+			}
+		},
+			Entry("with default config", testCase{
+				config:      discriminatedunions.Config{},
+				expectedErr: "",
+			}),
+			Entry("with explicit Forbid", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsForbid},
+				expectedErr: "",
+			}),
+			Entry("with explicit Allow", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: discriminatedunions.NonMemberFieldsAllow},
+				expectedErr: "",
+			}),
+			Entry("with explicit optional marker preference", testCase{
+				config:      discriminatedunions.Config{PreferredOptionalMarker: markers.OptionalMarker},
+				expectedErr: "",
+			}),
+			Entry("with explicit kubebuilder optional marker preference", testCase{
+				config:      discriminatedunions.Config{PreferredOptionalMarker: markers.KubebuilderOptionalMarker},
+				expectedErr: "",
+			}),
+			Entry("with explicit k8s optional marker preference", testCase{
+				config:      discriminatedunions.Config{PreferredOptionalMarker: markers.K8sOptionalMarker},
+				expectedErr: "",
+			}),
+			Entry("with invalid policy", testCase{
+				config:      discriminatedunions.Config{NonMemberFields: "invalid"},
+				expectedErr: "discriminatedunions.nonMemberFields: Invalid value: \"invalid\": invalid value, must be one of \"Forbid\", \"Allow\" or omitted",
+			}),
+			Entry("with invalid optional marker preference", testCase{
+				config:      discriminatedunions.Config{PreferredOptionalMarker: "invalid"},
+				expectedErr: "discriminatedunions.preferredOptionalMarker: Invalid value: \"invalid\": invalid value, must be one of \"optional\", \"kubebuilder:validation:Optional\", \"k8s:optional\" or omitted",
+			}),
+		)
+	})
+})

--- a/pkg/analysis/discriminatedunions/testdata/src/a/a.go
+++ b/pkg/analysis/discriminatedunions/testdata/src/a/a.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package a
+
+// +union
+type ValidLegacyUnion struct {
+	// +unionDiscriminator
+	// +required
+	Type string `json:"type"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type ValidLegacyUnionOptionalMember struct {
+	// +unionDiscriminator
+	// +required
+	Type string `json:"type"`
+
+	// +unionMember,optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type ValidDeclarativeUnion struct {
+	// +k8s:unionDiscriminator
+	// +k8s:required
+	Type string `json:"type"`
+
+	// +k8s:unionMember
+	// +k8s:optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type MissingDiscriminatorUnion struct { // want "type MissingDiscriminatorUnion is marked as a discriminated union but has no discriminator field"
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type MultipleDiscriminatorUnion struct { // want "type MultipleDiscriminatorUnion is marked as a discriminated union but has 2 discriminator fields"
+	// +unionDiscriminator
+	// +required
+	One string `json:"one"`
+
+	// +unionDiscriminator
+	// +required
+	Two string `json:"two"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type DiscriminatorNotRequiredUnion struct {
+	// +unionDiscriminator
+	Kind string `json:"kind"` // want "discriminator field DiscriminatorNotRequiredUnion.Kind must be marked as required"
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type MemberNotOptionalUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	Foo *string `json:"foo,omitempty"` // want "union member field MemberNotOptionalUnion.Foo must be marked as optional"
+}
+
+// +union
+type NonMemberFieldUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+
+	Other string `json:"other,omitempty"` // want "field NonMemberFieldUnion.Other is not a union discriminator/member in union type NonMemberFieldUnion"
+}
+
+type UnionWithoutTypeMarkerWithK8sMarkers struct {
+	// +k8s:unionDiscriminator
+	// +k8s:required
+	Kind string `json:"kind"`
+
+	// +k8s:unionMember
+	Foo *string `json:"foo,omitempty"` // want "union member field UnionWithoutTypeMarkerWithK8sMarkers.Foo must be marked as optional"
+}

--- a/pkg/analysis/discriminatedunions/testdata/src/a/a.go
+++ b/pkg/analysis/discriminatedunions/testdata/src/a/a.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package a
+
+// +union
+type ValidLegacyUnion struct {
+	// +unionDiscriminator
+	// +required
+	Type string `json:"type"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type ValidLegacyUnionOptionalMember struct {
+	// +unionDiscriminator
+	// +required
+	Type string `json:"type"`
+
+	// +unionMember,optional
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type ValidDeclarativeUnion struct {
+	// +k8s:unionDiscriminator
+	// +k8s:required
+	Type string `json:"type"`
+
+	// +k8s:unionMember
+	// +k8s:optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+type ValidNamedDeclarativeUnions struct {
+	// +k8s:unionDiscriminator(union: "transport")
+	// +k8s:required
+	TransportType string `json:"transportType"`
+
+	// +k8s:unionMember(union: "transport")
+	// +k8s:optional
+	HTTP *string `json:"http,omitempty"`
+
+	// +k8s:unionDiscriminator(union: "credentials")
+	// +k8s:required
+	CredentialType string `json:"credentialType"`
+
+	// +k8s:unionMember(union: "credentials")
+	// +k8s:optional
+	Token *string `json:"token,omitempty"`
+}
+
+// +union
+type MissingDiscriminatorUnion struct { // want "type MissingDiscriminatorUnion is marked as a discriminated union but has no discriminator field"
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type MultipleDiscriminatorUnion struct { // want "type MultipleDiscriminatorUnion is marked as a discriminated union but has 2 discriminator fields"
+	// +unionDiscriminator
+	// +required
+	One string `json:"one"`
+
+	// +unionDiscriminator
+	// +required
+	Two string `json:"two"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type DiscriminatorNotRequiredUnion struct {
+	// +unionDiscriminator
+	Kind string `json:"kind"` // want "discriminator field DiscriminatorNotRequiredUnion.Kind must be marked as required"
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+}
+
+// +union
+type MemberNotOptionalUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	Foo *string `json:"foo,omitempty"` // want "union member field MemberNotOptionalUnion.Foo must be marked as optional"
+}
+
+// +union
+type MemberOnlyHasOptionalUnionMemberVariant struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember,optional
+	Foo *string `json:"foo,omitempty"` // want "union member field MemberOnlyHasOptionalUnionMemberVariant.Foo must be marked as optional"
+}
+
+// +union
+type ValidDiscriminatorOnlyUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+}
+
+// +union
+type NonMemberFieldUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+
+	Other string `json:"other,omitempty"` // want "field NonMemberFieldUnion.Other is not a union discriminator/member in union type NonMemberFieldUnion"
+}
+
+type UnionWithoutTypeMarkerWithK8sMarkers struct {
+	// +k8s:unionDiscriminator
+	// +k8s:required
+	Kind string `json:"kind"`
+
+	// +k8s:unionMember
+	Foo *string `json:"foo,omitempty"` // want "union member field UnionWithoutTypeMarkerWithK8sMarkers.Foo must be marked as optional"
+}

--- a/pkg/analysis/discriminatedunions/testdata/src/b/b.go
+++ b/pkg/analysis/discriminatedunions/testdata/src/b/b.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package b
+
+// +union
+type NonMemberAllowedUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	// +optional
+	Foo *string `json:"foo,omitempty"`
+
+	Other string `json:"other,omitempty"`
+}

--- a/pkg/analysis/discriminatedunions/testdata/src/c/c.go
+++ b/pkg/analysis/discriminatedunions/testdata/src/c/c.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package c
+
+// +union
+type PreferredOptionalMarkerUnion struct {
+	// +unionDiscriminator
+	// +required
+	Kind string `json:"kind"`
+
+	// +unionMember
+	Foo *string `json:"foo,omitempty"` // want "union member field PreferredOptionalMarkerUnion.Foo must be marked as optional \\(use \\+k8s:optional\\)"
+}

--- a/pkg/analysis/helpers/markers/analyzer.go
+++ b/pkg/analysis/helpers/markers/analyzer.go
@@ -743,6 +743,16 @@ func extractArgumentsAndPayload(expressionStr string) (map[string]string, Payloa
 		expressionsMap[key] = value
 	}
 
+	// Some legacy kubebuilder-style markers use a single bare suffix after a comma,
+	// for example `+unionMember,optional`. Preserve that suffix as an unnamed argument
+	// so analyzers can rely on parsed marker arguments instead of raw string matching.
+	if len(expressionsMap) == 0 && payload == (Payload{}) {
+		bareValue := strings.TrimSpace(strings.TrimLeft(expressionStr, ":,"))
+		if bareValue != "" && !strings.Contains(bareValue, "=") && !strings.Contains(bareValue, ",") {
+			expressionsMap[UnnamedArgument] = bareValue
+		}
+	}
+
 	return expressionsMap, payload
 }
 

--- a/pkg/analysis/helpers/markers/analyzer_test.go
+++ b/pkg/analysis/helpers/markers/analyzer_test.go
@@ -433,3 +433,15 @@ func TestIdentifierFromString(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractKnownMarkerIDArgumentsAndPayload(t *testing.T) {
+	g := NewWithT(t)
+
+	id, arguments, payload := extractKnownMarkerIDArgumentsAndPayload("unionMember", "unionMember,optional")
+
+	g.Expect(id).To(Equal("unionMember"))
+	g.Expect(arguments).To(Equal(map[string]string{
+		UnnamedArgument: "optional",
+	}))
+	g.Expect(payload).To(Equal(Payload{}))
+}

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -22,6 +22,15 @@ const (
 	// RequiredMarker is the marker that indicates that a field is required.
 	RequiredMarker = "required"
 
+	// UnionMarker is the marker that indicates that a struct is a discriminated union.
+	UnionMarker = "union"
+
+	// UnionDiscriminatorMarker is the marker that indicates that a field is the discriminator for a legacy union.
+	UnionDiscriminatorMarker = "unionDiscriminator"
+
+	// UnionMemberMarker is the marker that indicates that a field is a member of a legacy union.
+	UnionMemberMarker = "unionMember"
+
 	// NullableMarker is the marker that indicates that a field can be null.
 	NullableMarker = "nullable"
 
@@ -211,4 +220,10 @@ const (
 
 	// K8sDefaultMarker is the marker that indicates the default value for a field in k8s declarative validation.
 	K8sDefaultMarker = "k8s:default"
+
+	// K8sUnionDiscriminatorMarker is the marker that indicates that a field is the discriminator for a declarative union.
+	K8sUnionDiscriminatorMarker = "k8s:unionDiscriminator"
+
+	// K8sUnionMemberMarker is the marker that indicates that a field is a member of a declarative union.
+	K8sUnionMemberMarker = "k8s:unionMember"
 )

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -31,6 +31,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/defaultorrequired"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/defaults"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/dependenttags"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/discriminatedunions"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/duplicatemarkers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/forbiddenmarkers"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/integers"


### PR DESCRIPTION
## Description

This PR introduces a new `discriminatedunions` linter to enforce structural best practices for discriminated unions.

The new linter, `discriminatedunions`, does the following:

- **Validates Union Structure:** Detects unions from either legacy markers or declarative markers, including field-marker-only unions.
- **Enforces Discriminator/Member Rules:** Requires exactly one discriminator field, requires the discriminator to be marked required, and requires union member fields to be optional (including support for `+unionMember,optional`).
- **Configurable Non-Member Policy:** Enforces or allows non-member fields via config (`nonMemberFields: Forbid | Allow`), with `Forbid` as default.
- **Safe Rollout:** The linter is disabled by default.

This is the first part and intentionally scopes to structure validation only.  
CRD reachability and CEL gating checks will follow.

Part of #20
