### PR TITLE
Fix inline json tag detection

### DIFF
--- a/pkg/analysis/jsontags/analyzer.go
+++ b/pkg/analysis/jsontags/analyzer.go
@@ -77,8 +77,11 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 }
 
 func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo, qualifiedFieldName string) {
+	embedded := false
 	prefix := "field %s"
+
 	if len(field.Names) == 0 || field.Names[0] == nil {
+		embedded = true
 		prefix = "embedded field %s"
 	}
 
@@ -90,11 +93,18 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, tagInfo ext
 	}
 
 	if tagInfo.Inline {
+		if !embedded {
+			pass.Reportf(field.Pos(), "%s has inline json tag, but is not embedded", prefix)
+		}
+
 		return
 	}
 
 	if tagInfo.Name == "" {
-		pass.Reportf(field.Pos(), "%s has empty json tag", prefix)
+		if !embedded {
+			pass.Reportf(field.Pos(), "%s has empty json tag", prefix)
+		}
+
 		return
 	}
 

--- a/pkg/analysis/jsontags/testdata/src/a/a.go
+++ b/pkg/analysis/jsontags/testdata/src/a/a.go
@@ -12,7 +12,10 @@ type JSONTagTestStruct struct {
 	PascalCaseJSONTag    string `json:"PascalCaseJSONTag"`       // want "field JSONTagTestStruct.PascalCaseJSONTag json tag does not match pattern \"\\^\\[a-z\\]\\[a-z0-9\\]\\*\\(\\?:\\[A-Z\\]\\[a-z0-9\\]\\*\\)\\*\\$\": PascalCaseJSONTag"
 	NonTerminatedJSONTag string `json:"nonTerminatedJSONTag`     // want "field JSONTagTestStruct.NonTerminatedJSONTag is missing json tag"
 	XMLTag               string `xml:"xmlTag"`                   // want "field JSONTagTestStruct.XMLTag is missing json tag"
-	InlineJSONTag        string `json:",inline"`
+	NamedInline          string `json:",inline"`                 // want "field JSONTagTestStruct.NamedInline has inline json tag, but is not embedded"
+	NamedEmptyTag        string `json:""`                        // want "field JSONTagTestStruct.NamedEmptyTag has empty json tag"
+	EmbeddedInline       `json:",inline"`
+	EmbeddedEmptyTag     `json:""`
 	ValidJSONTag         string `json:"validJsonTag"`
 	ValidOptionalJSONTag string `json:"validOptionalJsonTag,omitempty"`
 	JSONTagWithID        string `json:"jsonTagWithID"`
@@ -27,11 +30,11 @@ type JSONTagTestStruct struct {
 
 	A `json:",inline"`
 	B `json:"bar,omitempty"`
-	C             // want "embedded field JSONTagTestStruct.C is missing json tag"
-	D `json:""`   // want "embedded field JSONTagTestStruct.D has empty json tag"
+	C // want "embedded field JSONTagTestStruct.C is missing json tag"
+	D `json:""`
 	E `json:"e-"` // want "embedded field JSONTagTestStruct.E json tag does not match pattern \"\\^\\[a-z\\]\\[a-z0-9\\]\\*\\(\\?:\\[A-Z\\]\\[a-z0-9\\]\\*\\)\\*\\$\": e-"
 
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:""`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
@@ -46,6 +49,10 @@ type C struct{}
 type D struct{}
 
 type E struct{}
+
+type EmbeddedInline struct{}
+
+type EmbeddedEmptyTag struct{}
 
 type Interface interface {
 	InaccessibleFunction() string

--- a/pkg/analysis/jsontags/testdata/src/b/b.go
+++ b/pkg/analysis/jsontags/testdata/src/b/b.go
@@ -8,10 +8,12 @@ type JSONTagTestStruct struct {
 	PascalCaseJSONTag    string `json:"PascalCaseJSONTag"`       // want "field JSONTagTestStruct.PascalCaseJSONTag json tag does not match pattern \"\\^\\[a-z\\]\\[a-z\\]\\*\\(\\?\\:\\[A-Z\\]\\[a-z0-9\\]\\+\\)\\*\\[a-z0-9\\]\\?\\$\": PascalCaseJSONTag"
 	NonTerminatedJSONTag string `json:"nonTerminatedJSONTag`     // want "field JSONTagTestStruct.NonTerminatedJSONTag is missing json tag"
 	XMLTag               string `xml:"xmlTag"`                   // want "field JSONTagTestStruct.XMLTag is missing json tag"
-	InlineJSONTag        string `json:",inline"`
+	InlineJSONTag        `json:",inline"`
 	ValidJSONTag         string `json:"validJsonTag"`
 	ValidOptionalJSONTag string `json:"validOptionalJsonTag,omitempty"`
 	JSONTagWithID        string `json:"jsonTagWithID"`  // want "field JSONTagTestStruct.JSONTagWithID json tag does not match pattern \"\\^\\[a-z\\]\\[a-z\\]\\*\\(\\?\\:\\[A-Z\\]\\[a-z0-9\\]\\+\\)\\*\\[a-z0-9\\]\\?\\$\": jsonTagWithID"
 	JSONTagWithTTL       string `json:"jsonTagWithTTL"` // want "field JSONTagTestStruct.JSONTagWithTTL json tag does not match pattern \"\\^\\[a-z\\]\\[a-z\\]\\*\\(\\?\\:\\[A-Z\\]\\[a-z0-9\\]\\+\\)\\*\\[a-z0-9\\]\\?\\$\": jsonTagWithTTL"
 	JSONTagWithGiB       string `json:"jsonTagWithGiB"` // want "field JSONTagTestStruct.JSONTagWithGiB json tag does not match pattern \"\\^\\[a-z\\]\\[a-z\\]\\*\\(\\?\\:\\[A-Z\\]\\[a-z0-9\\]\\+\\)\\*\\[a-z0-9\\]\\?\\$\": jsonTagWithGiB"
 }
+
+type InlineJSONTag struct{}


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/pull/138260 https://github.com/kubernetes/kubernetes/issues/138133

1. Flags use of `json:",inline"` with non-embedded fields as problematic
2. Allows use of `json:""` with embedded fields

/cc @JoelSpeed 