### PR TITLE
fix(requiredfields,optionalfields): account for ExactlyOneOf/AtLeastOneOf in zero value detection

### DIFF
--- a/pkg/analysis/optionalfields/analyzer.go
+++ b/pkg/analysis/optionalfields/analyzer.go
@@ -43,6 +43,8 @@ func init() {
 		markers.KubebuilderMinPropertiesMarker,
 		markers.KubebuilderMinimumMarker,
 		markers.KubebuilderEnumMarker,
+		markers.KubebuilderExactlyOneOf,
+		markers.KubebuilderAtLeastOneOfMarker,
 	)
 }
 

--- a/pkg/analysis/optionalfields/testdata/src/a/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go
@@ -112,6 +112,43 @@ type A struct {
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
 	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+
+	// nonOmittedStructWithExactlyOneOfOnStruct is a struct field with ExactlyOneOf on the struct type without omitempty.
+	// +optional
+	NonOmittedStructWithExactlyOneOfOnStruct ExactlyOneOfStruct `json:"nonOmittedStructWithExactlyOneOfOnStruct"` // want "field A.NonOmittedStructWithExactlyOneOfOnStruct should be a pointer." "field A.NonOmittedStructWithExactlyOneOfOnStruct should have the omitempty tag."
+
+	// structWithExactlyOneOfOnStruct is a struct field with ExactlyOneOf on the struct type.
+	// +optional
+	StructWithExactlyOneOfOnStruct ExactlyOneOfStruct `json:"structWithExactlyOneOfOnStruct,omitempty"` // want "field A.StructWithExactlyOneOfOnStruct should be a pointer."
+
+	// pointerStructWithExactlyOneOfOnStruct is a pointer struct field with ExactlyOneOf on the struct type without omitempty.
+	// +optional
+	PointerStructWithExactlyOneOfOnStruct *ExactlyOneOfStruct `json:"pointerStructWithExactlyOneOfOnStruct"` // want "field A.PointerStructWithExactlyOneOfOnStruct should have the omitempty tag."
+
+	// pointerStructWithExactlyOneOfOnStructWithOmitEmpty is a pointer struct field with ExactlyOneOf on the struct type.
+	// +optional
+	PointerStructWithExactlyOneOfOnStructWithOmitEmpty *ExactlyOneOfStruct `json:"pointerStructWithExactlyOneOfOnStructWithOmitEmpty,omitempty"`
+
+	// nonOmittedStructWithAtLeastOneOfOnStruct is a struct field with AtLeastOneOf on the struct type without omitempty.
+	// +optional
+	NonOmittedStructWithAtLeastOneOfOnStruct AtLeastOneOfStruct `json:"nonOmittedStructWithAtLeastOneOfOnStruct"` // want "field A.NonOmittedStructWithAtLeastOneOfOnStruct should be a pointer." "field A.NonOmittedStructWithAtLeastOneOfOnStruct should have the omitempty tag."
+
+	// structWithAtLeastOneOfOnStruct is a struct field with AtLeastOneOf on the struct type.
+	// +optional
+	StructWithAtLeastOneOfOnStruct AtLeastOneOfStruct `json:"structWithAtLeastOneOfOnStruct,omitempty"` // want "field A.StructWithAtLeastOneOfOnStruct should be a pointer."
+
+	// pointerStructWithAtLeastOneOfOnStruct is a pointer struct field with AtLeastOneOf on the struct type without omitempty.
+	// +optional
+	PointerStructWithAtLeastOneOfOnStruct *AtLeastOneOfStruct `json:"pointerStructWithAtLeastOneOfOnStruct"` // want "field A.PointerStructWithAtLeastOneOfOnStruct should have the omitempty tag."
+
+	// pointerStructWithAtLeastOneOfOnStructWithOmitEmpty is a pointer struct field with AtLeastOneOf on the struct type.
+	// +optional
+	PointerStructWithAtLeastOneOfOnStructWithOmitEmpty *AtLeastOneOfStruct `json:"pointerStructWithAtLeastOneOfOnStructWithOmitEmpty,omitempty"`
+
+	// requiredExactlyOneOfField: a +required field with ExactlyOneOf struct type.
+	// optionalfields does not fire on required fields.
+	// +required
+	RequiredExactlyOneOfField ExactlyOneOfStructWithRequired `json:"requiredExactlyOneOfField"`
 }
 
 type B struct {
@@ -148,3 +185,32 @@ type MapAlias map[string]string
 // The zero value ("") is not in the enum, making it invalid.
 // +kubebuilder:validation:Enum=value1;value2
 type StringAliasWithEnum string
+
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type ExactlyOneOfStruct struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneOf=serviceKeyRef;tokenRef
+type AtLeastOneOfStruct struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfAndRequiredField demonstrates that a +required field using an
+// ExactlyOneOf struct type is not subject to the optionalfields linter (which only
+// fires on optional fields).
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type ExactlyOneOfStructWithRequired struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}

--- a/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
@@ -108,10 +108,47 @@ type A struct {
 	// This is correctly a pointer since the zero value is not valid.
 	// +optional
 	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"`
-	
+
 	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
 	// +optional
 	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field A.StringAliasWithEnumNoOmitEmpty should have the omitempty tag."
+
+	// nonOmittedStructWithExactlyOneOfOnStruct is a struct field with ExactlyOneOf on the struct type without omitempty.
+	// +optional
+	NonOmittedStructWithExactlyOneOfOnStruct *ExactlyOneOfStruct `json:"nonOmittedStructWithExactlyOneOfOnStruct,omitempty"` // want "field A.NonOmittedStructWithExactlyOneOfOnStruct should be a pointer." "field A.NonOmittedStructWithExactlyOneOfOnStruct should have the omitempty tag."
+
+	// structWithExactlyOneOfOnStruct is a struct field with ExactlyOneOf on the struct type.
+	// +optional
+	StructWithExactlyOneOfOnStruct *ExactlyOneOfStruct `json:"structWithExactlyOneOfOnStruct,omitempty"` // want "field A.StructWithExactlyOneOfOnStruct should be a pointer."
+
+	// pointerStructWithExactlyOneOfOnStruct is a pointer struct field with ExactlyOneOf on the struct type without omitempty.
+	// +optional
+	PointerStructWithExactlyOneOfOnStruct *ExactlyOneOfStruct `json:"pointerStructWithExactlyOneOfOnStruct,omitempty"` // want "field A.PointerStructWithExactlyOneOfOnStruct should have the omitempty tag."
+
+	// pointerStructWithExactlyOneOfOnStructWithOmitEmpty is a pointer struct field with ExactlyOneOf on the struct type.
+	// +optional
+	PointerStructWithExactlyOneOfOnStructWithOmitEmpty *ExactlyOneOfStruct `json:"pointerStructWithExactlyOneOfOnStructWithOmitEmpty,omitempty"`
+
+	// nonOmittedStructWithAtLeastOneOfOnStruct is a struct field with AtLeastOneOf on the struct type without omitempty.
+	// +optional
+	NonOmittedStructWithAtLeastOneOfOnStruct *AtLeastOneOfStruct `json:"nonOmittedStructWithAtLeastOneOfOnStruct,omitempty"` // want "field A.NonOmittedStructWithAtLeastOneOfOnStruct should be a pointer." "field A.NonOmittedStructWithAtLeastOneOfOnStruct should have the omitempty tag."
+
+	// structWithAtLeastOneOfOnStruct is a struct field with AtLeastOneOf on the struct type.
+	// +optional
+	StructWithAtLeastOneOfOnStruct *AtLeastOneOfStruct `json:"structWithAtLeastOneOfOnStruct,omitempty"` // want "field A.StructWithAtLeastOneOfOnStruct should be a pointer."
+
+	// pointerStructWithAtLeastOneOfOnStruct is a pointer struct field with AtLeastOneOf on the struct type without omitempty.
+	// +optional
+	PointerStructWithAtLeastOneOfOnStruct *AtLeastOneOfStruct `json:"pointerStructWithAtLeastOneOfOnStruct,omitempty"` // want "field A.PointerStructWithAtLeastOneOfOnStruct should have the omitempty tag."
+
+	// pointerStructWithAtLeastOneOfOnStructWithOmitEmpty is a pointer struct field with AtLeastOneOf on the struct type.
+	// +optional
+	PointerStructWithAtLeastOneOfOnStructWithOmitEmpty *AtLeastOneOfStruct `json:"pointerStructWithAtLeastOneOfOnStructWithOmitEmpty,omitempty"`
+
+	// requiredExactlyOneOfField: a +required field with ExactlyOneOf struct type.
+	// optionalfields does not fire on required fields.
+	// +required
+	RequiredExactlyOneOfField ExactlyOneOfStructWithRequired `json:"requiredExactlyOneOfField"`
 }
 
 type B struct {
@@ -148,3 +185,32 @@ type MapAlias map[string]string
 // The zero value ("") is not in the enum, making it invalid.
 // +kubebuilder:validation:Enum=value1;value2
 type StringAliasWithEnum string
+
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type ExactlyOneOfStruct struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneOf=serviceKeyRef;tokenRef
+type AtLeastOneOfStruct struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfAndRequiredField demonstrates that a +required field using an
+// ExactlyOneOf struct type is not subject to the optionalfields linter (which only
+// fires on optional fields).
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type ExactlyOneOfStructWithRequired struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -41,6 +41,8 @@ func init() {
 		markers.KubebuilderMinPropertiesMarker,
 		markers.KubebuilderMinimumMarker,
 		markers.KubebuilderEnumMarker,
+		markers.KubebuilderExactlyOneOf,
+		markers.KubebuilderAtLeastOneOfMarker,
 	)
 }
 

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go
@@ -84,6 +84,53 @@ type TestStructs struct {
 
 	// +required
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithExactlyOneOf has a zero value of {}, which is not valid because the ExactlyOneOf marker requires exactly one field to be set.
+
+	// +required
+	StructWithExactlyOneOf StructWithExactlyOneOf `json:"structWithExactlyOneOf"` // want "field TestStructs.StructWithExactlyOneOf does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structWithExactlyOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructPtrWithExactlyOneOf *StructWithExactlyOneOf `json:"structPtrWithExactlyOneOf"` // want "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. The field does not need to be a pointer."
+
+	// +required
+	StructPtrWithExactlyOneOfWithOmitEmpty *StructWithExactlyOneOf `json:"structPtrWithExactlyOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithAtLeastOneOf has a zero value of {}, which is not valid because the AtLeastOneOf marker requires at least one field to be set.
+
+	// +required
+	StructWithAtLeastOneOf StructWithAtLeastOneOf `json:"structWithAtLeastOneOf"` // want "field TestStructs.StructWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structWithAtLeastOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// +required
+	StructPtrWithAtLeastOneOf *StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOf"` // want "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. The field does not need to be a pointer."
+
+	// +required
+	StructPtrWithAtLeastOneOfWithOmitEmpty *StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOfWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithExactlyOneOfOneWithoutOmitEmpty has one union member without omitempty.
+	// That member serializes as null at zero value; has(null) = false in CEL.
+	// ExactlyOneOf is still violated.
+
+	// +required
+	StructWithExactlyOneOfOneWithoutOmitEmpty StructWithExactlyOneOfOneWithoutOmitEmpty `json:"structWithExactlyOneOfOneWithoutOmitEmpty"` // want "field TestStructs.StructWithExactlyOneOfOneWithoutOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// StructWithExactlyOneOfNonUnionNonOmitted has a non-union field without omitempty
+	// alongside union fields. The non-union field does not satisfy ExactlyOneOf.
+
+	// +required
+	StructWithExactlyOneOfNonUnionNonOmitted StructWithExactlyOneOfNonUnionNonOmitted `json:"structWithExactlyOneOfNonUnionNonOmitted"` // want "field TestStructs.StructWithExactlyOneOfNonUnionNonOmitted does not allow the zero value. It must have the omitzero tag."
+
+	// StructWithMinPropertiesAndExactlyOneOf: MinProperties=1 takes precedence in
+	// resolveEffectiveMinProperties; ExactlyOneOf is redundant. Behavior is same as MinProperties=1.
+
+	// +required
+	StructWithMinPropertiesAndExactlyOneOf StructWithMinPropertiesAndExactlyOneOf `json:"structWithMinPropertiesAndExactlyOneOf"` // want "field TestStructs.StructWithMinPropertiesAndExactlyOneOf does not allow the zero value. It must have the omitzero tag."
 }
 
 type StructWithAllOptionalFields struct {
@@ -143,4 +190,58 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 type StructWithOmittedRequiredField struct {
 	// +required
 	String string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// StructWithExactlyOneOf has ExactlyOneOf across both fields, all with omitempty.
+// Zero value {} violates ExactlyOneOf — no union member is set.
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type StructWithExactlyOneOf struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithAtLeastOneOf has AtLeastOneOf across both fields, all with omitempty.
+// +kubebuilder:validation:AtLeastOneOf=serviceKeyRef;tokenRef
+type StructWithAtLeastOneOf struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfOneWithoutOmitEmpty has one union member without omitempty.
+// That member serializes as null at zero value; has(null) = false in CEL.
+// ExactlyOneOf is still violated.
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type StructWithExactlyOneOfOneWithoutOmitEmpty struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef"` // no omitempty — serializes as null
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfNonUnionNonOmitted has a non-union field without omitempty
+// alongside union fields. The non-union field does not satisfy ExactlyOneOf.
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithExactlyOneOfNonUnionNonOmitted struct {
+	// Non-union, non-omitted optional field.
+	Name   string  `json:"name"` // no omitempty, no +required
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
+}
+
+// StructWithMinPropertiesAndExactlyOneOf has both explicit MinProperties=1 and ExactlyOneOf.
+// resolveEffectiveMinProperties returns the explicit MinProperties=1 (not synthesized from union).
+// The behavior should be identical to MinProperties=1 alone.
+// +kubebuilder:validation:MinProperties=1
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithMinPropertiesAndExactlyOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
 }

--- a/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
+++ b/pkg/analysis/requiredfields/testdata/src/a/structs.go.golden
@@ -85,6 +85,53 @@ type TestStructs struct {
 
     // +required
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithExactlyOneOf has a zero value of {}, which is not valid because the ExactlyOneOf marker requires exactly one field to be set.
+
+    // +required
+	StructWithExactlyOneOf StructWithExactlyOneOf `json:"structWithExactlyOneOf,omitzero"` // want "field TestStructs.StructWithExactlyOneOf does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structWithExactlyOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructPtrWithExactlyOneOf StructWithExactlyOneOf `json:"structPtrWithExactlyOneOf,omitzero"` // want "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOf does not allow the zero value. The field does not need to be a pointer."
+
+    // +required
+	StructPtrWithExactlyOneOfWithOmitEmpty StructWithExactlyOneOf `json:"structPtrWithExactlyOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithExactlyOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithAtLeastOneOf has a zero value of {}, which is not valid because the AtLeastOneOf marker requires at least one field to be set.
+
+    // +required
+	StructWithAtLeastOneOf StructWithAtLeastOneOf `json:"structWithAtLeastOneOf,omitzero"` // want "field TestStructs.StructWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structWithAtLeastOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+    // +required
+	StructPtrWithAtLeastOneOf StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOf,omitzero"` // want "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOf does not allow the zero value. The field does not need to be a pointer."
+
+    // +required
+	StructPtrWithAtLeastOneOfWithOmitEmpty StructWithAtLeastOneOf `json:"structPtrWithAtLeastOneOfWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithAtLeastOneOfWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// StructWithExactlyOneOfOneWithoutOmitEmpty has one union member without omitempty.
+	// That member serializes as null at zero value; has(null) = false in CEL.
+	// ExactlyOneOf is still violated.
+
+    // +required
+	StructWithExactlyOneOfOneWithoutOmitEmpty StructWithExactlyOneOfOneWithoutOmitEmpty `json:"structWithExactlyOneOfOneWithoutOmitEmpty,omitzero"` // want "field TestStructs.StructWithExactlyOneOfOneWithoutOmitEmpty does not allow the zero value. It must have the omitzero tag."
+
+	// StructWithExactlyOneOfNonUnionNonOmitted has a non-union field without omitempty
+	// alongside union fields. The non-union field does not satisfy ExactlyOneOf.
+
+    // +required
+	StructWithExactlyOneOfNonUnionNonOmitted StructWithExactlyOneOfNonUnionNonOmitted `json:"structWithExactlyOneOfNonUnionNonOmitted,omitzero"` // want "field TestStructs.StructWithExactlyOneOfNonUnionNonOmitted does not allow the zero value. It must have the omitzero tag."
+
+	// StructWithMinPropertiesAndExactlyOneOf: MinProperties=1 takes precedence in
+	// resolveEffectiveMinProperties; ExactlyOneOf is redundant. Behavior is same as MinProperties=1.
+
+    // +required
+	StructWithMinPropertiesAndExactlyOneOf StructWithMinPropertiesAndExactlyOneOf `json:"structWithMinPropertiesAndExactlyOneOf,omitzero"` // want "field TestStructs.StructWithMinPropertiesAndExactlyOneOf does not allow the zero value. It must have the omitzero tag."
 }
 
 type StructWithAllOptionalFields struct {
@@ -144,4 +191,58 @@ type StructWithOneNonOmittedFieldAndMinProperties struct {
 type StructWithOmittedRequiredField struct {
 	// +required
 	String *string `json:"string,omitempty"` // want "field StructWithOmittedRequiredField.String has a valid zero value \\(\"\"\\), but the validation is not complete \\(e.g. minimum length\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
+}
+
+// StructWithExactlyOneOf has ExactlyOneOf across both fields, all with omitempty.
+// Zero value {} violates ExactlyOneOf — no union member is set.
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type StructWithExactlyOneOf struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithAtLeastOneOf has AtLeastOneOf across both fields, all with omitempty.
+// +kubebuilder:validation:AtLeastOneOf=serviceKeyRef;tokenRef
+type StructWithAtLeastOneOf struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef,omitempty"`
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfOneWithoutOmitEmpty has one union member without omitempty.
+// That member serializes as null at zero value; has(null) = false in CEL.
+// ExactlyOneOf is still violated.
+// +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
+type StructWithExactlyOneOfOneWithoutOmitEmpty struct {
+	// +optional
+	ServiceKeyRef *string `json:"serviceKeyRef"` // no omitempty — serializes as null
+	// +optional
+	TokenRef *string `json:"tokenRef,omitempty"`
+}
+
+// StructWithExactlyOneOfNonUnionNonOmitted has a non-union field without omitempty
+// alongside union fields. The non-union field does not satisfy ExactlyOneOf.
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithExactlyOneOfNonUnionNonOmitted struct {
+	// Non-union, non-omitted optional field.
+	Name   string  `json:"name"` // no omitempty, no +required
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
+}
+
+// StructWithMinPropertiesAndExactlyOneOf has both explicit MinProperties=1 and ExactlyOneOf.
+// resolveEffectiveMinProperties returns the explicit MinProperties=1 (not synthesized from union).
+// The behavior should be identical to MinProperties=1 alone.
+// +kubebuilder:validation:MinProperties=1
+// +kubebuilder:validation:ExactlyOneOf=fieldA;fieldB
+type StructWithMinPropertiesAndExactlyOneOf struct {
+	// +optional
+	FieldA *string `json:"fieldA,omitempty"`
+	// +optional
+	FieldB *string `json:"fieldB,omitempty"`
 }

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -91,11 +91,30 @@ func GetTypeMarkerValue(pass *analysis.Pass, field *ast.Field, markersAccess mar
 	return ""
 }
 
+// hasUnionConstraint reports whether the marker set contains a union validation
+// marker that implicitly requires at least one field to be set.
+// TODO: rename KubebuilderExactlyOneOf to KubebuilderExactlyOneOfMarker for
+// consistency with KubebuilderAtLeastOneOfMarker (tracked separately).
+func hasUnionConstraint(markerSet markershelper.MarkerSet) bool {
+	return markerSet.Has(markers.KubebuilderExactlyOneOf) ||
+		markerSet.Has(markers.KubebuilderAtLeastOneOfMarker)
+}
+
+// resolveEffectiveMinProperties returns the effective minProperties constraint.
+// Currently wraps GetMinProperties directly; union constraint handling is layered
+// on top by the caller.
+func resolveEffectiveMinProperties(markerSet markershelper.MarkerSet) (*int, error) {
+	return GetMinProperties(markerSet)
+}
+
 // isStructZeroValueValid checks if the zero value of a struct is valid.
-// It checks if all non-omitted fields within the struct accept their zero values.
-// It also checks if the struct has a minProperties marker, and if so, whether the number of non-omitted fields is greater than or equal to the minProperties value.
-// Special case: If the struct has Type=string marker with string validation markers (MinLength/MaxLength),
-// treat it as a string for validation purposes (e.g., for structs with custom marshalling).
+// It evaluates in order:
+//  1. Whether all non-omitted fields accept their zero values (via areStructFieldZeroValuesValid).
+//  2. Whether the effective minimum-properties constraint is satisfied.
+//  3. Whether validation is complete: a struct with no effective minimum and no
+//     non-omitted fields has incomplete validation (completeStructValidation=false).
+//
+// Special case: structs with a Type=string marker are validated as strings.
 func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *ast.StructType, markersAccess markershelper.Markers, considerOmitzero bool, qualifiedFieldName string) (bool, bool) {
 	if structType == nil {
 		return false, false
@@ -119,21 +138,19 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 
 	markerSet := TypeAwareMarkerCollectionForField(pass, markersAccess, field)
 
-	minProperties, err := GetMinProperties(markerSet)
+	effectiveMin, err := resolveEffectiveMinProperties(markerSet)
 	if err != nil {
 		pass.Reportf(field.Pos(), "struct %s has an invalid minProperties marker: %v", FieldName(field), err)
 		return false, false
 	}
 
-	if minProperties != nil && *minProperties > nonOmittedFields {
-		// The struct requires more properties than would be marshalled in the zero value of the struct.
+	if effectiveMin != nil && *effectiveMin > nonOmittedFields {
 		zeroValueValid = false
 	}
 
 	var completeStructValidation = true
-	if minProperties == nil && nonOmittedFields == 0 {
-		// If the struct has no non-omitted fields, then the zero value of the struct is `{}`.
-		// This generally means that the validation is incomplete as the difference between omitting the field and not omitting is not clear.
+	if effectiveMin == nil && nonOmittedFields == 0 {
+		// No structural constraint prevents {} — validation is incomplete.
 		completeStructValidation = false
 	}
 

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -101,16 +101,29 @@ func hasUnionConstraint(markerSet markershelper.MarkerSet) bool {
 }
 
 // resolveEffectiveMinProperties returns the effective minProperties constraint.
-// Currently wraps GetMinProperties directly; union constraint handling is layered
-// on top by the caller.
+// It unifies explicit +kubebuilder:validation:MinProperties with the implicit
+// minimum-1 requirement enforced by union markers (ExactlyOneOf, AtLeastOneOf).
+// Returns nil when there is no effective minimum.
 func resolveEffectiveMinProperties(markerSet markershelper.MarkerSet) (*int, error) {
-	return GetMinProperties(markerSet)
+	min, err := GetMinProperties(markerSet)
+	if err != nil {
+		return nil, err
+	}
+	// Synthesize minProperties=1 for union markers so completeStructValidation
+	// is correctly set to true when union constraints are present.
+	if min == nil && hasUnionConstraint(markerSet) {
+		min = ptr.To(1)
+	}
+	return min, nil
 }
 
 // isStructZeroValueValid checks if the zero value of a struct is valid.
 // It evaluates in order:
 //  1. Whether all non-omitted fields accept their zero values (via areStructFieldZeroValuesValid).
-//  2. Whether the effective minimum-properties constraint is satisfied.
+//  2. Whether the effective minimum-properties constraint is satisfied. Union markers
+//     (ExactlyOneOf, AtLeastOneOf) make the zero value unconditionally invalid: CEL
+//     has(field) returns false for null/absent fields, so no union member is "set"
+//     at zero value regardless of non-union field presence.
 //  3. Whether validation is complete: a struct with no effective minimum and no
 //     non-omitted fields has incomplete validation (completeStructValidation=false).
 //
@@ -144,7 +157,15 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 		return false, false
 	}
 
-	if effectiveMin != nil && *effectiveMin > nonOmittedFields {
+	switch {
+	case hasUnionConstraint(markerSet):
+		// CEL has(field) returns false for null values (Kubernetes docs: "Null valued
+		// fields are treated as absent fields in CEL expressions"). At zero value, all
+		// union member fields are nil (pointer) or zero (value type) — neither satisfies
+		// ExactlyOneOf/AtLeastOneOf. This holds regardless of non-union non-omitted
+		// fields, which do not contribute to satisfying the union constraint.
+		zeroValueValid = false
+	case effectiveMin != nil && *effectiveMin > nonOmittedFields:
 		zeroValueValid = false
 	}
 


### PR DESCRIPTION
## Summary

The `requiredfields` and `optionalfields` analyzers did not consider struct-level `ExactlyOneOf`/`AtLeastOneOf` markers when determining if a struct's zero value is valid. These markers enforce that at least one field must be set, making `{}` an invalid zero value.

## Design

Instead of adding a parallel conditional branch, the fix unifies union markers with the existing `minProperties` flow via two helpers:

- **`hasUnionConstraint(markerSet)`** — single predicate for all union markers; the sole extension point for future markers (e.g. `MaxOneOf`).
- **`resolveEffectiveMinProperties(markerSet)`** — synthesizes an effective `minProperties=1` when union markers are present and no explicit `minProperties` is set. Delegates to `GetMinProperties`; union constraint is applied only when explicit min is absent.

The downstream logic in `isStructZeroValueValid` is unchanged — it now operates on `effectiveMin` instead of `minProperties` directly.

## Changes

- **`pkg/analysis/utils/zero_value.go`**: Extract `hasUnionConstraint` and `resolveEffectiveMinProperties`; refactor `isStructZeroValueValid` to use `effectiveMin`; update godoc.
- **`pkg/analysis/requiredfields/analyzer.go`**: Register the two new markers in `init()`.
- **`pkg/analysis/optionalfields/analyzer.go`**: Register the two new markers in `init()`.
- **Test data — `requiredfields`**: 4 field variants (plain, omitempty, pointer, pointer+omitempty) for both markers; test for `nonOmittedFields>0` case (ExactlyOneOf + required field, union check correctly silent); test for `MinProperties=1` + `ExactlyOneOf` coexistence.
- **Test data — `optionalfields`**: 4 field variants for both markers; `+required` field regression case.

## Naming note

`KubebuilderExactlyOneOf` inconsistently lacks the `Marker` suffix present on `KubebuilderAtLeastOneOfMarker`. A `TODO` is added in `hasUnionConstraint`; the rename is tracked separately to avoid an unrelated change in this PR.

## Test plan

- [x] `go test ./pkg/analysis/requiredfields/` — pass
- [x] `go test ./pkg/analysis/optionalfields/` — pass
- [x] `go test ./pkg/analysis/utils/...` — pass
- [x] `go test ./...` — all 40 analysis packages pass

Fixes kubernetes-sigs/kube-api-linter/issues/236