### PR TITLE
refactor inspector helper to use iterators instead of callbacks

### DIFF
--- a/pkg/analysis/arrayofstruct/analyzer.go
+++ b/pkg/analysis/arrayofstruct/analyzer.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -50,9 +49,9 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/commentstart/analyzer.go
+++ b/pkg/analysis/commentstart/analyzer.go
@@ -25,7 +25,6 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 )
 
 const name = "commentstart"
@@ -45,9 +44,9 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/conflictingmarkers/analyzer.go
+++ b/pkg/analysis/conflictingmarkers/analyzer.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -67,9 +66,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, a.conflictSets, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, a.conflictSets, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/defaults/analyzer.go
+++ b/pkg/analysis/defaults/analyzer.go
@@ -107,9 +107,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, jsonTagInfo, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.JSONTagInfo, f.Markers, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/dependenttags/analyzer.go
+++ b/pkg/analysis/dependenttags/analyzer.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -65,26 +64,26 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		if field.Doc == nil {
-			return
+	for f := range inspect.Fields() {
+		if f.Field.Doc == nil {
+			continue
 		}
 
-		fieldMarkers := utils.TypeAwareMarkerCollectionForField(pass, markersAccess, field)
+		fieldMarkers := utils.TypeAwareMarkerCollectionForField(pass, f.Markers, f.Field)
 
 		for _, rule := range a.cfg.Rules {
 			if _, ok := fieldMarkers[rule.Identifier]; ok {
 				switch rule.Type {
 				case DependencyTypeAny:
-					handleAny(pass, field, rule, fieldMarkers, qualifiedFieldName)
+					handleAny(pass, f.Field, rule, fieldMarkers, f.QualifiedFieldName)
 				case DependencyTypeAll:
-					handleAll(pass, field, rule, fieldMarkers, qualifiedFieldName)
+					handleAll(pass, f.Field, rule, fieldMarkers, f.QualifiedFieldName)
 				default:
 					panic(fmt.Sprintf("unknown dependency type %s", rule.Type))
 				}
 			}
 		}
-	})
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/duplicatemarkers/analyzer.go
+++ b/pkg/analysis/duplicatemarkers/analyzer.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -48,13 +47,13 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, f.QualifiedFieldName)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		checkTypeSpec(pass, typeSpec, markersAccess)
-	})
+	for ts := range inspect.TypeSpecs() {
+		checkTypeSpec(pass, ts.TypeSpec, ts.Markers)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/forbiddenmarkers/analyzer.go
+++ b/pkg/analysis/forbiddenmarkers/analyzer.go
@@ -22,7 +22,6 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -61,13 +60,13 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, a.forbiddenMarkers, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, a.forbiddenMarkers, f.QualifiedFieldName)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		checkType(pass, typeSpec, markersAccess, a.forbiddenMarkers)
-	})
+	for ts := range inspect.TypeSpecs() {
+		checkType(pass, ts.TypeSpec, ts.Markers, a.forbiddenMarkers)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/helpers/inspector/analyzer_test.go
+++ b/pkg/analysis/helpers/inspector/analyzer_test.go
@@ -17,14 +17,11 @@ package inspector_test
 
 import (
 	"errors"
-	"go/ast"
 	"testing"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -49,13 +46,13 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, errCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		pass.Reportf(field.Pos(), "field: %v", utils.FieldName(field))
+	for f := range inspect.Fields() {
+		pass.Reportf(f.Field.Pos(), "field: %v", utils.FieldName(f.Field))
 
-		if jsonTagInfo.Name != "" {
-			pass.Reportf(field.Pos(), "json tag: %v", jsonTagInfo.Name)
+		if f.JSONTagInfo.Name != "" {
+			pass.Reportf(f.Field.Pos(), "json tag: %v", f.JSONTagInfo.Name)
 		}
-	})
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/helpers/inspector/inspector.go
+++ b/pkg/analysis/helpers/inspector/inspector.go
@@ -20,6 +20,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"iter"
 
 	astinspector "golang.org/x/tools/go/ast/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
@@ -28,16 +29,42 @@ import (
 	markersconsts "sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
+// Field is the data yielded for each struct field during inspection.
+type Field struct {
+	// Field is the AST node of the field being inspected.
+	Field *ast.Field
+
+	// JSONTagInfo holds the parsed JSON tag information for the field.
+	JSONTagInfo extractjsontags.FieldTagInfo
+
+	// Markers provides access to the markers for the package being inspected.
+	Markers markers.Markers
+
+	// QualifiedFieldName is the field name qualified with its struct name (e.g. "MyStruct.MyField").
+	QualifiedFieldName string
+}
+
+// TypeSpec is the data yielded for each type spec during inspection.
+type TypeSpec struct {
+	// TypeSpec is the AST node of the type spec being inspected.
+	TypeSpec *ast.TypeSpec
+
+	// Markers provides access to the markers for the package being inspected.
+	Markers markers.Markers
+}
+
 // Inspector is an interface that allows for the inspection of fields in structs.
 type Inspector interface {
-	// InspectFields is a function that iterates over fields in structs.
-	InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string))
+	// Fields returns an iterator over fields in structs, ignoring any struct that is not a type
+	// declaration, and any field that is ignored and therefore would not be included in the CRD spec.
+	Fields() iter.Seq[Field]
 
-	// InspectFieldsIncludingListTypes is a function that iterates over fields in structs, including list types.
-	InspectFieldsIncludingListTypes(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string))
+	// FieldsIncludingListTypes returns an iterator over fields in structs, including list types.
+	// Unlike Fields, it does not skip fields in list type structs.
+	FieldsIncludingListTypes() iter.Seq[Field]
 
-	// InspectTypeSpec is a function that inspects the type spec and calls the provided inspectTypeSpec function.
-	InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers))
+	// TypeSpecs returns an iterator over the type specs in the package.
+	TypeSpecs() iter.Seq[TypeSpec]
 }
 
 // inspector implements the Inspector interface.
@@ -56,91 +83,101 @@ func newInspector(astinspector *astinspector.Inspector, jsonTags extractjsontags
 	}
 }
 
-// InspectFields iterates over fields in structs, ignoring any struct that is not a type declaration, and any field that is ignored and
-// therefore would not be included in the CRD spec.
-// For the remaining fields, it calls the provided inspectField function to apply analysis logic.
-func (i *inspector) InspectFields(inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string)) {
-	i.inspectFields(inspectField, true)
+// Fields returns an iterator over fields in structs, ignoring any struct that is not a type declaration,
+// and any field that is ignored and therefore would not be included in the CRD spec.
+func (i *inspector) Fields() iter.Seq[Field] {
+	return i.fields(true)
 }
 
-// InspectFieldsIncludingListTypes iterates over fields in structs, including list types.
-// Unlike InspectFields, this method does not skip fields in list type structs.
-func (i *inspector) InspectFieldsIncludingListTypes(inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string)) {
-	i.inspectFields(inspectField, false)
+// FieldsIncludingListTypes returns an iterator over fields in structs, including list types.
+// Unlike Fields, it does not skip fields in list type structs.
+func (i *inspector) FieldsIncludingListTypes() iter.Seq[Field] {
+	return i.fields(false)
 }
 
-// inspectFields is a shared implementation for field iteration.
+// fields is a shared implementation for field iteration.
 // The skipListTypes parameter controls whether list type structs should be skipped.
-func (i *inspector) inspectFields(inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string), skipListTypes bool) {
-	// Filter to fields so that we can iterate over fields in a struct.
-	nodeFilter := []ast.Node{
-		(*ast.Field)(nil),
+func (i *inspector) fields(skipListTypes bool) iter.Seq[Field] {
+	return func(yield func(Field) bool) {
+		// Cursor.Preorder yields a Cursor per field, which provides O(1) access to enclosing
+		// nodes (Parent/Enclosing) without manual stack bookkeeping.
+		for c := range i.inspector.Root().Preorder((*ast.Field)(nil)) {
+			field, ok := c.Node().(*ast.Field)
+			if !ok {
+				continue
+			}
+
+			// The field's parent is the enclosing *ast.FieldList; its parent is the type
+			// (struct, interface, func signature, ...) that owns the field.
+			structCursor := c.Parent().Parent()
+
+			structType, ok := structCursor.Node().(*ast.StructType)
+			if !ok || !isTopLevelTypeDecl(c) {
+				continue
+			}
+
+			if skipListTypes && utils.IsKubernetesListType(structType, "") {
+				continue
+			}
+
+			// Skip ignored or schemaless fields, as well as any field nested within one.
+			if i.isFieldSkipped(c) {
+				continue
+			}
+
+			if !i.yieldFieldWithRecovery(field, qualifiedFieldName(field, structCursor), yield) {
+				return
+			}
+		}
+	}
+}
+
+// isFieldSkipped reports whether the field at the cursor, or any field enclosing it,
+// should be skipped (ignored or schemaless). Fields nested within a skipped field are
+// themselves skipped, matching a traversal that prunes skipped subtrees.
+func (i *inspector) isFieldSkipped(c astinspector.Cursor) bool {
+	for fc := range c.Enclosing((*ast.Field)(nil)) {
+		field, ok := fc.Node().(*ast.Field)
+		if ok && i.shouldSkipField(field) {
+			return true
+		}
 	}
 
-	i.inspector.WithStack(nodeFilter, func(n ast.Node, push bool, stack []ast.Node) (proceed bool) {
-		if !push {
+	return false
+}
+
+// isTopLevelTypeDecl reports whether the cursor is enclosed by a top-level type declaration,
+// i.e. a `type` GenDecl that is a direct child of the file. This excludes types declared
+// within functions or non-type (var/const) declarations.
+func isTopLevelTypeDecl(c astinspector.Cursor) bool {
+	for genDecl := range c.Enclosing((*ast.GenDecl)(nil)) {
+		decl, ok := genDecl.Node().(*ast.GenDecl)
+		if !ok || decl.Tok != token.TYPE {
 			return false
 		}
 
-		field, ok := n.(*ast.Field)
-		if !ok || !i.shouldProcessField(stack, skipListTypes) {
-			return ok
-		}
+		_, ok = genDecl.Parent().Node().(*ast.File)
 
-		if i.shouldSkipField(field) {
-			return false
-		}
+		return ok
+	}
 
-		var structName string
-
-		qualifiedFieldName := utils.FieldName(field)
-		if qualifiedFieldName == "" {
-			qualifiedFieldName = types.ExprString(field.Type)
-		}
-
-		// The 0th node in the stack is the *ast.File.
-		file, ok := stack[0].(*ast.File)
-		if ok {
-			structName = utils.GetStructNameFromFile(file, field)
-		}
-
-		if structName != "" {
-			qualifiedFieldName = fmt.Sprintf("%s.%s", structName, qualifiedFieldName)
-		}
-
-		i.processFieldWithRecovery(field, qualifiedFieldName, inspectField)
-
-		return true
-	})
+	return false
 }
 
-// shouldProcessField checks if the field should be processed.
-// The skipListTypes parameter controls whether list type structs should be skipped.
-func (i *inspector) shouldProcessField(stack []ast.Node, skipListTypes bool) bool {
-	if len(stack) < 3 {
-		return false
+// qualifiedFieldName returns the field name qualified with its struct name (e.g. "MyStruct.MyField").
+// The struct name is taken from the enclosing *ast.TypeSpec when the struct is a named type;
+// fields of anonymous (inline) structs are left unqualified.
+func qualifiedFieldName(field *ast.Field, structCursor astinspector.Cursor) string {
+	name := utils.FieldName(field)
+	if name == "" {
+		name = types.ExprString(field.Type)
 	}
 
-	// The 0th node in the stack is the *ast.File.
-	// The 1st node in the stack is the *ast.GenDecl.
-	decl, ok := stack[1].(*ast.GenDecl)
-	if !ok || decl.Tok != token.TYPE {
-		// Make sure that we don't inspect structs within a function or non-type declarations.
-		return false
+	if typeSpec, ok := structCursor.Parent().Node().(*ast.TypeSpec); ok {
+		name = fmt.Sprintf("%s.%s", typeSpec.Name.Name, name)
 	}
 
-	structType, ok := stack[len(stack)-3].(*ast.StructType)
-	if !ok {
-		// Not in a struct.
-		return false
-	}
-
-	if skipListTypes && utils.IsKubernetesListType(structType, "") {
-		// Skip list types if requested.
-		return false
-	}
-
-	return true
+	return name
 }
 
 // shouldSkipField checks if a field should be skipped.
@@ -155,35 +192,37 @@ func (i *inspector) shouldSkipField(field *ast.Field) bool {
 	return isSchemalessType(markerSet)
 }
 
-// processFieldWithRecovery processes a field with panic recovery.
-func (i *inspector) processFieldWithRecovery(field *ast.Field, qualifiedFieldName string, inspectField func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string)) {
+// yieldFieldWithRecovery yields a field to the consumer with panic recovery.
+// It returns whether the iteration should proceed.
+func (i *inspector) yieldFieldWithRecovery(field *ast.Field, qualifiedFieldName string, yield func(Field) bool) (proceed bool) {
 	tagInfo := i.jsonTags.FieldTags(field)
 
 	defer func() {
 		if r := recover(); r != nil {
-			// If the inspectField function panics, we recover and log information that will help identify the issue.
+			// If the consumer panics, we recover and log information that will help identify the issue.
 			debug := printDebugInfo(field)
 			panic(fmt.Sprintf("%s %v", debug, r)) // Re-panic to propagate the error.
 		}
 	}()
 
-	inspectField(field, tagInfo, i.markers, qualifiedFieldName)
+	return yield(Field{
+		Field:              field,
+		JSONTagInfo:        tagInfo,
+		Markers:            i.markers,
+		QualifiedFieldName: qualifiedFieldName,
+	})
 }
 
-// InspectTypeSpec inspects the type spec and calls the provided inspectTypeSpec function.
-func (i *inspector) InspectTypeSpec(inspectTypeSpec func(typeSpec *ast.TypeSpec, markersAccess markers.Markers)) {
-	nodeFilter := []ast.Node{
-		(*ast.TypeSpec)(nil),
-	}
-
-	i.inspector.Preorder(nodeFilter, func(n ast.Node) {
-		typeSpec, ok := n.(*ast.TypeSpec)
-		if !ok {
-			return
+// TypeSpecs returns an iterator over the type specs in the package.
+func (i *inspector) TypeSpecs() iter.Seq[TypeSpec] {
+	return func(yield func(TypeSpec) bool) {
+		// All yields *ast.TypeSpec nodes directly, so no node-type assertion is needed.
+		for typeSpec := range astinspector.All[*ast.TypeSpec](i.inspector) {
+			if !yield(TypeSpec{TypeSpec: typeSpec, Markers: i.markers}) {
+				return
+			}
 		}
-
-		inspectTypeSpec(typeSpec, i.markers)
-	})
+	}
 }
 
 func isSchemalessType(markerSet markers.MarkerSet) bool {

--- a/pkg/analysis/integers/analyzer.go
+++ b/pkg/analysis/integers/analyzer.go
@@ -21,9 +21,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -46,13 +44,13 @@ func run(pass *analysis.Pass) (any, error) {
 
 	typeChecker := utils.NewTypeChecker(utils.IsBasicType, checkIntegers)
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		typeChecker.CheckNode(pass, field)
-	})
+	for f := range inspect.Fields() {
+		typeChecker.CheckNode(pass, f.Field)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		typeChecker.CheckNode(pass, typeSpec)
-	})
+	for ts := range inspect.TypeSpecs() {
+		typeChecker.CheckNode(pass, ts.TypeSpec)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/jsontags/analyzer.go
+++ b/pkg/analysis/jsontags/analyzer.go
@@ -27,7 +27,6 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 )
 
 const (
@@ -74,9 +73,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFieldsIncludingListTypes(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, _ markers.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.FieldsIncludingListTypes() {
+		a.checkField(pass, f.Field, f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -21,7 +21,6 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -47,9 +46,9 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/minlength/analyzer.go
+++ b/pkg/analysis/minlength/analyzer.go
@@ -21,7 +21,6 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -47,9 +46,9 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/namingconventions/analyzer.go
+++ b/pkg/analysis/namingconventions/analyzer.go
@@ -26,7 +26,6 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -59,9 +58,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTags extractjsontags.FieldTagInfo, _ markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, jsonTags, qualifiedFieldName, a.conventions...)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.JSONTagInfo, f.QualifiedFieldName, a.conventions...)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/nobools/analyzer.go
+++ b/pkg/analysis/nobools/analyzer.go
@@ -21,9 +21,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -46,13 +44,13 @@ func run(pass *analysis.Pass) (any, error) {
 
 	typeChecker := utils.NewTypeChecker(utils.IsBasicType, checkBool)
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		typeChecker.CheckNode(pass, field)
-	})
+	for f := range inspect.Fields() {
+		typeChecker.CheckNode(pass, f.Field)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		typeChecker.CheckNode(pass, typeSpec)
-	})
+	for ts := range inspect.TypeSpecs() {
+		typeChecker.CheckNode(pass, ts.TypeSpec)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/nodurations/analyzer.go
+++ b/pkg/analysis/nodurations/analyzer.go
@@ -21,9 +21,7 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -46,13 +44,13 @@ func run(pass *analysis.Pass) (any, error) {
 
 	typeChecker := utils.NewTypeChecker(isDurationType, checkDuration)
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		typeChecker.CheckNode(pass, field)
-	})
+	for f := range inspect.Fields() {
+		typeChecker.CheckNode(pass, f.Field)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		typeChecker.CheckNode(pass, typeSpec)
-	})
+	for ts := range inspect.TypeSpecs() {
+		typeChecker.CheckNode(pass, ts.TypeSpec)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/nofloats/analyzer.go
+++ b/pkg/analysis/nofloats/analyzer.go
@@ -21,9 +21,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -46,13 +44,13 @@ func run(pass *analysis.Pass) (any, error) {
 
 	typeChecker := utils.NewTypeChecker(utils.IsBasicType, checkFloat)
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		typeChecker.CheckNode(pass, field)
-	})
+	for f := range inspect.Fields() {
+		typeChecker.CheckNode(pass, f.Field)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		typeChecker.CheckNode(pass, typeSpec)
-	})
+	for ts := range inspect.TypeSpecs() {
+		typeChecker.CheckNode(pass, ts.TypeSpec)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/nomaps/analyzer.go
+++ b/pkg/analysis/nomaps/analyzer.go
@@ -22,9 +22,7 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
 )
 
@@ -64,13 +62,13 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 
 	typeChecker := utils.NewTypeChecker(isMap, a.checkMap)
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, _ markers.Markers, _ string) {
-		typeChecker.CheckNode(pass, field)
-	})
+	for f := range inspect.Fields() {
+		typeChecker.CheckNode(pass, f.Field)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, _ markers.Markers) {
-		typeChecker.CheckNode(pass, typeSpec)
-	})
+	for ts := range inspect.TypeSpecs() {
+		typeChecker.CheckNode(pass, ts.TypeSpec)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/nonpointerstructs/analyzer.go
+++ b/pkg/analysis/nonpointerstructs/analyzer.go
@@ -61,9 +61,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.Markers, f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/optionalfields/analyzer.go
+++ b/pkg/analysis/optionalfields/analyzer.go
@@ -96,9 +96,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.Markers, f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/optionalorrequired/analyzer.go
+++ b/pkg/analysis/optionalorrequired/analyzer.go
@@ -92,13 +92,13 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, markersAccess.FieldMarkers(field), jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.Markers.FieldMarkers(f.Field), f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
-		a.checkTypeSpec(pass, typeSpec, markersAccess)
-	})
+	for ts := range inspect.TypeSpecs() {
+		a.checkTypeSpec(pass, ts.TypeSpec, ts.Markers)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/preferredmarkers/analyzer.go
+++ b/pkg/analysis/preferredmarkers/analyzer.go
@@ -24,7 +24,6 @@ import (
 
 	"golang.org/x/tools/go/analysis"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 )
@@ -83,13 +82,13 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, a.equivalentToPreferred, a.preferredToMessage, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, a.equivalentToPreferred, a.preferredToMessage, f.QualifiedFieldName)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		checkType(pass, typeSpec, markersAccess, a.equivalentToPreferred, a.preferredToMessage)
-	})
+	for ts := range inspect.TypeSpecs() {
+		checkType(pass, ts.TypeSpec, ts.Markers, a.equivalentToPreferred, a.preferredToMessage)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -95,9 +95,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.Markers, f.JSONTagInfo, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/ssatags/analyzer.go
+++ b/pkg/analysis/ssatags/analyzer.go
@@ -66,9 +66,9 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		a.checkField(pass, field, markersAccess, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		a.checkField(pass, f.Field, f.Markers, f.QualifiedFieldName)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/statusoptional/analyzer.go
+++ b/pkg/analysis/statusoptional/analyzer.go
@@ -79,14 +79,14 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetJSONTags
 	}
 
-	inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, _ string) {
-		if jsonTagInfo.Name != statusJSONTag {
-			return
+	for f := range inspect.Fields() {
+		if f.JSONTagInfo.Name != statusJSONTag {
+			continue
 		}
 
-		statusStructType := getStructFromField(pass, field)
-		a.checkStatusStruct(pass, statusStructType, markersAccess, jsonTags)
-	})
+		statusStructType := getStructFromField(pass, f.Field)
+		a.checkStatusStruct(pass, statusStructType, f.Markers, jsonTags)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/uniquemarkers/analyzer.go
+++ b/pkg/analysis/uniquemarkers/analyzer.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
@@ -65,13 +64,13 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers, qualifiedFieldName string) {
-		checkField(pass, field, markersAccess, a.uniqueMarkers, qualifiedFieldName)
-	})
+	for f := range inspect.Fields() {
+		checkField(pass, f.Field, f.Markers, a.uniqueMarkers, f.QualifiedFieldName)
+	}
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
-		checkType(pass, typeSpec, markersAccess, a.uniqueMarkers)
-	})
+	for ts := range inspect.TypeSpecs() {
+		checkType(pass, ts.TypeSpec, ts.Markers, a.uniqueMarkers)
+	}
 
 	return nil, nil //nolint:nilnil
 }

--- a/pkg/analysis/utils/serialization/serialization_check_test.go
+++ b/pkg/analysis/utils/serialization/serialization_check_test.go
@@ -17,14 +17,12 @@ package serialization_test
 
 import (
 	"errors"
-	"go/ast"
 	"testing"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils/serialization"
 )
 
@@ -123,9 +121,9 @@ func testSerializationAnalyzer(cfg *serialization.Config) *analysis.Analyzer {
 				return nil, errCouldNotGetInspector
 			}
 
-			inspect.InspectFields(func(field *ast.Field, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers, qualifiedFieldName string) {
-				serialization.New(cfg).Check(pass, field, markersAccess, jsonTagInfo, qualifiedFieldName)
-			})
+			for f := range inspect.Fields() {
+				serialization.New(cfg).Check(pass, f.Field, f.Markers, f.JSONTagInfo, f.QualifiedFieldName)
+			}
 
 			return nil, nil
 		},


### PR DESCRIPTION
Introduce iterator pattern instead of callbacks. It's faster and safer than current implementation.

