### PR TITLE
[utils] Handle omitzero for external struct types

### DIFF
--- a/pkg/analysis/utils/serialization/serialization_check.go
+++ b/pkg/analysis/utils/serialization/serialization_check.go
@@ -116,7 +116,7 @@ func (s *serializationCheck) Check(pass *analysis.Pass, field *ast.Field, marker
 		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "should be a pointer.", qualifiedFieldName)
 		s.handleFieldShouldHaveOmitEmpty(pass, field, qualifiedFieldName, hasOmitEmpty, jsonTags)
 	case PointersPreferenceWhenRequired:
-		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct, markersAccess, qualifiedFieldName)
+		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct || utils.HasIsZeroMethod(pass, underlying), markersAccess, qualifiedFieldName)
 
 		if s.omitEmptyPolicy != OmitEmptyPolicyIgnore || hasOmitEmpty {
 			// If we require omitempty, or the field has omitempty, we can check the field properties based on it being an omitempty field.
@@ -153,6 +153,14 @@ func (s *serializationCheck) handleFieldShouldHaveOmitEmpty(pass *analysis.Pass,
 
 func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	switch {
+	case jsonTags.OmitZero && s.omitZeroPolicy != OmitZeroPolicyForbid && utils.IsZeroOmittableType(pass, underlying):
+		// Struct fields with omitzero already omit their zero value, so they do
+		// not also need omitempty or pointer indirection for omission.
+		return
+	case utils.IsZeroOmittableType(pass, underlying) && !hasValidZeroValue && s.omitZeroPolicy != OmitZeroPolicyForbid:
+		// OmitZero handling already reports the missing omitzero tag for this
+		// field. Do not also require omitempty.
+		return
 	case isStruct && !hasValidZeroValue && s.omitZeroPolicy != OmitZeroPolicyForbid:
 		// The struct field need not be pointer if it does not have a valid zero value.
 		return

--- a/pkg/analysis/utils/serialization/serialization_check.go
+++ b/pkg/analysis/utils/serialization/serialization_check.go
@@ -116,9 +116,13 @@ func (s *serializationCheck) Check(pass *analysis.Pass, field *ast.Field, marker
 		s.handleFieldShouldBePointer(pass, field, fieldName, isPointer, underlying, markersAccess, "should be a pointer.", qualifiedFieldName)
 		s.handleFieldShouldHaveOmitEmpty(pass, field, qualifiedFieldName, hasOmitEmpty, jsonTags)
 	case PointersPreferenceWhenRequired:
-		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct || utils.HasIsZeroMethod(pass, underlying), markersAccess, qualifiedFieldName)
+		s.handleFieldOmitZero(pass, field, fieldName, jsonTags, underlying, hasOmitZero, hasValidZeroValue, isPointer, isStruct, markersAccess, qualifiedFieldName)
 
 		if s.omitEmptyPolicy != OmitEmptyPolicyIgnore || hasOmitEmpty {
+			if s.isOmittedByOmitZero(pass, jsonTags, underlying) {
+				return
+			}
+
 			// If we require omitempty, or the field has omitempty, we can check the field properties based on it being an omitempty field.
 			s.checkFieldPropertiesWithOmitEmptyRequired(pass, field, fieldName, jsonTags, underlying, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct, markersAccess, qualifiedFieldName)
 		} else {
@@ -153,14 +157,6 @@ func (s *serializationCheck) handleFieldShouldHaveOmitEmpty(pass *analysis.Pass,
 
 func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasOmitEmpty, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {
 	switch {
-	case jsonTags.OmitZero && s.omitZeroPolicy != OmitZeroPolicyForbid && utils.IsZeroOmittableType(pass, underlying):
-		// Struct fields with omitzero already omit their zero value, so they do
-		// not also need omitempty or pointer indirection for omission.
-		return
-	case utils.IsZeroOmittableType(pass, underlying) && !hasValidZeroValue && s.omitZeroPolicy != OmitZeroPolicyForbid:
-		// OmitZero handling already reports the missing omitzero tag for this
-		// field. Do not also require omitempty.
-		return
 	case isStruct && !hasValidZeroValue && s.omitZeroPolicy != OmitZeroPolicyForbid:
 		// The struct field need not be pointer if it does not have a valid zero value.
 		return
@@ -182,6 +178,14 @@ func (s *serializationCheck) checkFieldPropertiesWithOmitEmptyRequired(pass *ana
 
 	// In this case, we should always add the omitempty if it isn't present.
 	s.handleFieldShouldHaveOmitEmpty(pass, field, qualifiedFieldName, hasOmitEmpty, jsonTags)
+}
+
+func (s *serializationCheck) isOmittedByOmitZero(pass *analysis.Pass, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr) bool {
+	if !jsonTags.OmitZero || s.omitZeroPolicy == OmitZeroPolicyForbid {
+		return false
+	}
+
+	return utils.IsExternalStructType(pass, underlying) || utils.HasIsZeroMethod(pass, underlying)
 }
 
 func (s *serializationCheck) checkFieldPropertiesWithoutOmitEmpty(pass *analysis.Pass, field *ast.Field, fieldName string, jsonTags extractjsontags.FieldTagInfo, underlying ast.Expr, hasValidZeroValue, completeValidation, isPointer, isStruct bool, markersAccess markershelper.Markers, qualifiedFieldName string) {

--- a/pkg/analysis/utils/serialization/testdata/src/externaltypes/types.go
+++ b/pkg/analysis/utils/serialization/testdata/src/externaltypes/types.go
@@ -37,3 +37,15 @@ type StructTypeWithNonOmittedField struct {
 	// Description is an optional field with omitempty.
 	Description string `json:"description,omitempty"`
 }
+
+// StructTypeWithIsZero is a named struct type that can be omitted with omitzero.
+// This simulates types like metav1.Time.
+type StructTypeWithIsZero struct {
+	// Field is an omitted field.
+	Field string `json:"field,omitempty"`
+}
+
+// IsZero reports whether the struct is zero.
+func (StructTypeWithIsZero) IsZero() bool {
+	return true
+}

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
@@ -9,6 +9,8 @@ type TestStructs struct {
 
 	StructWithAllOptionalFieldsWithOmitEmpty StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
+	StructWithAllOptionalFieldsWithOmitZero StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitZero,omitzero"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitZero has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field TestStructs.StructWithAllOptionalFieldsWithOmitZero should have the omitempty tag."
+
 	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
@@ -69,8 +71,8 @@ type TestStructs struct {
 	// ExternalStructWithIsZeroWithOmitZero is an external struct with IsZero and omitzero.
 	ExternalStructWithIsZeroWithOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithOmitZero,omitzero"`
 
-	// ExternalStructWithIsZeroMissingOmitZero is an external struct with IsZero but no omitzero.
-	ExternalStructWithIsZeroMissingOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroMissingOmitZero"` // want "field TestStructs.ExternalStructWithIsZeroMissingOmitZero does not allow the zero value. It must have the omitzero tag."
+	// ExternalStructWithIsZeroWithoutOmitZero confirms IsZero alone does not make the zero value invalid.
+	ExternalStructWithIsZeroWithoutOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithoutOmitZero"` // want "field TestStructs.ExternalStructWithIsZeroWithoutOmitZero has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field TestStructs.ExternalStructWithIsZeroWithoutOmitZero should have the omitempty tag."
 }
 
 type StructWithAllOptionalFields struct {

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go
@@ -1,5 +1,7 @@
 package a
 
+import "externaltypes"
+
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
@@ -60,6 +62,15 @@ type TestStructs struct {
 	StructPtrWithOmittedRequiredField *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty *StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// ExternalStructWithOmitZero is an external struct with omitzero.
+	ExternalStructWithOmitZero externaltypes.StructType `json:"externalStructWithOmitZero,omitzero"`
+
+	// ExternalStructWithIsZeroWithOmitZero is an external struct with IsZero and omitzero.
+	ExternalStructWithIsZeroWithOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithOmitZero,omitzero"`
+
+	// ExternalStructWithIsZeroMissingOmitZero is an external struct with IsZero but no omitzero.
+	ExternalStructWithIsZeroMissingOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroMissingOmitZero"` // want "field TestStructs.ExternalStructWithIsZeroMissingOmitZero does not allow the zero value. It must have the omitzero tag."
 }
 
 type StructWithAllOptionalFields struct {

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
@@ -1,5 +1,7 @@
 package a
 
+import "externaltypes"
+
 type TestStructs struct {
 	// StructWithAllOptionalFields has a zero value of {}, which is valid because all fields are optional.
 
@@ -60,6 +62,15 @@ type TestStructs struct {
 	StructPtrWithOmittedRequiredField StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredField,omitzero"` // want "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredField does not allow the zero value. The field does not need to be a pointer."
 
 	StructPtrWithOmittedRequiredFieldWithOmitEmpty StructWithOmittedRequiredField `json:"structPtrWithOmittedRequiredFieldWithOmitEmpty,omitzero,omitempty"` // want "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. It must have the omitzero tag." "field TestStructs.StructPtrWithOmittedRequiredFieldWithOmitEmpty does not allow the zero value. The field does not need to be a pointer."
+
+	// ExternalStructWithOmitZero is an external struct with omitzero.
+	ExternalStructWithOmitZero externaltypes.StructType `json:"externalStructWithOmitZero,omitzero"`
+
+	// ExternalStructWithIsZeroWithOmitZero is an external struct with IsZero and omitzero.
+	ExternalStructWithIsZeroWithOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithOmitZero,omitzero"`
+
+	// ExternalStructWithIsZeroMissingOmitZero is an external struct with IsZero but no omitzero.
+	ExternalStructWithIsZeroMissingOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroMissingOmitZero,omitzero"` // want "field TestStructs.ExternalStructWithIsZeroMissingOmitZero does not allow the zero value. It must have the omitzero tag."
 }
 
 type StructWithAllOptionalFields struct {

--- a/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
+++ b/pkg/analysis/utils/serialization/testdata/src/pointers_when_required_omit_empty_suggest_fix_omit_zero_suggest_fix/structs.go.golden
@@ -9,6 +9,8 @@ type TestStructs struct {
 
 	StructWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitEmpty,omitempty"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitEmpty has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer."
 
+	StructWithAllOptionalFieldsWithOmitZero *StructWithAllOptionalFields `json:"structWithAllOptionalFieldsWithOmitZero,omitempty,omitzero"` // want "field TestStructs.StructWithAllOptionalFieldsWithOmitZero has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field TestStructs.StructWithAllOptionalFieldsWithOmitZero should have the omitempty tag."
+
 	StructPtrWithAllOptionalFields *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFields,omitempty"` // want "field TestStructs.StructPtrWithAllOptionalFields should have the omitempty tag."
 
 	StructPtrWithAllOptionalFieldsWithOmitEmpty *StructWithAllOptionalFields `json:"structPtrWithAllOptionalFieldsWithOmitEmpty,omitempty"`
@@ -69,8 +71,8 @@ type TestStructs struct {
 	// ExternalStructWithIsZeroWithOmitZero is an external struct with IsZero and omitzero.
 	ExternalStructWithIsZeroWithOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithOmitZero,omitzero"`
 
-	// ExternalStructWithIsZeroMissingOmitZero is an external struct with IsZero but no omitzero.
-	ExternalStructWithIsZeroMissingOmitZero externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroMissingOmitZero,omitzero"` // want "field TestStructs.ExternalStructWithIsZeroMissingOmitZero does not allow the zero value. It must have the omitzero tag."
+	// ExternalStructWithIsZeroWithoutOmitZero confirms IsZero alone does not make the zero value invalid.
+	ExternalStructWithIsZeroWithoutOmitZero *externaltypes.StructTypeWithIsZero `json:"externalStructWithIsZeroWithoutOmitZero,omitempty"` // want "field TestStructs.ExternalStructWithIsZeroWithoutOmitZero has a valid zero value \\({}\\), but the validation is not complete \\(e.g. min properties/adding required fields\\). The field should be a pointer to allow the zero value to be set. If the zero value is not a valid use case, complete the validation and remove the pointer." "field TestStructs.ExternalStructWithIsZeroWithoutOmitZero should have the omitempty tag."
 }
 
 type StructWithAllOptionalFields struct {

--- a/pkg/analysis/utils/utils.go
+++ b/pkg/analysis/utils/utils.go
@@ -86,6 +86,54 @@ func IsStructType(pass *analysis.Pass, expr ast.Expr) bool {
 	return false
 }
 
+// IsZeroOmittableType checks whether the type can be omitted by the json
+// omitzero tag because it is a struct or declares IsZero() bool.
+func IsZeroOmittableType(pass *analysis.Pass, expr ast.Expr) bool {
+	if IsStructType(pass, expr) || HasIsZeroMethod(pass, expr) {
+		return true
+	}
+
+	typeOf := pass.TypesInfo.TypeOf(expr)
+	if typeOf == nil {
+		return false
+	}
+
+	_, ok := typeOf.Underlying().(*types.Struct)
+	return ok
+}
+
+// HasIsZeroMethod checks whether the type declares an IsZero() bool method.
+func HasIsZeroMethod(pass *analysis.Pass, expr ast.Expr) bool {
+	typeOf := pass.TypesInfo.TypeOf(expr)
+	if typeOf == nil {
+		return false
+	}
+
+	return hasIsZeroMethod(typeOf)
+}
+
+func hasIsZeroMethod(typeOf types.Type) bool {
+	method, _, _ := types.LookupFieldOrMethod(typeOf, false, nil, "IsZero")
+	if method == nil {
+		method, _, _ = types.LookupFieldOrMethod(types.NewPointer(typeOf), false, nil, "IsZero")
+		if method == nil {
+			return false
+		}
+	}
+
+	signature, ok := method.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	if signature.Params().Len() != 0 || signature.Results().Len() != 1 {
+		return false
+	}
+
+	result, ok := signature.Results().At(0).Type().(*types.Basic)
+	return ok && result.Kind() == types.Bool
+}
+
 // IsStarExpr checks if the expression is a pointer type.
 // If it is, it returns the expression inside the pointer.
 func IsStarExpr(expr ast.Expr) (bool, ast.Expr) {

--- a/pkg/analysis/utils/utils.go
+++ b/pkg/analysis/utils/utils.go
@@ -86,19 +86,21 @@ func IsStructType(pass *analysis.Pass, expr ast.Expr) bool {
 	return false
 }
 
-// IsZeroOmittableType checks whether the type can be omitted by the json
-// omitzero tag because it is a struct or declares IsZero() bool.
-func IsZeroOmittableType(pass *analysis.Pass, expr ast.Expr) bool {
-	if IsStructType(pass, expr) || HasIsZeroMethod(pass, expr) {
-		return true
+// IsExternalStructType checks whether the expression refers to a struct from
+// another package.
+func IsExternalStructType(pass *analysis.Pass, expr ast.Expr) bool {
+	underlying := getUnderlyingType(expr)
+	if _, ok := underlying.(*ast.SelectorExpr); !ok {
+		return false
 	}
 
-	typeOf := pass.TypesInfo.TypeOf(expr)
+	typeOf := pass.TypesInfo.TypeOf(underlying)
 	if typeOf == nil {
 		return false
 	}
 
 	_, ok := typeOf.Underlying().(*types.Struct)
+
 	return ok
 }
 
@@ -131,6 +133,7 @@ func hasIsZeroMethod(typeOf types.Type) bool {
 	}
 
 	result, ok := signature.Results().At(0).Type().(*types.Basic)
+
 	return ok && result.Kind() == types.Bool
 }
 

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -62,7 +62,7 @@ func IsZeroValueValid(pass *analysis.Pass, field *ast.Field, typeExpr ast.Expr, 
 	case *ast.SelectorExpr:
 		// For qualified identifiers (e.g., corev1.ResourceList), use type info
 		// since we cannot look up the AST for external packages.
-		return isSelectorExprZeroValueValid(pass, field, t, markersAccess, qualifiedFieldName)
+		return isSelectorExprZeroValueValid(pass, field, t, markersAccess, considerOmitzero, qualifiedFieldName)
 	}
 
 	// We don't know what the type is so can't assert the zero value is valid.
@@ -71,10 +71,14 @@ func IsZeroValueValid(pass *analysis.Pass, field *ast.Field, typeExpr ast.Expr, 
 
 // isSelectorExprZeroValueValid checks if a qualified identifier (external package type) has a valid zero value.
 // It uses Go's type system to determine the underlying type.
-func isSelectorExprZeroValueValid(pass *analysis.Pass, field *ast.Field, selector *ast.SelectorExpr, markersAccess markershelper.Markers, qualifiedFieldName string) (bool, bool) {
+func isSelectorExprZeroValueValid(pass *analysis.Pass, field *ast.Field, selector *ast.SelectorExpr, markersAccess markershelper.Markers, considerOmitzero bool, qualifiedFieldName string) (bool, bool) {
 	typeOf := pass.TypesInfo.TypeOf(selector)
 	if typeOf == nil {
 		return false, false
+	}
+
+	if considerOmitzero && HasIsZeroMethod(pass, selector) {
+		return false, true
 	}
 
 	underlying := typeOf.Underlying()

--- a/pkg/analysis/utils/zero_value.go
+++ b/pkg/analysis/utils/zero_value.go
@@ -62,7 +62,7 @@ func IsZeroValueValid(pass *analysis.Pass, field *ast.Field, typeExpr ast.Expr, 
 	case *ast.SelectorExpr:
 		// For qualified identifiers (e.g., corev1.ResourceList), use type info
 		// since we cannot look up the AST for external packages.
-		return isSelectorExprZeroValueValid(pass, field, t, markersAccess, considerOmitzero, qualifiedFieldName)
+		return isSelectorExprZeroValueValid(pass, field, t, markersAccess, qualifiedFieldName)
 	}
 
 	// We don't know what the type is so can't assert the zero value is valid.
@@ -71,14 +71,10 @@ func IsZeroValueValid(pass *analysis.Pass, field *ast.Field, typeExpr ast.Expr, 
 
 // isSelectorExprZeroValueValid checks if a qualified identifier (external package type) has a valid zero value.
 // It uses Go's type system to determine the underlying type.
-func isSelectorExprZeroValueValid(pass *analysis.Pass, field *ast.Field, selector *ast.SelectorExpr, markersAccess markershelper.Markers, considerOmitzero bool, qualifiedFieldName string) (bool, bool) {
+func isSelectorExprZeroValueValid(pass *analysis.Pass, field *ast.Field, selector *ast.SelectorExpr, markersAccess markershelper.Markers, qualifiedFieldName string) (bool, bool) {
 	typeOf := pass.TypesInfo.TypeOf(selector)
 	if typeOf == nil {
 		return false, false
-	}
-
-	if considerOmitzero && HasIsZeroMethod(pass, selector) {
-		return false, true
 	}
 
 	underlying := typeOf.Underlying()


### PR DESCRIPTION
Fixes #249.

The linter already handles local structs with `omitzero`, but external selector types could still fall through to the later pointer/`omitempty` checks. This keeps the existing `IsStructType` behavior and skips that later path only when `omitzero` is already present for an external struct or a type with `IsZero() bool`.

The tests cover external structs with `omitzero`, an external `IsZero()` type with and without the tag, and a local valid-zero struct to make sure its existing warning is unchanged.

Testing:
- `go test ./...`
- `go tool -modfile tools/go.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run ./... --timeout 5m -v`
- `go tool -modfile tools/go.mod golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize -diff ./...`