### PR TITLE
Update kube-api-linter version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: 'v0.0.0-20251029102002-9992248f8813'
+  version: 'v0.0.0-20260416084302-2b3d1fe14578'
 ```
 
 **Important - Version Format**: Since this repository does not have releases yet, you must use a [pseudo-version](https://go.dev/ref/mod#pseudo-versions) in the format `v0.0.0-YYYYMMDDHHMMSS-commithash`.


### PR DESCRIPTION
Updated kube-api-linter version in README.

## Why

The version currently present does not work

Stacktrace
```
$golangci-lint custom
WARN go: sigs.k8s.io/kube-api-linter@v0.0.0-20251029102002-9992248f8813: invalid pseudo-version: does not match version-control timestamp (expected 20251029172002) 
Error: build process: add to go.mod: go get sigs.k8s.io/kube-api-linter@v0.0.0-20251029102002-9992248f8813: exit status 1
The command is terminated due to an error: build process: add to go.mod: go get sigs.k8s.io/kube-api-linter@v0.0.0-20251029102002-9992248f8813: exit status 1
```

Replacing by latest here https://pkg.go.dev/sigs.k8s.io/kube-api-linter?tab=versions