### PR TITLE
Account for ExactlyOneOf/AtLeastOneOf in zero value detection

### DIFF
--- a/pkg/analysis/optionalfields/analyzer.go
+++ b/pkg/analysis/optionalfields/analyzer.go
@@ -43,6 +43,8 @@ func init() {
 		markers.KubebuilderMinPropertiesMarker,
 		markers.KubebuilderMinimumMarker,
 		markers.KubebuilderEnumMarker,
+		markers.KubebuilderExactlyOneOf,
+		markers.KubebuilderAtLeastOneOfMarker,
 	)
 }
 

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -41,6 +41,8 @@ func init() {
 		markers.KubebuilderMinPropertiesMarker,
 		markers.KubebuilderMinimumMarker,
 		markers.KubebuilderEnumMarker,
+		markers.KubebuilderExactlyOneOf,
+		markers.KubebuilderAtLeastOneOfMarker,
 	)
 }
 

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go
@@ -29,6 +29,34 @@ type TestStructs struct {
 	// +required
 	StructPtrWithMinPropertiesWithOmitEmpty *StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
+	// StructWithExactlyOneOf has a zero value of {}, which is not valid because the ExactlyOneOf marker requires at least one field to be set.
+
+	// +required
+	StructWithExactlyOneOf StructWithExactlyOneOf `json:"structWithExactlyOneOf"` // want "field TestStructs.StructWithExactlyOneOf does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structWithExactlyOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructPtrWithExactlyOneOf *StructWithExactlyOneOf `json:"structPtrWithExactlyOneOf"` // want "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. The field does not need to be a pointer."
+
+	// +required
+	StructPtrWithExactlyOneOfWithOmitEmpty *StructWithExactlyOneOf `json:"structPtrWithExactlyOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithAtLeastOneOf has a zero value of {}, which is not valid because the AtLeastOneOf marker requires at least one field to be set.
+
+	// +required
+	StructWithAtLeastOneOf StructWithAtLeastOneOf `json:"structWithAtLeastOneOf"` // want "field TestStructs.StructWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structWithAtLeastOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructPtrWithAtLeastOneOf *StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOf"` // want "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. The field does not need to be a pointer."
+
+	// +required
+	StructPtrWithAtLeastOneOfWithOmitEmpty *StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
 	// +required
@@ -143,4 +171,28 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 type StructWithOmittedRequiredField struct {
 	// +required
 	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// Struct with ExactlyOneOf marker.
+// The zero value of the struct is `{}` which is not valid because the ExactlyOneOf marker
+// requires exactly one field to be set.
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithExactlyOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
+}
+
+// Struct with AtLeastOneOf marker.
+// The zero value of the struct is `{}` which is not valid because the AtLeastOneOf marker
+// requires at least one field to be set.
+// +kubebuilder:validation:AtLeastOneOf=fieldA;fieldB
+type StructWithAtLeastOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
@@ -30,6 +30,34 @@ type TestStructs struct {
     // +required
 	StructPtrWithMinPropertiesWithOmitEmpty StructWithMinProperties `json:"structPtrWithMinPropertiesWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithMinPropertiesWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
 
+	// StructWithExactlyOneOf has a zero value of {}, which is not valid because the ExactlyOneOf marker requires at least one field to be set.
+
+    // +required
+	StructWithExactlyOneOf StructWithExactlyOneOf `json:"structWithExactlyOneOf,omitzero"` // want "field TestStructs.StructWithExactlyOneOf does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structWithExactlyOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructPtrWithExactlyOneOf StructWithExactlyOneOf `json:"structPtrWithExactlyOneOf,omitzero"` // want "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. The field does not need to be a pointer."
+
+    // +required
+	StructPtrWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structPtrWithExactlyOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithAtLeastOneOf has a zero value of {}, which is not valid because the AtLeastOneOf marker requires at least one field to be set.
+
+    // +required
+	StructWithAtLeastOneOf StructWithAtLeastOneOf `json:"structWithAtLeastOneOf,omitzero"` // want "field TestStructs.StructWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structWithAtLeastOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructPtrWithAtLeastOneOf StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOf,omitzero"` // want "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. The field does not need to be a pointer."
+
+    // +required
+	StructPtrWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
 	// StructWithNonOmittedFields has a zero value of {"string":"", "int":0}, which is valid because all fields are required.
 
     // +required
@@ -144,4 +172,28 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 type StructWithOmittedRequiredField struct {
 	// +required
 	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// Struct with ExactlyOneOf marker.
+// The zero value of the struct is `{}` which is not valid because the ExactlyOneOf marker
+// requires exactly one field to be set.
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithExactlyOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
+}
+
+// Struct with AtLeastOneOf marker.
+// The zero value of the struct is `{}` which is not valid because the AtLeastOneOf marker
+// requires at least one field to be set.
+// +kubebuilder:validation:AtLeastOneOf=fieldA;fieldB
+type StructWithAtLeastOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
 }

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -130,8 +130,17 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 		zeroValueValid = false
 	}
 
+	// Check if the struct has ExactlyOneOf or AtLeastOneOf markers.
+	// These markers enforce that at least one field must be set, making `{}` an invalid zero value.
+	structMarkerSet := markersAccess.StructMarkers(structType)
+	hasUnionMarker := structMarkerSet.Has(markers.KubebuilderExactlyOneOf) || structMarkerSet.Has(markers.KubebuilderAtLeastOneOfMarker)
+
+	if hasUnionMarker {
+		zeroValueValid = false
+	}
+
 	var completeStructValidation = true
-	if minProperties == nil && nonOmittedFields == 0 {
+	if !hasUnionMarker && minProperties == nil && nonOmittedFields == 0 {
 		// If the struct has no non-omitted fields, then the zero value of the struct is `{}`.
 		// This generally means that the validation is incomplete as the difference between omitting the field and not omitting is not clear.
 		completeStructValidation = false

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -119,34 +119,38 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 
 	markerSet := TypeAwareMarkerCollectionForField(pass, markersAccess, field)
 
+	structZeroValid, completeStructValidation := checkStructMinProperties(pass, field, markerSet, structType, markersAccess, nonOmittedFields)
+	if !structZeroValid {
+		zeroValueValid = false
+	}
+
+	return zeroValueValid, completeStructValidation
+}
+
+// checkStructMinProperties checks if the struct's zero value satisfies min-properties constraints.
+// It considers both explicit minProperties markers and union markers (ExactlyOneOf/AtLeastOneOf),
+// which implicitly require at least one field to be set.
+// Returns (zeroValueValid, completeValidation).
+func checkStructMinProperties(pass *analysis.Pass, field *ast.Field, markerSet markershelper.MarkerSet, structType *ast.StructType, markersAccess markershelper.Markers, nonOmittedFields int) (bool, bool) {
 	minProperties, err := GetMinProperties(markerSet)
 	if err != nil {
 		pass.Reportf(field.Pos(), "struct %s has an invalid minProperties marker: %v", FieldName(field), err)
 		return false, false
 	}
 
-	if minProperties != nil && *minProperties > nonOmittedFields {
-		// The struct requires more properties than would be marshalled in the zero value of the struct.
-		zeroValueValid = false
-	}
-
-	// Check if the struct has ExactlyOneOf or AtLeastOneOf markers.
-	// These markers enforce that at least one field must be set, making `{}` an invalid zero value.
+	// Union markers (ExactlyOneOf/AtLeastOneOf) implicitly require at least one field,
+	// equivalent to minProperties=1.
 	structMarkerSet := markersAccess.StructMarkers(structType)
-	hasUnionMarker := structMarkerSet.Has(markers.KubebuilderExactlyOneOf) || structMarkerSet.Has(markers.KubebuilderAtLeastOneOfMarker)
-
-	if hasUnionMarker {
-		zeroValueValid = false
+	if minProperties == nil && (structMarkerSet.Has(markers.KubebuilderExactlyOneOf) || structMarkerSet.Has(markers.KubebuilderAtLeastOneOfMarker)) {
+		minProperties = ptr.To(1)
 	}
 
-	var completeStructValidation = true
-	if !hasUnionMarker && minProperties == nil && nonOmittedFields == 0 {
-		// If the struct has no non-omitted fields, then the zero value of the struct is `{}`.
-		// This generally means that the validation is incomplete as the difference between omitting the field and not omitting is not clear.
-		completeStructValidation = false
-	}
+	zeroValueValid := minProperties == nil || *minProperties <= nonOmittedFields
+	// If the struct has no non-omitted fields and no min-properties constraint, then the zero value
+	// is `{}` and the validation is incomplete.
+	completeValidation := minProperties != nil || nonOmittedFields > 0
 
-	return zeroValueValid, completeStructValidation
+	return zeroValueValid, completeValidation
 }
 
 // areStructFieldZeroValuesValid checks if all non-omitted fields within a struct accept their zero values.


### PR DESCRIPTION
## Summary

The `requiredfields` and `optionalfields` analyzers did not consider struct-level `ExactlyOneOf`/`AtLeastOneOf` markers when determining if a struct's zero value is valid. These markers enforce that at least one field must be set, making `{}` an invalid zero value.

Without this fix, the linter incorrectly suggests making a field a pointer when the struct already has sufficient validation via union markers.

### Changes

- **`pkg/analysis/utils/zero_value.go`**: In `isStructZeroValueValid()`, check `StructMarkers` for `ExactlyOneOf`/`AtLeastOneOf`. If present, mark zero value as invalid and validation as complete.
- **`pkg/analysis/requiredfields/analyzer.go`**: Register `ExactlyOneOf` and `AtLeastOneOf` markers
- **`pkg/analysis/optionalfields/analyzer.go`**: Register `ExactlyOneOf` and `AtLeastOneOf` markers
- **Test data**: Added `StructWithExactlyOneOf` and `StructWithAtLeastOneOf` test cases with expected diagnostics and golden file entries

Fixes #236

## Test plan

- [x] `go test ./pkg/analysis/requiredfields/`  all tests pass (12/12 specs)
- [x] `go test ./pkg/analysis/optionalfields/`  all tests pass (11/11 specs)
- [x] `go test ./pkg/analysis/...`  all 40 analysis packages pass
- [x] `go build ./pkg/analysis/...`  builds clean