### PR TITLE
Fix inline json tag detection

### DIFF
--- a/pkg/analysis/helpers/extractjsontags/analyzer.go
+++ b/pkg/analysis/helpers/extractjsontags/analyzer.go
@@ -91,14 +91,16 @@ func run(pass *analysis.Pass) (any, error) {
 			return
 		}
 
-		results.insertFieldTagInfo(field, extractTagInfo(field.Tag))
+		results.insertFieldTagInfo(field, extractTagInfo(field, field.Tag))
 	})
 
 	return results, nil
 }
 
+const emptyJSONTagPrefix = `json:"`
+
 //nolint:cyclop
-func extractTagInfo(tag *ast.BasicLit) FieldTagInfo {
+func extractTagInfo(field *ast.Field, tag *ast.BasicLit) FieldTagInfo {
 	if tag == nil || tag.Value == "" {
 		return FieldTagInfo{Missing: true}
 	}
@@ -115,6 +117,11 @@ func extractTagInfo(tag *ast.BasicLit) FieldTagInfo {
 	}
 
 	if tagValue == "" {
+		if field.Names == nil { // Embedded field with `json:""`
+			pos := tag.Pos() + token.Pos(strings.Index(tag.Value, emptyJSONTagPrefix)+len(emptyJSONTagPrefix))
+			return FieldTagInfo{Inline: true, RawValue: "", Pos: pos, End: pos + token.Pos(1)}
+		}
+
 		return FieldTagInfo{}
 	}
 
@@ -169,7 +176,7 @@ type FieldTagInfo struct {
 	// OmitZero is true if the field has the omitzero option in the json tag.
 	OmitZero bool
 
-	// Inline is true if the field has the inline option in the json tag.
+	// Inline is true if the json tag is ",inline", or if the field is embedded and the json tag is "".
 	Inline bool
 
 	// Missing is true when the field had no json tag.

--- a/pkg/analysis/nonpointerstructs/testdata/src/a/a.go
+++ b/pkg/analysis/nonpointerstructs/testdata/src/a/a.go
@@ -45,6 +45,8 @@ type A struct {
 	WithOptionalField                  `json:",inline"`
 	WithRequiredAndOptionalField       `json:",inline"`
 	WithOptionalFieldsAndMinProperties `json:",inline"`
+	WithRequiredFieldEmbedded          `json:""`
+	WithOptionalFieldEmbedded          `json:""`
 }
 
 type WithRequiredField struct {
@@ -67,5 +69,15 @@ type WithRequiredAndOptionalField struct {
 // +kubebuilder:validation:MinProperties=1
 type WithOptionalFieldsAndMinProperties struct {
 	// +k8s:optional
+	OptionalField string `json:"optionalField"`
+}
+
+type WithRequiredFieldEmbedded struct {
+	// +required
+	RequiredField string `json:"requiredField"`
+}
+
+type WithOptionalFieldEmbedded struct {
+	// +optional
 	OptionalField string `json:"optionalField"`
 }

--- a/pkg/analysis/nonpointerstructs/testdata/src/a/a.go.golden
+++ b/pkg/analysis/nonpointerstructs/testdata/src/a/a.go.golden
@@ -49,6 +49,8 @@ type A struct {
 	WithOptionalField                  `json:",inline"`
 	WithRequiredAndOptionalField       `json:",inline"`
 	WithOptionalFieldsAndMinProperties `json:",inline"`
+	WithRequiredFieldEmbedded          `json:""`
+	WithOptionalFieldEmbedded          `json:""`
 }
 
 type WithRequiredField struct {
@@ -71,5 +73,15 @@ type WithRequiredAndOptionalField struct {
 // +kubebuilder:validation:MinProperties=1
 type WithOptionalFieldsAndMinProperties struct {
 	// +k8s:optional
+	OptionalField string `json:"optionalField"`
+}
+
+type WithRequiredFieldEmbedded struct {
+	// +required
+	RequiredField string `json:"requiredField"`
+}
+
+type WithOptionalFieldEmbedded struct {
+	// +optional
 	OptionalField string `json:"optionalField"`
 }

--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go
@@ -88,6 +88,8 @@ type OptionalOrRequiredTestStruct struct {
 
 	// +optional
 	C `json:"c,omitempty"`
+
+	Embedded `json:""`
 }
 
 type A struct{}
@@ -102,3 +104,5 @@ type C struct{}
 type Interface interface {
 	InaccessibleFunction() string
 }
+
+type Embedded struct{}

--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
@@ -83,6 +83,8 @@ type OptionalOrRequiredTestStruct struct {
 
 	// +optional
 	C `json:"c,omitempty"`
+
+	Embedded `json:""`
 }
 
 type A struct{}
@@ -97,3 +99,5 @@ type C struct{}
 type Interface interface {
 	InaccessibleFunction() string
 }
+
+type Embedded struct{}


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes-sigs/kube-api-linter/pull/239

Prereq for https://github.com/kubernetes/kubernetes/pull/138260

Part 2 (fixes inline detection so other linters which exempt inline fields work properly)

/assign @JoelSpeed 