### PR TITLE
nonpointerstructs: detect union markers and warn on +k8s:required with valid zero-value structs

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -616,8 +616,16 @@ This linter is NOT intended to be used to check for CRD types.
 The advice of this linter may be applied to CRD types, but it is not necessary for CRD types due to optionality being validated by openapi and no native Go code.
 For CRD types, the optionalfields and requiredfields linters should be used instead.
 
-If a struct is marked required, this can only be validated by having a required field within it.
-If there are no required fields, the struct is implicitly optional and must be marked as so.
+If a struct is marked required, this can only be validated by having something within it that makes the zero
+value invalid. The linter recognises the following presence-enforcing signals:
+
+- A field marked `+required`, `+kubebuilder:validation:Required`, or `+k8s:required`.
+- A non-zero `+kubebuilder:validation:MinProperties` marker on the struct.
+- A `+kubebuilder:validation:ExactlyOneOf` or `+kubebuilder:validation:AtLeastOneOf` marker on the struct.
+- Any field of the struct carrying `+k8s:unionMember` or `+k8s:unionDiscriminator` (a declarative-validation
+  union, whose validators require at least one member to be set).
+
+If none of these apply, the struct is implicitly optional and must be marked as so.
 
 To have an optional struct field that includes required fields, the struct must be a pointer.
 To have a required struct field that includes no required fields, the struct must be a pointer.

--- a/pkg/analysis/nonpointerstructs/analyzer.go
+++ b/pkg/analysis/nonpointerstructs/analyzer.go
@@ -44,7 +44,7 @@ func newAnalyzer(cfg *Config) *analysis.Analyzer {
 
 	return &analysis.Analyzer{
 		Name:     name,
-		Doc:      "Checks that non-pointer structs that contain required fields are marked as required. Non-pointer structs that contain no required fields are marked as optional.",
+		Doc:      "Checks that non-pointer structs whose zero value is invalid (e.g. contain required fields, declare a union, or set a non-zero minProperties) are marked as required, and that those whose zero value is valid are marked as optional.",
 		Run:      a.run,
 		Requires: []*analysis.Analyzer{inspector.Analyzer},
 	}
@@ -91,6 +91,8 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, markersAcce
 		// This is the desired case.
 	case hasRequiredField:
 		a.handleShouldBeRequired(pass, field, markersAccess, qualifiedFieldName)
+	case !hasRequiredField && hasK8sRequiredMarker(field, markersAccess):
+		a.handleK8sRequiredWithoutValidation(pass, field, markersAccess, qualifiedFieldName)
 	case !hasRequiredField:
 		a.handleShouldBeOptional(pass, field, markersAccess, qualifiedFieldName)
 	}
@@ -117,6 +119,15 @@ func hasRequiredField(structType *ast.StructType, markersAccess markershelper.Ma
 		if utils.IsFieldRequired(field, markersAccess) {
 			return true
 		}
+
+		// A declarative-validation union member or discriminator on any field implies
+		// the struct is a union. validation-gen's union validators require at least one
+		// member to be set, so the struct's zero value is invalid and the containing
+		// non-pointer field can be treated the same as having a required field.
+		fieldMarkers := markersAccess.FieldMarkers(field)
+		if fieldMarkers.Has(markers.K8sUnionMemberMarker) || fieldMarkers.Has(markers.K8sUnionDiscriminatorMarker) {
+			return true
+		}
 	}
 
 	structMarkers := markersAccess.StructMarkers(structType)
@@ -127,7 +138,18 @@ func hasRequiredField(structType *ast.StructType, markersAccess markershelper.Ma
 		return true
 	}
 
+	// Kubebuilder union markers (ExactlyOneOf / AtLeastOneOf) on the struct imply that
+	// at least one field must be set, equivalent to minProperties>=1. This mirrors the
+	// convention in pkg/analysis/utils/zero_value.go's checkStructMinProperties.
+	if structMarkers.Has(markers.KubebuilderExactlyOneOf) || structMarkers.Has(markers.KubebuilderAtLeastOneOfMarker) {
+		return true
+	}
+
 	return false
+}
+
+func hasK8sRequiredMarker(field *ast.Field, markersAccess markershelper.Markers) bool {
+	return markersAccess.FieldMarkers(field).Has(markers.K8sRequiredMarker)
 }
 
 func defaultConfig(cfg *Config) {
@@ -198,6 +220,38 @@ func (a *analyzer) handleShouldBeOptional(pass *analysis.Pass, field *ast.Field,
 	pass.Report(analysis.Diagnostic{
 		Pos:     field.Pos(),
 		Message: fmt.Sprintf("field %s is a non-pointer struct with no required fields. It must be marked as optional.", qualifiedFieldName),
+		SuggestedFixes: []analysis.SuggestedFix{
+			{
+				Message:   "should mark the field as optional",
+				TextEdits: textEdits,
+			},
+		},
+	})
+}
+
+func (a *analyzer) handleK8sRequiredWithoutValidation(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers, qualifiedFieldName string) {
+	fieldMarkers := markersAccess.FieldMarkers(field)
+
+	textEdits := []analysis.TextEdit{}
+
+	for _, m := range fieldMarkers.Get(markers.K8sRequiredMarker) {
+		textEdits = append(textEdits, analysis.TextEdit{
+			Pos:     m.Pos,
+			End:     m.End + 1, // Add 1 to include the newline character
+			NewText: nil,
+		})
+	}
+
+	textEdits = append(textEdits, analysis.TextEdit{
+		Pos:     field.Pos(),
+		End:     field.Pos(),
+		NewText: fmt.Appendf(nil, "// +%s\n", a.preferredOptionalMarker),
+	})
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     field.Pos(),
+		End:     field.Pos(),
+		Message: fmt.Sprintf("field %s is marked as +k8s:required but the struct has a valid zero value; the marker is documentation-only because the struct contains no presence-enforcing validation (required fields, union markers, or minProperties)", qualifiedFieldName),
 		SuggestedFixes: []analysis.SuggestedFix{
 			{
 				Message:   "should mark the field as optional",

--- a/pkg/analysis/nonpointerstructs/testdata/src/a/a.go
+++ b/pkg/analysis/nonpointerstructs/testdata/src/a/a.go
@@ -20,6 +20,12 @@ type A struct {
 	// +k8s:required
 	WithOptionalFieldsAndMinPropertiesCorrect WithOptionalFieldsAndMinProperties `json:"withOptionalFieldsAndMinPropertiesCorrect"`
 
+	// +k8s:required
+	WithDVUnionCorrectK8sRequired WithDVUnion `json:"withDVUnionCorrectK8sRequired"`
+
+	// +k8s:required
+	WithDVDiscriminatedUnionCorrectK8sRequired WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnionCorrectK8sRequired"`
+
 	// Diagnostic with incorrect markers
 
 	// +kubebuilder:validation:Optional
@@ -33,6 +39,40 @@ type A struct {
 
 	// +kubebuilder:validation:Optional
 	WithOptionalFieldsAndMinPropertiesIncorrect WithOptionalFieldsAndMinProperties `json:"withOptionalFieldsAndMinPropertiesIncorrect"` // want "field A.WithOptionalFieldsAndMinPropertiesIncorrect is a non-pointer struct with required fields. It must be marked as required."
+
+	// +k8s:required on non-pointer structs: warns when the struct has no presence-enforcing validation.
+	// +k8s:required
+	WithOptionalFieldK8sRequiredNoValidation WithOptionalField `json:"withOptionalFieldK8sRequiredNoValidation"` // want "field A.WithOptionalFieldK8sRequiredNoValidation is marked as .k8s:required but the struct has a valid zero value.*"
+
+	// +k8s:required
+	WithOptionalFieldEmbeddedK8sRequiredNoValidation WithOptionalFieldEmbedded `json:"withOptionalFieldEmbeddedK8sRequiredNoValidation"` // want "field A.WithOptionalFieldEmbeddedK8sRequiredNoValidation is marked as .k8s:required but the struct has a valid zero value.*"
+
+	// Unions enforce "at least one set" semantics, so the zero value is invalid
+	// and the containing non-pointer field must be marked as required.
+
+	// Diagnostic when no marker is set on a union-bearing non-pointer struct field.
+
+	WithKubebuilderExactlyOneOfUnion WithKubebuilderExactlyOneOfUnion `json:"withKubebuilderExactlyOneOfUnion"` // want "field A.WithKubebuilderExactlyOneOfUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	WithKubebuilderAtLeastOneOfUnion WithKubebuilderAtLeastOneOfUnion `json:"withKubebuilderAtLeastOneOfUnion"` // want "field A.WithKubebuilderAtLeastOneOfUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	WithDVUnion WithDVUnion `json:"withDVUnion"` // want "field A.WithDVUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	WithDVDiscriminatedUnion WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnion"` // want "field A.WithDVDiscriminatedUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	// No diagnostic when correctly marked as required.
+
+	// +required
+	WithKubebuilderExactlyOneOfUnionCorrect WithKubebuilderExactlyOneOfUnion `json:"withKubebuilderExactlyOneOfUnionCorrect"`
+
+	// +required
+	WithKubebuilderAtLeastOneOfUnionCorrect WithKubebuilderAtLeastOneOfUnion `json:"withKubebuilderAtLeastOneOfUnionCorrect"`
+
+	// +required
+	WithDVUnionCorrect WithDVUnion `json:"withDVUnionCorrect"`
+
+	// +required
+	WithDVDiscriminatedUnionCorrect WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnionCorrect"`
 
 	// Pointers are ignored in this linter.
 	WithRequiredFieldAndPointer                  *WithRequiredField                  `json:"withRequiredFieldAndPointer"`
@@ -80,4 +120,40 @@ type WithRequiredFieldEmbedded struct {
 type WithOptionalFieldEmbedded struct {
 	// +optional
 	OptionalField string `json:"optionalField"`
+}
+
+// +kubebuilder:validation:ExactlyOneOf=[a;b]
+type WithKubebuilderExactlyOneOfUnion struct {
+	// +optional
+	A string `json:"a,omitempty"`
+	// +optional
+	B string `json:"b,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneOf=[a;b]
+type WithKubebuilderAtLeastOneOfUnion struct {
+	// +optional
+	A string `json:"a,omitempty"`
+	// +optional
+	B string `json:"b,omitempty"`
+}
+
+type WithDVUnion struct {
+	// +k8s:optional
+	// +k8s:unionMember
+	A string `json:"a,omitempty"`
+	// +k8s:optional
+	// +k8s:unionMember
+	B string `json:"b,omitempty"`
+}
+
+type WithDVDiscriminatedUnion struct {
+	// +k8s:unionDiscriminator
+	Type string `json:"type"`
+	// +k8s:optional
+	// +k8s:unionMember
+	A string `json:"a,omitempty"`
+	// +k8s:optional
+	// +k8s:unionMember
+	B string `json:"b,omitempty"`
 }

--- a/pkg/analysis/nonpointerstructs/testdata/src/a/a.go.golden
+++ b/pkg/analysis/nonpointerstructs/testdata/src/a/a.go.golden
@@ -24,6 +24,12 @@ type A struct {
 	// +k8s:required
 	WithOptionalFieldsAndMinPropertiesCorrect WithOptionalFieldsAndMinProperties `json:"withOptionalFieldsAndMinPropertiesCorrect"`
 
+	// +k8s:required
+	WithDVUnionCorrectK8sRequired WithDVUnion `json:"withDVUnionCorrectK8sRequired"`
+
+	// +k8s:required
+	WithDVDiscriminatedUnionCorrectK8sRequired WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnionCorrectK8sRequired"`
+
 	// Diagnostic with incorrect markers
 
 	// +required
@@ -37,6 +43,44 @@ type A struct {
 
 	// +required
 	WithOptionalFieldsAndMinPropertiesIncorrect WithOptionalFieldsAndMinProperties `json:"withOptionalFieldsAndMinPropertiesIncorrect"` // want "field A.WithOptionalFieldsAndMinPropertiesIncorrect is a non-pointer struct with required fields. It must be marked as required."
+
+	// +k8s:required on non-pointer structs: warns when the struct has no presence-enforcing validation.
+	// +optional
+	WithOptionalFieldK8sRequiredNoValidation WithOptionalField `json:"withOptionalFieldK8sRequiredNoValidation"` // want "field A.WithOptionalFieldK8sRequiredNoValidation is marked as .k8s:required but the struct has a valid zero value.*"
+
+	// +optional
+	WithOptionalFieldEmbeddedK8sRequiredNoValidation WithOptionalFieldEmbedded `json:"withOptionalFieldEmbeddedK8sRequiredNoValidation"` // want "field A.WithOptionalFieldEmbeddedK8sRequiredNoValidation is marked as .k8s:required but the struct has a valid zero value.*"
+
+	// Unions enforce "at least one set" semantics, so the zero value is invalid
+	// and the containing non-pointer field must be marked as required.
+
+	// Diagnostic when no marker is set on a union-bearing non-pointer struct field.
+
+	// +required
+	WithKubebuilderExactlyOneOfUnion WithKubebuilderExactlyOneOfUnion `json:"withKubebuilderExactlyOneOfUnion"` // want "field A.WithKubebuilderExactlyOneOfUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	// +required
+	WithKubebuilderAtLeastOneOfUnion WithKubebuilderAtLeastOneOfUnion `json:"withKubebuilderAtLeastOneOfUnion"` // want "field A.WithKubebuilderAtLeastOneOfUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	// +required
+	WithDVUnion WithDVUnion `json:"withDVUnion"` // want "field A.WithDVUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	// +required
+	WithDVDiscriminatedUnion WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnion"` // want "field A.WithDVDiscriminatedUnion is a non-pointer struct with required fields. It must be marked as required."
+
+	// No diagnostic when correctly marked as required.
+
+	// +required
+	WithKubebuilderExactlyOneOfUnionCorrect WithKubebuilderExactlyOneOfUnion `json:"withKubebuilderExactlyOneOfUnionCorrect"`
+
+	// +required
+	WithKubebuilderAtLeastOneOfUnionCorrect WithKubebuilderAtLeastOneOfUnion `json:"withKubebuilderAtLeastOneOfUnionCorrect"`
+
+	// +required
+	WithDVUnionCorrect WithDVUnion `json:"withDVUnionCorrect"`
+
+	// +required
+	WithDVDiscriminatedUnionCorrect WithDVDiscriminatedUnion `json:"withDVDiscriminatedUnionCorrect"`
 
 	// Pointers are ignored in this linter.
 	WithRequiredFieldAndPointer                  *WithRequiredField                  `json:"withRequiredFieldAndPointer"`
@@ -84,4 +128,40 @@ type WithRequiredFieldEmbedded struct {
 type WithOptionalFieldEmbedded struct {
 	// +optional
 	OptionalField string `json:"optionalField"`
+}
+
+// +kubebuilder:validation:ExactlyOneOf=[a;b]
+type WithKubebuilderExactlyOneOfUnion struct {
+	// +optional
+	A string `json:"a,omitempty"`
+	// +optional
+	B string `json:"b,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneOf=[a;b]
+type WithKubebuilderAtLeastOneOfUnion struct {
+	// +optional
+	A string `json:"a,omitempty"`
+	// +optional
+	B string `json:"b,omitempty"`
+}
+
+type WithDVUnion struct {
+	// +k8s:optional
+	// +k8s:unionMember
+	A string `json:"a,omitempty"`
+	// +k8s:optional
+	// +k8s:unionMember
+	B string `json:"b,omitempty"`
+}
+
+type WithDVDiscriminatedUnion struct {
+	// +k8s:unionDiscriminator
+	Type string `json:"type"`
+	// +k8s:optional
+	// +k8s:unionMember
+	A string `json:"a,omitempty"`
+	// +k8s:optional
+	// +k8s:unionMember
+	B string `json:"b,omitempty"`
 }

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -211,4 +211,15 @@ const (
 
 	// K8sDefaultMarker is the marker that indicates the default value for a field in k8s declarative validation.
 	K8sDefaultMarker = "k8s:default"
+
+	// K8sUnionMemberMarker is the marker that indicates that a field is a member of a
+	// declarative-validation union. Validation-gen's union validators enforce that at
+	// least one union member must be set, which makes the parent struct's zero value
+	// invalid for presence-checking purposes.
+	K8sUnionMemberMarker = "k8s:unionMember"
+
+	// K8sUnionDiscriminatorMarker is the marker that indicates that a field is the
+	// discriminator of a declarative-validation union. Its presence on any field of a
+	// struct implies the struct is a union.
+	K8sUnionDiscriminatorMarker = "k8s:unionDiscriminator"
 )


### PR DESCRIPTION
## Summary

- **Union-aware presence detection**: extends `hasRequiredField` to recognise declarative-validation union markers (`+k8s:unionMember`, `+k8s:unionDiscriminator`) and kubebuilder union markers (`+kubebuilder:validation:ExactlyOneOf`, `+kubebuilder:validation:AtLeastOneOf`) as presence-enforcing validation. These markers imply "at least one field must be set", so the struct's zero value is invalid and the containing non-pointer field must be marked as `+required`.

- **`+k8s:required` smoke test**: when `+k8s:required` is used on a non-pointer struct field whose referenced struct has no presence-enforcing validation (no required fields, no unions, no `MinProperties>=1`), the linter now warns and suggests replacing it with `+optional`. The marker is documentation-only because the zero value would still pass.

Context: [kubernetes#136779](https://github.com/kubernetes/kubernetes/pull/136779) allowed `+k8s:required` / `+k8s:optional` on non-pointer struct fields in `validation-gen`, intentionally leaving presence enforcement to the linter. This implements the linter side as [discussed](https://github.com/kubernetes/kubernetes/pull/136779#discussion_r3119072973) by @JoelSpeed and @aaron-prindle.

## Test

- Added test cases for ExactlyOneOf, AtLeastOneOf, DV union member, and DV union discriminator all detected as presence-enforcing.
- Added test cases for `+k8s:required` on structs with only optional fields, confirms the documentation-only warning fires.