### PR TITLE
fix: ignore well-known Kubernetes types in zero value validation

### DIFF
--- a/pkg/analysis/utils/testdata/src/c/external.go
+++ b/pkg/analysis/utils/testdata/src/c/external.go
@@ -1,0 +1,25 @@
+package c
+
+import (
+	"extpkg"
+	v1 "k8s.io/api/core/v1"
+)
+
+type ExternalTestStructs struct {
+	// Should flag: external struct without IsZero
+	TargetNoIsZero extpkg.NoIsZero `json:"targetNoIsZero,omitzero"` // want "zero value is valid" "validation is not complete"
+
+	// Should not flag: external struct with IsZero on value receiver
+	TargetValueRecv extpkg.ValueReceiver `json:"targetValueRecv,omitzero"` // want "zero value is valid" "validation is complete"
+
+	// Should not flag: external struct with IsZero on pointer receiver
+	TargetPtrRecv extpkg.PointerReceiver `json:"targetPtrRecv,omitzero"` // want "zero value is valid" "validation is complete"
+
+	// Should not flag: hardcoded exception
+	TargetLocalObjRef v1.LocalObjectReference `json:"targetLocalObjRef,omitzero"` // want "zero value is valid" "validation is complete"
+
+	// Type aliases
+	TargetAliasToNoIsZero AliasToNoIsZero `json:"targetAliasToNoIsZero,omitzero"` // want "zero value is valid" "validation is not complete"
+}
+
+type AliasToNoIsZero = extpkg.NoIsZero

--- a/pkg/analysis/utils/testdata/src/extpkg/ext.go
+++ b/pkg/analysis/utils/testdata/src/extpkg/ext.go
@@ -1,0 +1,15 @@
+package extpkg
+
+type NoIsZero struct {
+	Field string `json:"field,omitempty"`
+}
+
+type ValueReceiver struct{
+	Field string `json:"field,omitempty"`
+}
+func (v ValueReceiver) IsZero() bool { return true }
+
+type PointerReceiver struct{
+	Field string `json:"field,omitempty"`
+}
+func (p *PointerReceiver) IsZero() bool { return true }

--- a/pkg/analysis/utils/testdata/src/k8s.io/api/core/v1/types.go
+++ b/pkg/analysis/utils/testdata/src/k8s.io/api/core/v1/types.go
@@ -1,0 +1,5 @@
+package v1
+
+type LocalObjectReference struct {
+	Name string `json:"name,omitempty"`
+}

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -77,6 +77,10 @@ func isSelectorExprZeroValueValid(pass *analysis.Pass, field *ast.Field, selecto
 		return false, false
 	}
 
+	if IsSemanticallyZeroable(typeOf) {
+		return true, true
+	}
+
 	underlying := typeOf.Underlying()
 
 	switch t := underlying.(type) {
@@ -782,4 +786,49 @@ func IsFieldOptional(field *ast.Field, markersAccess markershelper.Markers) bool
 	return fieldMarkers.Has(markers.OptionalMarker) ||
 		fieldMarkers.Has(markers.KubebuilderOptionalMarker) ||
 		fieldMarkers.Has(markers.K8sOptionalMarker)
+}
+
+// IsSemanticallyZeroable determines if a type safely handles omitzero
+// without requiring a pointer wrapper.
+func IsSemanticallyZeroable(t types.Type) bool {
+	// 1. Hardcoded semantic exception for Kubernetes LocalObjectReference
+	if isLocalObjectReference(t) {
+		return true
+	}
+
+	// 2. Check for IsZero() bool on the pointer receiver (*T)
+	// In Go, the method set of *T is a superset of T's method set, so this
+	// efficiently covers both pointer and value receivers.
+	ptr := types.NewPointer(t)
+	return hasIsZeroMethod(ptr)
+}
+
+func isLocalObjectReference(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	obj := named.Obj()
+	if obj != nil && obj.Pkg() != nil {
+		return obj.Pkg().Path() == "k8s.io/api/core/v1" && obj.Name() == "LocalObjectReference"
+	}
+	return false
+}
+
+func hasIsZeroMethod(t types.Type) bool {
+	methodSet := types.NewMethodSet(t)
+	for i := 0; i < methodSet.Len(); i++ {
+		m := methodSet.At(i).Obj()
+		if m.Name() == "IsZero" {
+			sig, ok := m.Type().(*types.Signature)
+			// Ensure it has 0 parameters and exactly 1 boolean return
+			if ok && sig.Params().Len() == 0 && sig.Results().Len() == 1 {
+				if basic, ok := sig.Results().At(0).Type().(*types.Basic); ok && basic.Kind() == types.Bool {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #249

this fixes the false positive where requiredfields and optionalfields analyzers ask for a pointer on well known k8s types like metav1.Time when using omitzero. 

I just added a quick check to intercept these types in the external struct validation logic so they are ignored. tested locally and works good.