### PR TITLE
Expand listType=set linter to disallow all non-scalars

### DIFF
--- a/pkg/analysis/ssatags/analyzer.go
+++ b/pkg/analysis/ssatags/analyzer.go
@@ -18,6 +18,7 @@ package ssatags
 import (
 	"fmt"
 	"go/ast"
+	"go/types"
 
 	"golang.org/x/tools/go/analysis"
 
@@ -176,8 +177,7 @@ func (a *analyzer) checkListTypeSet(pass *analysis.Pass, field *ast.Field, quali
 		return
 	}
 
-	isObjectList := utils.IsObjectList(pass, field)
-	if !isObjectList {
+	if !isListOfNonScalars(pass, field) {
 		return
 	}
 
@@ -187,6 +187,47 @@ func (a *analyzer) checkListTypeSet(pass *analysis.Pass, field *ast.Field, quali
 	}
 
 	pass.Report(diagnostic)
+}
+
+// isListOfNonScalars reports whether the field is a slice containing non-scalars
+// such as structs, slices, and map. Returns false if the type is unknown.
+func isListOfNonScalars(pass *analysis.Pass, field *ast.Field) bool {
+	typeOf := pass.TypesInfo.TypeOf(field.Type)
+	if typeOf == nil {
+		return false
+	}
+
+	outer, ok := asSlice(typeOf)
+	if !ok {
+		return false
+	}
+
+	elem := outer.Elem()
+	if ptr, ok := elem.(*types.Pointer); ok {
+		elem = ptr.Elem()
+	}
+
+	switch elem.Underlying().(type) {
+	case *types.Struct, *types.Slice, *types.Array:
+		return true
+	}
+
+	return false
+}
+
+func asSlice(t types.Type) (*types.Slice, bool) {
+	for {
+		switch u := t.(type) {
+		case *types.Alias:
+			t = u.Underlying()
+		case *types.Named:
+			t = u.Underlying()
+		case *types.Slice:
+			return u, true
+		default:
+			return nil, false
+		}
+	}
 }
 
 func (a *analyzer) validateListMapKeys(pass *analysis.Pass, field *ast.Field, listMapKeyMarkers []markers.Marker, qualifiedFieldName string) {

--- a/pkg/analysis/ssatags/config.go
+++ b/pkg/analysis/ssatags/config.go
@@ -17,13 +17,9 @@ package ssatags
 
 // SSATagsConfig contains configuration for the ssatags linter.
 type SSATagsConfig struct {
-	// listTypeSetUsage is the policy for the listType=set usage.
-	// Valid values are "Warn" and "Ignore".
-	// When set to "Warn", the linter will emit a warning if a listType=set is used on object arrays.
-	// When set to "Ignore", the linter will not emit a warning if a listType=set is used on object arrays.
-	// Note: listType=set is only flagged on object arrays, not primitive arrays, due to
-	// Server-Side Apply compatibility issues specific to object arrays.
-	// When otherwise not specified, the default value is "Warn".
+	// listTypeSetUsage is the policy for listType=set on slices of structs,
+	// slices, and maps. Valid values are "Warn" and "Ignore".
+	// Defaults to "Warn". Scalar element lists are never flagged.
 	ListTypeSetUsage SSATagsListTypeSetUsage `json:"listTypeSetUsage"`
 }
 
@@ -31,9 +27,9 @@ type SSATagsConfig struct {
 type SSATagsListTypeSetUsage string
 
 const (
-	// SSATagsListTypeSetUsageWarn indicates that the linter will emit a warning if a listType=set is used on object arrays.
+	// SSATagsListTypeSetUsageWarn warns when listType=set is used on slices of structs, slices, and maps.
 	SSATagsListTypeSetUsageWarn SSATagsListTypeSetUsage = "Warn"
 
-	// SSATagsListTypeSetUsageIgnore indicates that the linter will not emit a warning if a listType=set is used on object arrays.
+	// SSATagsListTypeSetUsageIgnore disables the check for listType=set used on slices of structs, slices, and maps.
 	SSATagsListTypeSetUsageIgnore SSATagsListTypeSetUsage = "Ignore"
 )

--- a/pkg/analysis/ssatags/doc.go
+++ b/pkg/analysis/ssatags/doc.go
@@ -27,18 +27,15 @@ limitations under the License.
 // - listType=map: Elements are identified by specific key fields for granular updates
 //
 // Important Note on listType=set:
-// The use of listType=set is discouraged for object arrays due to Server-Side Apply
-// compatibility issues. When multiple controllers attempt to apply changes to an object
-// array with listType=set, the merge behavior can be unpredictable and may lead to
-// data loss or unexpected conflicts. For object arrays, use listType=atomic for simple
-// replacement semantics or listType=map for granular field-level merging.
-// listType=set is safe to use with primitive arrays (strings, integers, etc.).
+// listType=set is only supported on slices of scalar elements. Slices of
+// structs, slices, and maps cannot be represented by Server-Side Apply. For
+// those fields, use listType=atomic or listType=map.
 //
 // The analyzer checks for:
 //
 // 1. Missing listType markers on array fields
 // 2. Invalid listType values (must be atomic, set, or map)
-// 3. Usage of listType=set on object arrays (discouraged due to compatibility issues)
+// 3. Usage of listType=set on slices of structs, slices, and maps
 // 4. Missing listMapKey markers for listType=map arrays
 // 5. Incorrect usage of listType=map on primitive arrays
 //

--- a/pkg/analysis/ssatags/testdata/src/a/a.go
+++ b/pkg/analysis/ssatags/testdata/src/a/a.go
@@ -230,7 +230,33 @@ type SSATagsTestSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	ObjectWithNamedEmbeddedStruct []ObjectWithNamedEmbedded `json:"objectWithNamedEmbeddedStruct,omitempty"` // want "SSATagsTestSpec.ObjectWithNamedEmbeddedStruct listMapKey \"name\" does not exist as a field in the struct"
+
+	// Slice-of-slice element - should warn
+	// +listType=set
+	SetOfStringSlices [][]string `json:"setOfStringSlices,omitempty"` // want "SSATagsTestSpec.SetOfStringSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Pointer-to-slice element - should warn
+	// +listType=set
+	SetOfPointerStringSlices []*[]string `json:"setOfPointerStringSlices,omitempty"` // want "SSATagsTestSpec.SetOfPointerStringSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Named slice element - should warn
+	// +listType=set
+	SetOfNamedSlices []StringArray `json:"setOfNamedSlices,omitempty"` // want "SSATagsTestSpec.SetOfNamedSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Named slice-of-slice at field position - should warn
+	// +listType=set
+	SetOfNamedSliceOfSlice StringArrayOfArrays `json:"setOfNamedSliceOfSlice,omitempty"` // want "SSATagsTestSpec.SetOfNamedSliceOfSlice with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// External-package scalar alias - should pass
+	// +listType=set
+	SetOfOtherPackageStringAlias []aa.OtherPackageStringAlias `json:"setOfOtherPackageStringAlias,omitempty"`
+
+	// External-package struct - should warn
+	// +listType=set
+	SetOfOtherPackageObject []aa.OtherPackageObject `json:"setOfOtherPackageObject,omitempty"` // want "SSATagsTestSpec.SetOfOtherPackageObject with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
 }
+
+type StringArrayOfArrays [][]string
 
 // JSONSchemaProps is a placeholder for the JSON schema properties.
 type JSONSchemaProps struct{}

--- a/pkg/analysis/ssatags/testdata/src/a/a.go.golden
+++ b/pkg/analysis/ssatags/testdata/src/a/a.go.golden
@@ -229,7 +229,33 @@ type SSATagsTestSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	ObjectWithNamedEmbeddedStruct []ObjectWithNamedEmbedded `json:"objectWithNamedEmbeddedStruct,omitempty"` // want "SSATagsTestSpec.ObjectWithNamedEmbeddedStruct listMapKey \"name\" does not exist as a field in the struct"
+
+	// Slice-of-slice element - should warn
+	// +listType=set
+	SetOfStringSlices [][]string `json:"setOfStringSlices,omitempty"` // want "SSATagsTestSpec.SetOfStringSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Pointer-to-slice element - should warn
+	// +listType=set
+	SetOfPointerStringSlices []*[]string `json:"setOfPointerStringSlices,omitempty"` // want "SSATagsTestSpec.SetOfPointerStringSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Named slice element - should warn
+	// +listType=set
+	SetOfNamedSlices []StringArray `json:"setOfNamedSlices,omitempty"` // want "SSATagsTestSpec.SetOfNamedSlices with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// Named slice-of-slice at field position - should warn
+	// +listType=set
+	SetOfNamedSliceOfSlice StringArrayOfArrays `json:"setOfNamedSliceOfSlice,omitempty"` // want "SSATagsTestSpec.SetOfNamedSliceOfSlice with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
+
+	// External-package scalar alias - should pass
+	// +listType=set
+	SetOfOtherPackageStringAlias []aa.OtherPackageStringAlias `json:"setOfOtherPackageStringAlias,omitempty"`
+
+	// External-package struct - should warn
+	// +listType=set
+	SetOfOtherPackageObject []aa.OtherPackageObject `json:"setOfOtherPackageObject,omitempty"` // want "SSATagsTestSpec.SetOfOtherPackageObject with listType=set is not recommended due to Server-Side Apply compatibility issues. Consider using listType=atomic or listType=map instead"
 }
+
+type StringArrayOfArrays [][]string
 
 // JSONSchemaProps is a placeholder for the JSON schema properties.
 type JSONSchemaProps struct{}

--- a/pkg/analysis/ssatags/testdata/src/a/aa/aa.go
+++ b/pkg/analysis/ssatags/testdata/src/a/aa/aa.go
@@ -2,3 +2,9 @@ package aa
 
 // +listType=atomic
 type OtherPackageStringArrayAtomic []string
+
+type OtherPackageStringAlias string
+
+type OtherPackageObject struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/140293#pullrequestreview-4705355233 it was noticed that CRDs allow listType=set for not only objects, but also slices and maps.

Due to the lack of SSA support, we would like to discourage use of non-scalar sets. We intend to ban the use for the native types in Kubernetes since none of the REST API types yet use non-scalar sets.