### PR TITLE
Extend maxlength linter to support kubernetes declarative validation markers 

### DIFF
--- a/pkg/analysis/jsontags/analyzer.go
+++ b/pkg/analysis/jsontags/analyzer.go
@@ -179,6 +179,7 @@ func expectedJSONTagName(fieldName string) string {
 	var b strings.Builder
 
 	b.WriteString(words[0])
+
 	for _, word := range words[1:] {
 		r := []rune(word)
 		if len(r) == 0 {
@@ -196,6 +197,7 @@ func jsonTagMatchesFieldName(fieldName, jsonTagName string) bool {
 	return slices.Equal(splitIdentifierWords(fieldName), splitIdentifierWords(jsonTagName))
 }
 
+//nolint:cyclop
 func splitIdentifierWords(in string) []string {
 	if in == "" {
 		return nil
@@ -218,12 +220,15 @@ func splitIdentifierWords(in string) []string {
 		curr := runes[i]
 
 		var next rune
+
 		hasNext := i+1 < len(runes)
+
 		if hasNext {
 			next = runes[i+1]
 		}
 
 		boundary := false
+
 		switch {
 		case unicode.IsLower(prev) && unicode.IsUpper(curr):
 			boundary = true

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -266,15 +266,24 @@ func (a *analyzer) needsStringMaxLength(markerSet markershelper.MarkerSet) bool 
 	return true
 }
 
-// needsByteSliceMaxLength is like needsStringMaxLength but also accepts +k8s:maxBytes,
-// which is the DV-correct marker for byte-length constraints on []byte fields.
-// (+k8s:maxLength counts Unicode characters; +k8s:maxBytes counts raw bytes.)
+// needsByteSliceMaxLength is like needsStringMaxLength but enforces that for DV markers,
+// +k8s:maxBytes is used instead of +k8s:maxLength (which counts characters).
 func (a *analyzer) needsByteSliceMaxLength(markerSet markershelper.MarkerSet) bool {
-	if markerSet.Has(markers.K8sMaxBytesMarker) {
+	switch {
+	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxBytesMarker),
+		markerSet.Has(markers.KubebuilderEnumMarker),
+		markerSet.Has(markers.K8sEnumMarker),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")),
+		markerSet.HasWithValue(k8sFormatWithValue("date")),
+		markerSet.HasWithValue(k8sFormatWithValue("date-time")),
+		markerSet.HasWithValue(k8sFormatWithValue("duration")):
 		return false
 	}
 
-	return a.needsStringMaxLength(markerSet)
+	return true
 }
 
 func (a *analyzer) needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
@@ -299,5 +308,5 @@ func kubebuilderItemsFormatWithValue(value string) string {
 }
 
 func k8sFormatWithValue(value string) string {
-	return fmt.Sprintf("%s:=%s", markers.K8sFormatMarker, value)
+	return fmt.Sprintf("%s=%s", markers.K8sFormatMarker, value)
 }

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -32,35 +32,84 @@ const (
 	name = "maxlength"
 )
 
-// Analyzer is the analyzer for the maxlength package.
-// It checks that strings and arrays have maximum lengths and maximum items respectively.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspector.Analyzer},
+func init() {
+	markershelper.DefaultRegistry().Register(
+		markers.K8sMaxLengthMarker,
+		markers.K8sMaxBytesMarker,
+		markers.K8sMaxItemsMarker,
+		markers.K8sMaxPropertiesMarker,
+		markers.K8sEnumMarker,
+		markers.K8sFormatMarker,
+	)
 }
 
-func run(pass *analysis.Pass) (any, error) {
+// Analyzer is the analyzer for the maxlength package with the default (kubebuilder-preferred) configuration.
+// It checks that strings and arrays have maximum lengths and maximum items respectively.
+var Analyzer = newAnalyzer(nil)
+
+type analyzer struct {
+	preferredMaxLengthMarker     string
+	preferredMaxItemsMarker      string
+	preferredMaxPropertiesMarker string
+}
+
+// newAnalyzer creates a new analysis.Analyzer for the given MaxLengthConfig.
+// If cfg is nil, the default configuration is used (kubebuilder markers preferred).
+func newAnalyzer(cfg *MaxLengthConfig) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &MaxLengthConfig{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		preferredMaxLengthMarker:     cfg.PreferredMaxLengthMarker,
+		preferredMaxItemsMarker:      cfg.PreferredMaxItemsMarker,
+		preferredMaxPropertiesMarker: cfg.PreferredMaxPropertiesMarker,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that all string fields are marked with a maximum length, arrays are marked with max items, and maps are marked with max properties.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+}
+
+func defaultConfig(cfg *MaxLengthConfig) {
+	if cfg.PreferredMaxLengthMarker == "" {
+		cfg.PreferredMaxLengthMarker = markers.KubebuilderMaxLengthMarker
+	}
+
+	if cfg.PreferredMaxItemsMarker == "" {
+		cfg.PreferredMaxItemsMarker = markers.KubebuilderMaxItemsMarker
+	}
+
+	if cfg.PreferredMaxPropertiesMarker == "" {
+		cfg.PreferredMaxPropertiesMarker = markers.KubebuilderMaxPropertiesMarker
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
 	if !ok {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
+		a.checkField(pass, field, markersAccess, qualifiedFieldName)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	prefix := fmt.Sprintf("field %s", qualifiedFieldName)
 
-	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+	a.checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, a.preferredMaxLengthMarker, a.needsStringMaxLength)
 }
 
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
 		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 
@@ -72,7 +121,7 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 		return
 	}
 
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
 }
 
 func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
@@ -80,14 +129,14 @@ func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases [
 		return
 	}
 
-	markers := getCombinedMarkers(markersAccess, node, aliases)
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if needsMaxLength(markers) {
+	if needsMaxLength(markerSet) {
 		pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
 	}
 }
 
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
 	}
@@ -95,49 +144,70 @@ func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, alia
 	typeName := tSpec.Name.Name
 	prefix = fmt.Sprintf("%s %s", prefix, typeName)
 
-	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	a.checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 }
 
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
-		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.StarExpr:
-		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.ArrayType:
-		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+		a.checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+	case *ast.MapType:
+		a.checkMapType(pass, typ, node, aliases, markersAccess, prefix)
 	}
 }
 
-func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func (a *analyzer) checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
 			if ident.Name == "byte" {
 				// byte slices are a special case as they are treated as strings.
 				// Pretend the ident is a string so that checkString can process it as expected.
+				// In DV, +k8s:maxBytes (not +k8s:maxLength) is the correct tag for []byte fields,
+				// as it constrains byte count rather than Unicode character count.
 				i := &ast.Ident{
 					NamePos: ident.NamePos,
 					Name:    "string",
 				}
-				checkString(pass, i, node, aliases, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+				checkString(pass, i, node, aliases, markersAccess, prefix, a.preferredMaxLengthMarker, a.needsByteSliceMaxLength)
 
 				return
 			}
 
-			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+			a.checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
 		}
 	}
 
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) {
-		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, markers.KubebuilderMaxItemsMarker)
+	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) && !markerSet.Has(markers.K8sMaxItemsMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, a.preferredMaxItemsMarker)
 	}
 }
 
-func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+// checkMapType checks that map[string]V fields have a maximum properties marker.
+// Only string-keyed maps are checked, mirroring the DV constraint that +k8s:maxProperties
+// applies to map[string]V types only.
+func (a *analyzer) checkMapType(pass *analysis.Pass, mapType *ast.MapType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+	// DV +k8s:maxProperties only supports string-keyed maps.
+	// Skip non-string-keyed maps (e.g. map[int]string) to avoid false positives.
+	if keyIdent, ok := mapType.Key.(*ast.Ident); !ok || keyIdent.Name != "string" {
+		return
+	}
+
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
+
+	if !markerSet.Has(markers.KubebuilderMaxPropertiesMarker) && !markerSet.Has(markers.K8sMaxPropertiesMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum properties, add %s marker", prefix, a.preferredMaxPropertiesMarker)
+	}
+}
+
+func (a *analyzer) checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
+		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, a.needsItemsMaxLength)
 
 		return
 	}
@@ -149,16 +219,16 @@ func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node
 
 	// If the array element wasn't directly a string, allow a string alias to be used
 	// with either the items style markers or the on alias style markers.
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
-		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
+		return a.needsStringMaxLength(ms) && a.needsItemsMaxLength(ms)
 	})
 }
 
 func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
 	base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
 
-	for _, a := range aliases {
-		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+	for _, alias := range aliases {
+		base.Insert(getMarkers(markersAccess, alias).UnsortedList()...)
 	}
 
 	return base
@@ -175,23 +245,39 @@ func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelpe
 	return nil
 }
 
-// needsMaxLength returns true if the field needs a maximum length.
-// Fields do not need a maximum length if they are already marked with a maximum length,
-// or if they are an enum, or if they are a date, date-time or duration.
-func needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
+// needsStringMaxLength returns true if the field needs a maximum length.
+// Returns false if either a kubebuilder or DV max-length marker is already present,
+// or if the field is an enum, or is formatted as a date, date-time or duration.
+func (a *analyzer) needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
 	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxLengthMarker),
 		markerSet.Has(markers.KubebuilderEnumMarker),
+		markerSet.Has(markers.K8sEnumMarker),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")),
+		markerSet.HasWithValue(k8sFormatWithValue("date")),
+		markerSet.HasWithValue(k8sFormatWithValue("date-time")),
+		markerSet.HasWithValue(k8sFormatWithValue("duration")):
 		return false
 	}
 
 	return true
 }
 
-func needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
+// needsByteSliceMaxLength is like needsStringMaxLength but also accepts +k8s:maxBytes,
+// which is the DV-correct marker for byte-length constraints on []byte fields.
+// (+k8s:maxLength counts Unicode characters; +k8s:maxBytes counts raw bytes.)
+func (a *analyzer) needsByteSliceMaxLength(markerSet markershelper.MarkerSet) bool {
+	if markerSet.Has(markers.K8sMaxBytesMarker) {
+		return false
+	}
+
+	return a.needsStringMaxLength(markerSet)
+}
+
+func (a *analyzer) needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
 	case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
 		markerSet.Has(markers.KubebuilderItemsEnumMarker),
@@ -210,4 +296,8 @@ func kubebuilderFormatWithValue(value string) string {
 
 func kubebuilderItemsFormatWithValue(value string) string {
 	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+}
+
+func k8sFormatWithValue(value string) string {
+	return fmt.Sprintf("%s:=%s", markers.K8sFormatMarker, value)
 }

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -32,35 +32,84 @@ const (
 	name = "maxlength"
 )
 
-// Analyzer is the analyzer for the maxlength package.
-// It checks that strings and arrays have maximum lengths and maximum items respectively.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspector.Analyzer},
+func init() {
+	markershelper.DefaultRegistry().Register(
+		markers.K8sMaxLengthMarker,
+		markers.K8sMaxBytesMarker,
+		markers.K8sMaxItemsMarker,
+		markers.K8sMaxPropertiesMarker,
+		markers.K8sEnumMarker,
+		markers.K8sFormatMarker,
+	)
 }
 
-func run(pass *analysis.Pass) (any, error) {
+// Analyzer is the analyzer for the maxlength package with the default (kubebuilder-preferred) configuration.
+// It checks that strings and arrays have maximum lengths and maximum items respectively.
+var Analyzer = newAnalyzer(nil)
+
+type analyzer struct {
+	preferredMaxLengthMarker     string
+	preferredMaxItemsMarker      string
+	preferredMaxPropertiesMarker string
+}
+
+// newAnalyzer creates a new analysis.Analyzer for the given MaxLengthConfig.
+// If cfg is nil, the default configuration is used (kubebuilder markers preferred).
+func newAnalyzer(cfg *MaxLengthConfig) *analysis.Analyzer {
+	if cfg == nil {
+		cfg = &MaxLengthConfig{}
+	}
+
+	defaultConfig(cfg)
+
+	a := &analyzer{
+		preferredMaxLengthMarker:     cfg.PreferredMaxLengthMarker,
+		preferredMaxItemsMarker:      cfg.PreferredMaxItemsMarker,
+		preferredMaxPropertiesMarker: cfg.PreferredMaxPropertiesMarker,
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that all string fields are marked with a maximum length, arrays are marked with max items, and maps are marked with max properties.",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+}
+
+func defaultConfig(cfg *MaxLengthConfig) {
+	if cfg.PreferredMaxLengthMarker == "" {
+		cfg.PreferredMaxLengthMarker = markers.KubebuilderMaxLengthMarker
+	}
+
+	if cfg.PreferredMaxItemsMarker == "" {
+		cfg.PreferredMaxItemsMarker = markers.KubebuilderMaxItemsMarker
+	}
+
+	if cfg.PreferredMaxPropertiesMarker == "" {
+		cfg.PreferredMaxPropertiesMarker = markers.KubebuilderMaxPropertiesMarker
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
 	if !ok {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
 	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
+		a.checkField(pass, field, markersAccess, qualifiedFieldName)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	prefix := fmt.Sprintf("field %s", qualifiedFieldName)
 
-	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+	a.checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, a.preferredMaxLengthMarker, a.needsStringMaxLength)
 }
 
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
 		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 
@@ -72,7 +121,7 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 		return
 	}
 
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
 }
 
 func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
@@ -80,14 +129,14 @@ func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases [
 		return
 	}
 
-	markers := getCombinedMarkers(markersAccess, node, aliases)
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if needsMaxLength(markers) {
+	if needsMaxLength(markerSet) {
 		pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
 	}
 }
 
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
 	}
@@ -95,49 +144,80 @@ func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, alia
 	typeName := tSpec.Name.Name
 	prefix = fmt.Sprintf("%s %s", prefix, typeName)
 
-	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	a.checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 }
 
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
+func (a *analyzer) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
-		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.StarExpr:
-		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+		a.checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 	case *ast.ArrayType:
-		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+		a.checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+	case *ast.MapType:
+		a.checkMapType(pass, typ, node, aliases, markersAccess, prefix)
 	}
 }
 
-func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func (a *analyzer) checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
 			if ident.Name == "byte" {
-				// byte slices are a special case as they are treated as strings.
-				// Pretend the ident is a string so that checkString can process it as expected.
-				i := &ast.Ident{
-					NamePos: ident.NamePos,
-					Name:    "string",
-				}
-				checkString(pass, i, node, aliases, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
+				a.checkByteSlice(pass, ident, node, aliases, markersAccess, prefix)
 
 				return
 			}
 
-			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+			a.checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
 		}
 	}
 
 	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) {
-		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, markers.KubebuilderMaxItemsMarker)
+	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) && !markerSet.Has(markers.K8sMaxItemsMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, a.preferredMaxItemsMarker)
 	}
 }
 
-func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+func (a *analyzer) checkByteSlice(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+	// byte slices are a special case as they are treated as strings.
+	// Pretend the ident is a string so that checkString can process it as expected.
+	// In DV, k8s:maxBytes (not k8s:maxLength) is the correct tag for []byte fields,
+	// as it constrains byte count rather than Unicode character count.
+	i := &ast.Ident{
+		NamePos: ident.NamePos,
+		Name:    "string",
+	}
+
+	suggestedMarker := a.preferredMaxLengthMarker
+	if suggestedMarker == markers.K8sMaxLengthMarker {
+		suggestedMarker = markers.K8sMaxBytesMarker
+	}
+
+	checkString(pass, i, node, aliases, markersAccess, prefix, suggestedMarker, a.needsByteSliceMaxLength)
+}
+
+// checkMapType checks that map[string]V fields have a maximum properties marker.
+// Only string-keyed maps are checked, mirroring the constraint that maxProperties
+// validation only applies to map[string]V types.
+func (a *analyzer) checkMapType(pass *analysis.Pass, mapType *ast.MapType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
+	// Map maxProperties validation only supports string-keyed maps.
+	// Skip non-string-keyed maps (e.g. map[int]string) to avoid false positives.
+	if !utils.IsStringType(pass, mapType.Key) {
+		return
+	}
+
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
+
+	if !markerSet.Has(markers.KubebuilderMaxPropertiesMarker) && !markerSet.Has(markers.K8sMaxPropertiesMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum properties, add %s marker", prefix, a.preferredMaxPropertiesMarker)
+	}
+}
+
+func (a *analyzer) checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
+		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, a.needsItemsMaxLength)
 
 		return
 	}
@@ -149,16 +229,16 @@ func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node
 
 	// If the array element wasn't directly a string, allow a string alias to be used
 	// with either the items style markers or the on alias style markers.
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
-		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+	a.checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
+		return a.needsStringMaxLength(ms) && a.needsItemsMaxLength(ms)
 	})
 }
 
 func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
 	base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
 
-	for _, a := range aliases {
-		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+	for _, alias := range aliases {
+		base.Insert(getMarkers(markersAccess, alias).UnsortedList()...)
 	}
 
 	return base
@@ -175,23 +255,48 @@ func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelpe
 	return nil
 }
 
-// needsMaxLength returns true if the field needs a maximum length.
-// Fields do not need a maximum length if they are already marked with a maximum length,
-// or if they are an enum, or if they are a date, date-time or duration.
-func needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
+// needsStringMaxLength returns true if the field needs a maximum length.
+// Returns false if either a kubebuilder or DV max-length marker is already present,
+// or if the field is an enum, or is formatted as a date, date-time or duration.
+func (a *analyzer) needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
 	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxLengthMarker),
 		markerSet.Has(markers.KubebuilderEnumMarker),
+		markerSet.Has(markers.K8sEnumMarker),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
-		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")),
+		markerSet.HasWithValue(k8sFormatWithValue("date")),
+		markerSet.HasWithValue(k8sFormatWithValue("date-time")),
+		markerSet.HasWithValue(k8sFormatWithValue("duration")):
 		return false
 	}
 
 	return true
 }
 
-func needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
+// needsByteSliceMaxLength is like needsStringMaxLength but enforces that for DV markers,
+// k8s:maxBytes is used instead of k8s:maxLength (which counts characters).
+func (a *analyzer) needsByteSliceMaxLength(markerSet markershelper.MarkerSet) bool {
+	switch {
+	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.K8sMaxBytesMarker),
+		markerSet.Has(markers.KubebuilderEnumMarker),
+		markerSet.Has(markers.K8sEnumMarker),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")),
+		markerSet.HasWithValue(k8sFormatWithValue("date")),
+		markerSet.HasWithValue(k8sFormatWithValue("date-time")),
+		markerSet.HasWithValue(k8sFormatWithValue("duration")):
+		return false
+	}
+
+	return true
+}
+
+func (a *analyzer) needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
 	case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
 		markerSet.Has(markers.KubebuilderItemsEnumMarker),
@@ -210,4 +315,8 @@ func kubebuilderFormatWithValue(value string) string {
 
 func kubebuilderItemsFormatWithValue(value string) string {
 	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
+}
+
+func k8sFormatWithValue(value string) string {
+	return fmt.Sprintf("%s=%s", markers.K8sFormatMarker, value)
 }

--- a/pkg/analysis/maxlength/analyzer_test.go
+++ b/pkg/analysis/maxlength/analyzer_test.go
@@ -19,11 +19,145 @@ import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/maxlength"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
+// TestMaxLength tests the default (kubebuilder-preferred) configuration against
+// existing kubebuilder testdata.
 func TestMaxLength(t *testing.T) {
 	testdata := analysistest.TestData()
 
 	analysistest.Run(t, testdata, maxlength.Analyzer, "a")
+}
+
+// TestMaxLength_DVMarkers tests that the linter (default config) accepts DV
+// markers as satisfying the max-length/max-items/max-properties constraints.
+func TestMaxLength_DVMarkers(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	// The DV testdata lives in the same package "a" (c.go + d.go).
+	// Running against "a" exercises both the original kubebuilder fixtures and the new DV ones.
+	analysistest.Run(t, testdata, maxlength.Analyzer, "a")
+}
+
+// TestMaxLength_DVPreferred tests the linter configured to prefer DV markers in
+// diagnostic messages.
+func TestMaxLength_DVPreferred(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	ci, ok := maxlength.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+	if !ok {
+		t.Fatal("maxlength.Initializer() does not implement ConfigurableAnalyzerInitializer")
+	}
+
+	a, err := ci.Init(&maxlength.MaxLengthConfig{
+		PreferredMaxLengthMarker:     markers.K8sMaxLengthMarker,
+		PreferredMaxItemsMarker:      markers.K8sMaxItemsMarker,
+		PreferredMaxPropertiesMarker: markers.K8sMaxPropertiesMarker,
+	})
+	if err != nil {
+		t.Fatalf("failed to init analyzer: %v", err)
+	}
+
+	// Run only against c.go-style testdata when DV markers are preferred.
+	// The want-comments in a.go cite kubebuilder markers; for this run we use a
+	// separate package that has no want-comments (happy-path only).
+	// For now we verify the analyzer initialises and runs without panicking.
+	_ = a
+	_ = testdata
+}
+
+// TestMaxLengthInitializerValidation tests that the MaxLengthConfig validator
+// accepts valid values and rejects invalid ones.
+func TestMaxLengthInitializerValidation(t *testing.T) {
+	ci, ok := maxlength.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+	if !ok {
+		t.Fatal("maxlength.Initializer() does not implement ConfigurableAnalyzerInitializer")
+	}
+
+	tests := []struct {
+		name        string
+		cfg         maxlength.MaxLengthConfig
+		wantErrPath string
+		wantErrMsg  string
+	}{
+		{
+			name: "empty config is valid",
+			cfg:  maxlength.MaxLengthConfig{},
+		},
+		{
+			name: "kubebuilder markers are valid",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker:     markers.KubebuilderMaxLengthMarker,
+				PreferredMaxItemsMarker:      markers.KubebuilderMaxItemsMarker,
+				PreferredMaxPropertiesMarker: markers.KubebuilderMaxPropertiesMarker,
+			},
+		},
+		{
+			name: "DV markers are valid",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker:     markers.K8sMaxLengthMarker,
+				PreferredMaxItemsMarker:      markers.K8sMaxItemsMarker,
+				PreferredMaxPropertiesMarker: markers.K8sMaxPropertiesMarker,
+			},
+		},
+		{
+			name: "invalid PreferredMaxLengthMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxLengthMarker",
+			wantErrMsg:  "invalid",
+		},
+		{
+			name: "invalid PreferredMaxItemsMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxItemsMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxItemsMarker",
+			wantErrMsg:  "invalid",
+		},
+		{
+			name: "invalid PreferredMaxPropertiesMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxPropertiesMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxPropertiesMarker",
+			wantErrMsg:  "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ci.ValidateConfig(&tt.cfg, field.NewPath("maxlength"))
+			if tt.wantErrPath == "" {
+				if len(errs) != 0 {
+					t.Errorf("expected no errors, got: %v", errs)
+				}
+
+				return
+			}
+
+			if len(errs) == 0 {
+				t.Fatalf("expected an error for %s, got none", tt.wantErrPath)
+			}
+
+			found := false
+
+			for _, e := range errs {
+				if e.Field == tt.wantErrPath {
+					found = true
+
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("expected error at field %q, got: %v", tt.wantErrPath, errs)
+			}
+		})
+	}
 }

--- a/pkg/analysis/maxlength/analyzer_test.go
+++ b/pkg/analysis/maxlength/analyzer_test.go
@@ -19,11 +19,126 @@ import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/maxlength"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
+// TestMaxLength tests the default (kubebuilder-preferred) configuration against
+// existing kubebuilder testdata.
 func TestMaxLength(t *testing.T) {
 	testdata := analysistest.TestData()
 
 	analysistest.Run(t, testdata, maxlength.Analyzer, "a")
+}
+
+// TestMaxLength_DVPreferred tests the linter configured to prefer DV markers.
+// DV-style markers (k8s:maxLength, k8s:maxItems, k8s:maxProperties, k8s:maxBytes)
+// satisfy the constraints and produce no diagnostic. Missing markers produce
+// diagnostics citing the k8s:* form.
+func TestMaxLength_DVPreferred(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	a, err := maxlength.Initializer().Initialize(&maxlength.MaxLengthConfig{
+		PreferredMaxLengthMarker:     markers.K8sMaxLengthMarker,
+		PreferredMaxItemsMarker:      markers.K8sMaxItemsMarker,
+		PreferredMaxPropertiesMarker: markers.K8sMaxPropertiesMarker,
+	})
+	if err != nil {
+		t.Fatalf("failed to init analyzer: %v", err)
+	}
+
+	// Package "b" has want-comments referencing k8s:* marker names, so the
+	// analyzer must emit diagnostics with those names when a field is missing a
+	// marker, and must not emit anything for fields that carry a DV marker.
+	analysistest.Run(t, testdata, a, "b")
+}
+
+// TestMaxLengthInitializerValidation tests that the MaxLengthConfig validator
+// accepts valid values and rejects invalid ones.
+func TestMaxLengthInitializerValidation(t *testing.T) {
+	ci := maxlength.Initializer()
+
+	tests := []struct {
+		name        string
+		cfg         maxlength.MaxLengthConfig
+		wantErrPath string
+		wantErrMsg  string
+	}{
+		{
+			name: "empty config is valid",
+			cfg:  maxlength.MaxLengthConfig{},
+		},
+		{
+			name: "kubebuilder markers are valid",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker:     markers.KubebuilderMaxLengthMarker,
+				PreferredMaxItemsMarker:      markers.KubebuilderMaxItemsMarker,
+				PreferredMaxPropertiesMarker: markers.KubebuilderMaxPropertiesMarker,
+			},
+		},
+		{
+			name: "DV markers are valid",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker:     markers.K8sMaxLengthMarker,
+				PreferredMaxItemsMarker:      markers.K8sMaxItemsMarker,
+				PreferredMaxPropertiesMarker: markers.K8sMaxPropertiesMarker,
+			},
+		},
+		{
+			name: "invalid PreferredMaxLengthMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxLengthMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxLengthMarker",
+			wantErrMsg:  "invalid",
+		},
+		{
+			name: "invalid PreferredMaxItemsMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxItemsMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxItemsMarker",
+			wantErrMsg:  "invalid",
+		},
+		{
+			name: "invalid PreferredMaxPropertiesMarker",
+			cfg: maxlength.MaxLengthConfig{
+				PreferredMaxPropertiesMarker: "invalid",
+			},
+			wantErrPath: "maxlength.preferredMaxPropertiesMarker",
+			wantErrMsg:  "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ci.ValidateConfig(&tt.cfg, field.NewPath("maxlength"))
+			if tt.wantErrPath == "" {
+				if len(errs) != 0 {
+					t.Errorf("expected no errors, got: %v", errs)
+				}
+
+				return
+			}
+
+			if len(errs) == 0 {
+				t.Fatalf("expected an error for %s, got none", tt.wantErrPath)
+			}
+
+			found := false
+
+			for _, e := range errs {
+				if e.Field == tt.wantErrPath {
+					found = true
+
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("expected error at field %q, got: %v", tt.wantErrPath, errs)
+			}
+		})
+	}
 }

--- a/pkg/analysis/maxlength/config.go
+++ b/pkg/analysis/maxlength/config.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package maxlength
+
+// MaxLengthConfig contains configuration for the maxlength linter.
+type MaxLengthConfig struct {
+	// PreferredMaxLengthMarker is the preferred marker to cite in diagnostics for
+	// string maximum-length violations.
+	// If not set, the default value is "kubebuilder:validation:MaxLength".
+	// Valid values are "kubebuilder:validation:MaxLength" and "k8s:maxLength".
+	PreferredMaxLengthMarker string `json:"preferredMaxLengthMarker"`
+
+	// PreferredMaxItemsMarker is the preferred marker to cite in diagnostics for
+	// array maximum-items violations.
+	// If not set, the default value is "kubebuilder:validation:MaxItems".
+	// Valid values are "kubebuilder:validation:MaxItems" and "k8s:maxItems".
+	PreferredMaxItemsMarker string `json:"preferredMaxItemsMarker"`
+
+	// PreferredMaxPropertiesMarker is the preferred marker to cite in diagnostics for
+	// map maximum-properties violations.
+	// If not set, the default value is "kubebuilder:validation:MaxProperties".
+	// Valid values are "kubebuilder:validation:MaxProperties" and "k8s:maxProperties".
+	PreferredMaxPropertiesMarker string `json:"preferredMaxPropertiesMarker"`
+}

--- a/pkg/analysis/maxlength/doc.go
+++ b/pkg/analysis/maxlength/doc.go
@@ -15,21 +15,43 @@ limitations under the License.
 */
 
 /*
-maxlength is an analyzer that checks that all string fields have a maximum length, and that all array fields have a maximum number of items.
+maxlength is an analyzer that checks that all string fields have a maximum length,
+all array fields have a maximum number of items, and all map fields have a maximum
+number of properties.
 
-String fields that are not otherwise bound in length, through being an enum or formatted in a certain way, should have a maximum length.
-This ensures that CEL validations on the field are not overly costly in terms of time and memory.
+String fields that are not otherwise bound in length, through being an enum or
+formatted in a certain way, should have a maximum length.
+This ensures that CEL validations on the field are not overly costly in terms of
+time and memory.
 
 Array fields should have a maximum number of items.
-This ensures that any CEL validations on the field are not overly costly in terms of time and memory.
-Where arrays are used to represent a list of structures, CEL rules may exist within the array.
-Limiting the array length ensures the cardinality of the rules within the array is not unbounded.
+This ensures that any CEL validations on the field are not overly costly in terms
+of time and memory. Where arrays are used to represent a list of structures, CEL
+rules may exist within the array. Limiting the array length ensures the cardinality
+of the rules within the array is not unbounded.
 
-For strings, the maximum length can be set using the `kubebuilder:validation:MaxLength` tag.
-For arrays, the maximum number of items can be set using the `kubebuilder:validation:MaxItems` tag.
+Map fields (with string keys) should have a maximum number of properties.
+This ensures that CEL validations on the map are not overly costly.
 
-For arrays of strings, the maximum length of each string can be set using the `kubebuilder:validation:items:MaxLength` tag,
-on the array field itself.
-Or, if the array uses a string type alias, the `kubebuilder:validation:MaxLength` tag can be used on the alias.
+For strings, the maximum length can be set using the `kubebuilder:validation:MaxLength`
+or `k8s:maxLength` tag.
+
+For byte slices ([]byte), the maximum length can be set using the
+`kubebuilder:validation:MaxLength` or `k8s:maxBytes` tag. Note that in k8s declarative
+validation, `k8s:maxBytes` constrains the byte count whereas `k8s:maxLength` constrains
+the Unicode character count — `k8s:maxBytes` is the semantically correct tag for []byte.
+
+For arrays, the maximum number of items can be set using the `kubebuilder:validation:MaxItems`
+or `k8s:maxItems` tag.
+
+For arrays of strings, the maximum length of each string can be set using the
+`kubebuilder:validation:items:MaxLength` tag on the array field itself.
+Or, if the array uses a string type alias, the `kubebuilder:validation:MaxLength` tag can
+be used on the alias.
+
+For maps with string keys, the maximum number of properties can be set using the
+`kubebuilder:validation:MaxProperties` or `k8s:maxProperties` tag.
+
+The preferred marker cited in diagnostics is configurable via MaxLengthConfig.
 */
 package maxlength

--- a/pkg/analysis/maxlength/initializer.go
+++ b/pkg/analysis/maxlength/initializer.go
@@ -16,8 +16,13 @@ limitations under the License.
 package maxlength
 
 import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func init() {
@@ -27,9 +32,61 @@ func init() {
 // Initializer returns the AnalyzerInitializer for this
 // Analyzer so that it can be added to the registry.
 func Initializer() initializer.AnalyzerInitializer {
-	return initializer.NewInitializer(
+	return initializer.NewConfigurableInitializer(
 		name,
-		Analyzer,
+		initAnalyzer,
 		false, // For now, CRD only, and so not on by default.
+		validateConfig,
 	)
+}
+
+func initAnalyzer(cfg *MaxLengthConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+// validateConfig validates the configuration in the MaxLengthConfig struct.
+func validateConfig(cfg *MaxLengthConfig, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{}
+	}
+
+	errs := field.ErrorList{}
+
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxLengthMarker"),
+		cfg.PreferredMaxLengthMarker,
+		markers.KubebuilderMaxLengthMarker,
+		markers.K8sMaxLengthMarker,
+		&errs,
+	)
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxItemsMarker"),
+		cfg.PreferredMaxItemsMarker,
+		markers.KubebuilderMaxItemsMarker,
+		markers.K8sMaxItemsMarker,
+		&errs,
+	)
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxPropertiesMarker"),
+		cfg.PreferredMaxPropertiesMarker,
+		markers.KubebuilderMaxPropertiesMarker,
+		markers.K8sMaxPropertiesMarker,
+		&errs,
+	)
+
+	return errs
+}
+
+// validateMarkerChoice validates that value is either empty, the kubebuilder form, or the k8s DV form.
+func validateMarkerChoice(fld *field.Path, value, kubebuilder, k8s string, errs *field.ErrorList) {
+	switch value {
+	case "", kubebuilder, k8s:
+		// Valid.
+	default:
+		*errs = append(*errs, field.Invalid(
+			fld,
+			value,
+			fmt.Sprintf("invalid value, must be one of %q, %q or omitted", kubebuilder, k8s),
+		))
+	}
 }

--- a/pkg/analysis/maxlength/initializer.go
+++ b/pkg/analysis/maxlength/initializer.go
@@ -16,20 +16,96 @@ limitations under the License.
 package maxlength
 
 import (
+	"fmt"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func init() {
 	registry.DefaultRegistry().RegisterLinter(Initializer())
 }
 
-// Initializer returns the AnalyzerInitializer for this
+// MaxLengthInitializer is the initializer for the maxlength analyzer.
+// It embeds ConfigurableAnalyzerInitializer and adds a typed Initialize
+// method so callers can skip the runtime type assertion.
+type MaxLengthInitializer struct {
+	initializer.ConfigurableAnalyzerInitializer
+}
+
+// Initialize creates a new maxlength analyzer configured with cfg.
+func (m MaxLengthInitializer) Initialize(cfg *MaxLengthConfig) (*analysis.Analyzer, error) {
+	a, err := m.Init(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("maxlength: %w", err)
+	}
+
+	return a, nil
+}
+
+// Initializer returns the MaxLengthInitializer for this
 // Analyzer so that it can be added to the registry.
-func Initializer() initializer.AnalyzerInitializer {
-	return initializer.NewInitializer(
-		name,
-		Analyzer,
-		false, // For now, CRD only, and so not on by default.
+func Initializer() MaxLengthInitializer {
+	return MaxLengthInitializer{
+		ConfigurableAnalyzerInitializer: initializer.NewConfigurableInitializer(
+			name,
+			initAnalyzer,
+			false, // For now, CRD only, and so not on by default.
+			validateConfig,
+		),
+	}
+}
+
+func initAnalyzer(cfg *MaxLengthConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+// validateConfig validates the configuration in the MaxLengthConfig struct.
+func validateConfig(cfg *MaxLengthConfig, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{}
+	}
+
+	errs := field.ErrorList{}
+
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxLengthMarker"),
+		cfg.PreferredMaxLengthMarker,
+		markers.KubebuilderMaxLengthMarker,
+		markers.K8sMaxLengthMarker,
+		&errs,
 	)
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxItemsMarker"),
+		cfg.PreferredMaxItemsMarker,
+		markers.KubebuilderMaxItemsMarker,
+		markers.K8sMaxItemsMarker,
+		&errs,
+	)
+	validateMarkerChoice(
+		fldPath.Child("preferredMaxPropertiesMarker"),
+		cfg.PreferredMaxPropertiesMarker,
+		markers.KubebuilderMaxPropertiesMarker,
+		markers.K8sMaxPropertiesMarker,
+		&errs,
+	)
+
+	return errs
+}
+
+// validateMarkerChoice validates that value is either empty, the kubebuilder form, or the k8s DV form.
+func validateMarkerChoice(fld *field.Path, value, kubebuilder, k8s string, errs *field.ErrorList) {
+	switch value {
+	case "", kubebuilder, k8s:
+		// Valid.
+	default:
+		*errs = append(*errs, field.Invalid(
+			fld,
+			value,
+			fmt.Sprintf("invalid value, must be one of %q, %q or omitted", kubebuilder, k8s),
+		))
+	}
 }

--- a/pkg/analysis/maxlength/testdata/src/a/c.go
+++ b/pkg/analysis/maxlength/testdata/src/a/c.go
@@ -1,0 +1,83 @@
+package a
+
+// DVMaxLength exercises the DV marker variants of the maxlength linter.
+// DV-only markers should be accepted without requiring the kubebuilder form.
+type DVMaxLength struct {
+	// Only DV maxLength — should NOT lint.
+	// +k8s:maxLength=256
+	StringWithDVMaxLength string
+
+	// DV maxBytes for a []byte field — should NOT lint.
+	// +k8s:maxBytes=512
+	ByteSliceWithDVMaxBytes []byte
+
+	// DV maxItems for an array — should NOT lint.
+	// +k8s:maxItems=128
+	ArrayWithDVMaxItems []int
+
+	// DV maxProperties for a map[string]V — should NOT lint.
+	// +k8s:maxProperties=64
+	MapWithDVMaxProperties map[string]string
+
+	// Both kubebuilder and DV markers — should NOT lint (either satisfies).
+	// +kubebuilder:validation:MaxLength:=256
+	// +k8s:maxLength=256
+	StringWithBothMarkers string
+
+	// Both kubebuilder and DV maxItems — should NOT lint.
+	// +kubebuilder:validation:MaxItems:=32
+	// +k8s:maxItems=32
+	ArrayWithBothMaxItemsMarkers []int
+
+	// +k8s:enum
+	// DV enum marker should exempt the string from requiring a max-length.
+	DVEnumString string
+
+	// +k8s:format=date-time
+	// DV format:=date-time should exempt the string from requiring a max-length.
+	DVDateTimeString string
+
+	// +k8s:format=date
+	// DV format:=date should exempt the string from requiring a max-length.
+	DVDateString string
+
+	// +k8s:format=duration
+	// DV format:=duration should exempt the string from requiring a max-length.
+	DVDurationString string
+
+	// No marker on string — SHOULD lint.
+	StringWithNoMaxLength string // want `field DVMaxLength.StringWithNoMaxLength must have a maximum length, add kubebuilder:validation:MaxLength marker`
+
+	// No marker on []byte — SHOULD lint.
+	ByteSliceWithNoMax []byte // want `field DVMaxLength.ByteSliceWithNoMax must have a maximum length, add kubebuilder:validation:MaxLength marker`
+
+	// No marker on array — SHOULD lint.
+	ArrayWithNoMaxItems []int // want `field DVMaxLength.ArrayWithNoMaxItems must have a maximum items, add kubebuilder:validation:MaxItems marker`
+
+	// No marker on map[string]V — SHOULD lint.
+	MapWithNoMaxProperties map[string]string // want `field DVMaxLength.MapWithNoMaxProperties must have a maximum properties, add kubebuilder:validation:MaxProperties marker`
+
+	// Non-string-keyed map — should NOT lint.
+	// DV +k8s:maxProperties only supports string-keyed maps; linter mirrors this constraint.
+	MapWithIntKey map[int]string
+
+	// DV maxLength applied to []byte — SHOULD lint.
+	// +k8s:maxLength (counts chars) is not the correct DV tag for []byte;
+	// +k8s:maxBytes (counts bytes) should be used instead.
+	// +k8s:maxLength=256
+	ByteSliceWithWrongDVMarker []byte // want `field DVMaxLength.ByteSliceWithWrongDVMarker must have a maximum length, add kubebuilder:validation:MaxLength marker`
+}
+
+// StringAliasDVMaxLength is a string type with the DV maxLength marker on the alias.
+// +k8s:maxLength=512
+type StringAliasDVMaxLength string
+
+// DVMaxLengthWithAliases exercises DV markers on string-alias array elements.
+type DVMaxLengthWithAliases struct {
+	// Array of DV-max-length string aliases — should NOT lint on the element length.
+	// +kubebuilder:validation:MaxItems:=64
+	AliasArrayWithMaxItems []StringAliasDVMaxLength
+
+	// Array without MaxItems marker — SHOULD lint.
+	AliasArrayWithoutMaxItems []StringAliasDVMaxLength // want `field DVMaxLengthWithAliases.AliasArrayWithoutMaxItems must have a maximum items, add kubebuilder:validation:MaxItems marker`
+}

--- a/pkg/analysis/maxlength/testdata/src/a/c.go
+++ b/pkg/analysis/maxlength/testdata/src/a/c.go
@@ -1,0 +1,90 @@
+package a
+
+// DVMaxLength exercises the DV marker variants of the maxlength linter.
+// DV-only markers should be accepted without requiring the kubebuilder form.
+type DVMaxLength struct {
+	// Only DV maxLength — should NOT lint.
+	// +k8s:maxLength=256
+	StringWithDVMaxLength string
+
+	// DV maxBytes for a []byte field — should NOT lint.
+	// +k8s:maxBytes=512
+	ByteSliceWithDVMaxBytes []byte
+
+	// DV maxItems for an array — should NOT lint.
+	// +k8s:maxItems=128
+	ArrayWithDVMaxItems []int
+
+	// DV maxProperties for a map[string]V — should NOT lint.
+	// +k8s:maxProperties=64
+	MapWithDVMaxProperties map[string]string
+
+	// Both kubebuilder and DV markers — should NOT lint (either satisfies).
+	// +kubebuilder:validation:MaxLength:=256
+	// +k8s:maxLength=256
+	StringWithBothMarkers string
+
+	// Both kubebuilder and DV maxItems — should NOT lint.
+	// +kubebuilder:validation:MaxItems:=32
+	// +k8s:maxItems=32
+	ArrayWithBothMaxItemsMarkers []int
+
+	// +k8s:enum
+	// DV enum marker should exempt the string from requiring a max-length.
+	DVEnumString string
+
+	// +k8s:format=date-time
+	// DV format:=date-time should exempt the string from requiring a max-length.
+	DVDateTimeString string
+
+	// +k8s:format=date
+	// DV format:=date should exempt the string from requiring a max-length.
+	DVDateString string
+
+	// +k8s:format=duration
+	// DV format:=duration should exempt the string from requiring a max-length.
+	DVDurationString string
+
+	// No marker on string — SHOULD lint.
+	StringWithNoMaxLength string // want `field DVMaxLength.StringWithNoMaxLength must have a maximum length, add kubebuilder:validation:MaxLength marker`
+
+	// No marker on []byte — SHOULD lint.
+	ByteSliceWithNoMax []byte // want `field DVMaxLength.ByteSliceWithNoMax must have a maximum length, add kubebuilder:validation:MaxLength marker`
+
+	// No marker on array — SHOULD lint.
+	ArrayWithNoMaxItems []int // want `field DVMaxLength.ArrayWithNoMaxItems must have a maximum items, add kubebuilder:validation:MaxItems marker`
+
+	// No marker on map[string]V — SHOULD lint.
+	MapWithNoMaxProperties map[string]string // want `field DVMaxLength.MapWithNoMaxProperties must have a maximum properties, add kubebuilder:validation:MaxProperties marker`
+
+	// Non-string-keyed map — should NOT lint.
+	// Map maxProperties validation only supports string-keyed maps; linter mirrors this constraint.
+	MapWithIntKey map[int]string
+
+	// DV maxLength applied to []byte — SHOULD lint.
+	// k8s:maxLength (counts chars) is not the correct DV tag for []byte;
+	// k8s:maxBytes (counts bytes) should be used instead.
+	// +k8s:maxLength=256
+	ByteSliceWithWrongDVMarker []byte // want `field DVMaxLength.ByteSliceWithWrongDVMarker must have a maximum length, add kubebuilder:validation:MaxLength marker`
+
+	// Map with string-alias key — should lint for maxProperties.
+	MapWithStringAliasKey map[StringAliasDVMaxLength]string // want `field DVMaxLength.MapWithStringAliasKey must have a maximum properties, add kubebuilder:validation:MaxProperties marker`
+
+	// Map with string-alias key with marker — should NOT lint.
+	// +kubebuilder:validation:MaxProperties:=16
+	MapWithStringAliasKeyAndMarker map[StringAliasDVMaxLength]string
+}
+
+// StringAliasDVMaxLength is a string type with the DV maxLength marker on the alias.
+// +k8s:maxLength=512
+type StringAliasDVMaxLength string
+
+// DVMaxLengthWithAliases exercises DV markers on string-alias array elements.
+type DVMaxLengthWithAliases struct {
+	// Array of DV-max-length string aliases — should NOT lint on the element length.
+	// +kubebuilder:validation:MaxItems:=64
+	AliasArrayWithMaxItems []StringAliasDVMaxLength
+
+	// Array without MaxItems marker — SHOULD lint.
+	AliasArrayWithoutMaxItems []StringAliasDVMaxLength // want `field DVMaxLengthWithAliases.AliasArrayWithoutMaxItems must have a maximum items, add kubebuilder:validation:MaxItems marker`
+}

--- a/pkg/analysis/maxlength/testdata/src/a/d.go
+++ b/pkg/analysis/maxlength/testdata/src/a/d.go
@@ -1,0 +1,8 @@
+package a
+
+// StringAliasDVMaxLengthB is a string type with the DV maxLength marker on the alias (second file).
+// +k8s:maxLength=512
+type StringAliasDVMaxLengthB string
+
+// StringAliasNoDVMaxLengthB is a string type without any max-length marker.
+type StringAliasNoDVMaxLengthB string

--- a/pkg/analysis/maxlength/testdata/src/b/b.go
+++ b/pkg/analysis/maxlength/testdata/src/b/b.go
@@ -1,0 +1,103 @@
+package b
+
+// DVPreferredMaxLength exercises the linter when configured to prefer DV markers.
+// Fields that carry only DV markers should NOT lint.
+// Fields that are missing markers should lint with a diagnostic citing the k8s:* form.
+type DVPreferredMaxLength struct {
+	// +k8s:maxLength=256
+	StringWithDVMaxLength string // satisfied by DV marker — no lint
+
+	// +kubebuilder:validation:MaxLength:=128
+	StringWithKubebuilderMaxLength string // kubebuilder marker also satisfies — no lint
+
+	StringWithoutMaxLength string // want `field DVPreferredMaxLength.StringWithoutMaxLength must have a maximum length, add k8s:maxLength marker`
+
+	// +k8s:maxBytes=512
+	ByteSliceWithDVMaxBytes []byte // satisfied by k8s:maxBytes — no lint
+
+	ByteSliceWithoutMax []byte // want `field DVPreferredMaxLength.ByteSliceWithoutMax must have a maximum length, add k8s:maxBytes marker`
+
+	// +k8s:maxItems=128
+	ArrayWithDVMaxItems []int // satisfied by k8s:maxItems — no lint
+
+	// +kubebuilder:validation:MaxItems:=64
+	ArrayWithKubebuilderMaxItems []int // kubebuilder marker also satisfies — no lint
+
+	ArrayWithoutMaxItems []int // want `field DVPreferredMaxLength.ArrayWithoutMaxItems must have a maximum items, add k8s:maxItems marker`
+
+	// +k8s:maxProperties=64
+	MapWithDVMaxProperties map[string]string // satisfied by k8s:maxProperties — no lint
+
+	// +kubebuilder:validation:MaxProperties:=32
+	MapWithKubebuilderMaxProperties map[string]string // kubebuilder marker also satisfies — no lint
+
+	MapWithoutMaxProperties map[string]string // want `field DVPreferredMaxLength.MapWithoutMaxProperties must have a maximum properties, add k8s:maxProperties marker`
+
+	// Non-string-keyed map — never linted regardless of config.
+	MapWithIntKey map[int]string
+
+	// +k8s:enum
+	DVEnumString string // enum exempts from max-length — no lint
+
+	// +kubebuilder:validation:Enum:="A";"B"
+	KubebuilderEnumString string // kubebuilder enum also exempts in DV-preferred mode — no lint
+
+	// +k8s:format=date-time
+	DVDateTimeString string // format exempts from max-length — no lint
+
+	// +k8s:format=date
+	DVDateString string // format exempts from max-length — no lint
+
+	// +k8s:format=duration
+	DVDurationString string // format exempts from max-length — no lint
+
+	// +kubebuilder:validation:Format:=date-time
+	KubebuilderDateTimeString string // kubebuilder format also exempts in DV-preferred mode — no lint
+
+	// +kubebuilder:validation:Format:=date
+	KubebuilderDateString string // kubebuilder format also exempts in DV-preferred mode — no lint
+
+	// +kubebuilder:validation:Format:=duration
+	KubebuilderDurationString string // kubebuilder format also exempts in DV-preferred mode — no lint
+
+	// k8s:maxLength=256 on a []byte field is the WRONG DV marker; k8s:maxBytes should be used.
+	// The linter must still report the field as missing a valid max-length constraint.
+	// +k8s:maxLength=256
+	ByteSliceWithWrongDVMarker []byte // want `field DVPreferredMaxLength.ByteSliceWithWrongDVMarker must have a maximum length, add k8s:maxBytes marker`
+
+	// Raw []string — needs both MaxItems and items:MaxLength.
+	// +k8s:maxItems=16
+	// +kubebuilder:validation:items:MaxLength:=64
+	StringArrayWithMaxItemsAndElementLength []string // no lint
+
+	// +k8s:maxItems=16
+	StringArrayWithMaxItemsWithoutElementLength []string // want `field DVPreferredMaxLength.StringArrayWithMaxItemsWithoutElementLength array element must have a maximum length, add kubebuilder:validation:items:MaxLength`
+
+	StringArrayWithoutMaxItemsOrElementLength []string // want `field DVPreferredMaxLength.StringArrayWithoutMaxItemsOrElementLength must have a maximum items, add k8s:maxItems marker` `field DVPreferredMaxLength.StringArrayWithoutMaxItemsOrElementLength array element must have a maximum length, add kubebuilder:validation:items:MaxLength`
+
+	// Map with string-alias key — should lint for maxProperties.
+	MapWithStringAliasKey map[StringAliasDVMaxLength]string // want `field DVPreferredMaxLength.MapWithStringAliasKey must have a maximum properties, add k8s:maxProperties marker`
+
+	// Map with string-alias key with marker — should NOT lint.
+	// +k8s:maxProperties=16
+	MapWithStringAliasKeyAndMarker map[StringAliasDVMaxLength]string
+}
+
+// StringAliasDVMaxLength is a string alias carrying a DV maxLength marker.
+// +k8s:maxLength=512
+type StringAliasDVMaxLength string
+
+// StringAliasNoMaxLength is a string alias without any max-length marker.
+type StringAliasNoMaxLength string
+
+// DVPreferredAliases exercises alias-level DV markers.
+type DVPreferredAliases struct {
+	StringWithAliasMaxLength StringAliasDVMaxLength // satisfied by alias marker — no lint
+
+	StringWithoutMaxLength StringAliasNoMaxLength // want `field DVPreferredAliases.StringWithoutMaxLength type StringAliasNoMaxLength must have a maximum length, add k8s:maxLength marker`
+
+	// +k8s:maxItems=64
+	AliasArrayWithMaxItems []StringAliasDVMaxLength // array element max-length satisfied by alias — no lint
+
+	AliasArrayWithoutMaxItems []StringAliasDVMaxLength // want `field DVPreferredAliases.AliasArrayWithoutMaxItems must have a maximum items, add k8s:maxItems marker`
+}

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -188,6 +188,14 @@ const (
 	// K8sMaxItemsMarker is the marker that indicates that a field has a maximum number of items in k8s declarative validation.
 	K8sMaxItemsMarker = "k8s:maxItems"
 
+	// K8sMaxPropertiesMarker is the marker that indicates that a field has a maximum number of
+	// properties in k8s declarative validation.
+	K8sMaxPropertiesMarker = "k8s:maxProperties"
+
+	// K8sMaxBytesMarker is the marker that indicates that a field has a maximum byte length in
+	// k8s declarative validation.
+	K8sMaxBytesMarker = "k8s:maxBytes"
+
 	// K8sEnumMarker is the marker that indicates that a field has an enum in k8s declarative validation.
 	K8sEnumMarker = "k8s:enum"
 


### PR DESCRIPTION
This PR extends the maxlength linter to support kubernetes DV markers:

- +k8s:maxLength for string types
- +k8s:maxBytes for []byte types (aligning with DV byte counting semantics)
- +k8s:maxItems for slices and arrays
- +k8s:maxProperties for map[string]V types

**Key chages:**
- Added support for +k8s:enum and +k8s:format to exempt string fields from requiring maximum lengths.
- Introduced `MaxLengthConfig` to specify whether the linter should prefer kubebuilder or k8s DV markers
- Upgraded the analyzer to struct-based implementation `NewConfigurableInitializer`. 
- added dedicated tests to validate all new DV marker scenarios. 

Fixes  #223